### PR TITLE
feat: accept both hex and SS58 addresses as CLI arguments

### DIFF
--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -3,13 +3,13 @@ import { BN } from '@polkadot/util';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
 import { executeTx } from '../services/tx-executor';
-import { output, verbose, CliError, resolveAmount, minimalToVara } from '../utils';
+import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex } from '../utils';
 
 export function registerBalanceCommand(program: Command): void {
   program
     .command('balance')
     .description('Query account balance')
-    .argument('[address]', 'account address (defaults to configured account)')
+    .argument('[address]', 'account address, hex or SS58 (defaults to configured account)')
     .action(async (address?: string) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
@@ -29,7 +29,7 @@ export function registerBalanceCommand(program: Command): void {
   program
     .command('transfer')
     .description('Transfer VARA tokens')
-    .argument('<to>', 'destination address')
+    .argument('<to>', 'destination address (hex or SS58)')
     .argument('<amount>', 'amount to transfer (in VARA by default)')
     .option('--units <units>', 'amount units: vara (default) or raw')
     .action(async (to: string, amount: string, options: { units?: string }) => {
@@ -43,16 +43,17 @@ export function registerBalanceCommand(program: Command): void {
         throw new CliError('Amount must be positive', 'INVALID_AMOUNT');
       }
 
-      verbose(`Transferring ${minimalToVara(amountMinimal)} VARA from ${account.address} to ${to}`);
+      const toHex = addressToHex(to);
+      verbose(`Transferring ${minimalToVara(amountMinimal)} VARA from ${account.address} to ${toHex}`);
 
-      const tx = api.balance.transfer(to, new BN(amountMinimal.toString()));
+      const tx = api.balance.transfer(toHex, new BN(amountMinimal.toString()));
       const result = await executeTx(api, tx, account);
 
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
         from: account.address,
-        to,
+        to: toHex,
         amount: minimalToVara(amountMinimal),
         amountRaw: amountMinimal.toString(),
       });

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -2,20 +2,20 @@ import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
 import { loadSails, describeSailsProgram } from '../services/sails';
-import { output, verbose, CliError, resolveAmount, minimalToVara } from '../utils';
+import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex } from '../utils';
 
 export function registerCallCommand(program: Command): void {
   program
     .command('call')
     .description('Call a Sails program method (auto-detects query vs function)')
-    .argument('<programId>', 'program ID (0x...)')
+    .argument('<programId>', 'program ID (hex or SS58)')
     .argument('<method>', 'Service/Method name (e.g. Counter/Increment)')
     .option('--args <json>', 'method arguments as JSON array', '[]')
     .option('--value <value>', 'value to send (in VARA, functions only)', '0')
     .option('--units <units>', 'amount units: vara (default) or raw')
     .option('--gas-limit <gas>', 'gas limit override (functions only)')
     .option('--idl <path>', 'path to local IDL file')
-    .action(async (programId: string, method: string, options: {
+    .action(async (programIdArg: string, method: string, options: {
       args: string;
       value: string;
       units?: string;
@@ -24,6 +24,7 @@ export function registerCallCommand(program: Command): void {
     }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
+      const programId = addressToHex(programIdArg);
 
       // Parse Service/Method
       const parts = method.split('/');

--- a/src/commands/discover.ts
+++ b/src/commands/discover.ts
@@ -1,25 +1,26 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { loadSails, describeSailsProgram } from '../services/sails';
-import { output, verbose } from '../utils';
+import { output, verbose, addressToHex } from '../utils';
 
 export function registerDiscoverCommand(program: Command): void {
   program
     .command('discover')
     .description('Discover program services, methods, and types via Sails IDL')
-    .argument('<programId>', 'program ID (0x...)')
+    .argument('<programId>', 'program ID (hex or SS58)')
     .option('--idl <path>', 'path to local IDL file')
     .action(async (programId: string, options: { idl?: string }) => {
       const opts = program.optsWithGlobals() as { ws?: string };
       const api = await getApi(opts.ws);
 
-      verbose(`Discovering program ${programId}`);
+      const programIdHex = addressToHex(programId);
+      verbose(`Discovering program ${programIdHex}`);
 
-      const sails = await loadSails(api, { programId, idl: options.idl });
+      const sails = await loadSails(api, { programId: programIdHex, idl: options.idl });
       const description = describeSailsProgram(sails);
 
       output({
-        programId,
+        programId: programIdHex,
         services: description,
       });
     });

--- a/src/commands/mailbox.ts
+++ b/src/commands/mailbox.ts
@@ -10,7 +10,7 @@ export function registerMailboxCommand(program: Command): void {
   mailbox
     .command('read')
     .description('Read mailbox messages for an account')
-    .argument('[address]', 'account address (defaults to configured account)')
+    .argument('[address]', 'account address, hex or SS58 (defaults to configured account)')
     .action(async (address?: string) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
@@ -18,7 +18,7 @@ export function registerMailboxCommand(program: Command): void {
 
       verbose(`Reading mailbox for ${resolvedAddress}`);
 
-      const messages = await api.mailbox.read(resolvedAddress as `0x${string}`);
+      const messages = await api.mailbox.read(resolvedAddress);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const items = messages.map((item: any) => {

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -1,12 +1,10 @@
 import { Command } from 'commander';
 import { ProgramMetadata } from '@gear-js/api';
-import { decodeAddress } from '@polkadot/util-crypto';
-import { u8aToHex } from '@polkadot/util';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
 import { resolveAccount, AccountOptions } from '../services/account';
 import { executeTx } from '../services/tx-executor';
-import { output, verbose, CliError, resolveAmount, minimalToVara } from '../utils';
+import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex } from '../utils';
 
 export function registerMessageCommand(program: Command): void {
   const message = program.command('message').description('Low-level message operations');
@@ -14,7 +12,7 @@ export function registerMessageCommand(program: Command): void {
   message
     .command('send')
     .description('Send a message to any on-chain actor (program, user, wallet)')
-    .argument('<destination>', 'destination address or program ID (0x...)')
+    .argument('<destination>', 'destination address or program ID (hex or SS58)')
     .option('--payload <payload>', 'message payload (hex 0x... or JSON string)', '0x')
     .option('--gas-limit <gas>', 'gas limit (auto-calculated if not set)')
     .option('--value <value>', 'value to send with message (in VARA)', '0')
@@ -39,6 +37,7 @@ export function registerMessageCommand(program: Command): void {
         meta = ProgramMetadata.from(metaHex);
       }
 
+      const destinationHex = addressToHex(destination);
       const payload = options.payload;
 
       // Auto-calculate gas if not provided
@@ -47,10 +46,10 @@ export function registerMessageCommand(program: Command): void {
         gasLimit = BigInt(options.gasLimit);
       } else {
         verbose('Calculating gas...');
-        const sourceHex = u8aToHex(decodeAddress(account.address));
+        const sourceHex = addressToHex(account.address);
         const gasInfo = await api.program.calculateGas.handle(
-          sourceHex as `0x${string}`,
-          destination as `0x${string}`,
+          sourceHex,
+          destinationHex,
           payload,
           value,
           true,
@@ -66,10 +65,10 @@ export function registerMessageCommand(program: Command): void {
         }
       }
 
-      verbose(`Sending message to ${destination}`);
+      verbose(`Sending message to ${destinationHex}`);
 
       const tx = api.message.send({
-        destination: destination as `0x${string}`,
+        destination: destinationHex,
         payload,
         gasLimit,
         value,
@@ -128,9 +127,9 @@ export function registerMessageCommand(program: Command): void {
         gasLimit = BigInt(options.gasLimit);
       } else {
         verbose('Calculating gas...');
-        const sourceHex = u8aToHex(decodeAddress(account.address));
+        const sourceHex = addressToHex(account.address);
         const gasInfo = await api.program.calculateGas.reply(
-          sourceHex as `0x${string}`,
+          sourceHex,
           messageId as `0x${string}`,
           payload,
           value,
@@ -162,11 +161,11 @@ export function registerMessageCommand(program: Command): void {
   message
     .command('calculate-reply')
     .description('Calculate reply from a program without sending a transaction')
-    .argument('<programId>', 'destination program ID (0x...)')
+    .argument('<programId>', 'destination program ID (hex or SS58)')
     .option('--payload <payload>', 'message payload (hex 0x... or JSON string)', '0x')
     .option('--value <value>', 'value to simulate (in VARA)', '0')
     .option('--units <units>', 'amount units: vara (default) or raw')
-    .option('--origin <address>', 'origin address for the calculation')
+    .option('--origin <address>', 'origin address for the calculation (hex or SS58)')
     .option('--at <blockHash>', 'block hash to query state at')
     .action(async (programId: string, options: {
       payload: string;
@@ -181,13 +180,13 @@ export function registerMessageCommand(program: Command): void {
       const value = resolveAmount(options.value, isRaw);
 
       // Resolve origin - use provided address or account
-      let origin: string;
+      let origin: `0x${string}`;
       if (options.origin) {
-        origin = options.origin;
+        origin = addressToHex(options.origin);
       } else {
         try {
           const account = await resolveAccount(opts);
-          origin = account.address;
+          origin = addressToHex(account.address);
         } catch {
           throw new CliError(
             'Provide --origin address or configure an account for calculate-reply',
@@ -196,11 +195,12 @@ export function registerMessageCommand(program: Command): void {
         }
       }
 
-      verbose(`Calculating reply from ${programId}`);
+      const programIdHex = addressToHex(programId);
+      verbose(`Calculating reply from ${programIdHex}`);
 
       const replyInfo = await api.message.calculateReply({
         origin,
-        destination: programId,
+        destination: programIdHex,
         payload: options.payload,
         value,
         at: options.at as `0x${string}` | undefined,

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import { getApi } from '../services/api';
 import { resolveAccount, AccountOptions } from '../services/account';
 import { executeTx } from '../services/tx-executor';
-import { output, verbose, CliError, resolveAmount } from '../utils';
+import { output, verbose, CliError, resolveAmount, addressToHex } from '../utils';
 
 export function registerProgramCommand(program: Command): void {
   const prog = program.command('program').description('Program operations');
@@ -51,7 +51,7 @@ export function registerProgramCommand(program: Command): void {
       } else {
         verbose('Calculating gas for program upload...');
         const gasInfo = await api.program.calculateGas.initUpload(
-          account.address as `0x${string}`,
+          addressToHex(account.address),
           code,
           options.payload,
           value,
@@ -120,7 +120,7 @@ export function registerProgramCommand(program: Command): void {
       } else {
         verbose('Calculating gas for program creation...');
         const gasInfo = await api.program.calculateGas.initCreate(
-          account.address as `0x${string}`,
+          addressToHex(account.address),
           codeId as `0x${string}`,
           options.payload,
           value,
@@ -155,29 +155,30 @@ export function registerProgramCommand(program: Command): void {
   prog
     .command('info')
     .description('Get program information')
-    .argument('<programId>', 'program ID (0x...)')
+    .argument('<programId>', 'program ID (hex or SS58)')
     .action(async (programId: string) => {
       const opts = program.optsWithGlobals() as { ws?: string };
       const api = await getApi(opts.ws);
 
-      verbose(`Fetching info for program ${programId}`);
+      const programIdHex = addressToHex(programId);
+      verbose(`Fetching info for program ${programIdHex}`);
 
-      const exists = await api.program.exists(programId as `0x${string}`);
+      const exists = await api.program.exists(programIdHex);
       if (!exists) {
-        throw new CliError(`Program ${programId} not found`, 'PROGRAM_NOT_FOUND');
+        throw new CliError(`Program ${programIdHex} not found`, 'PROGRAM_NOT_FOUND');
       }
 
-      const codeId = await api.program.codeId(programId);
+      const codeId = await api.program.codeId(programIdHex);
 
       let metaHash: string | null = null;
       try {
-        metaHash = await api.program.metaHash(programId as `0x${string}`);
+        metaHash = await api.program.metaHash(programIdHex);
       } catch {
         // Program may not have metadata
       }
 
       output({
-        programId,
+        programId: programIdHex,
         exists: true,
         codeId,
         metaHash,

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, AccountOptions } from '../services/account';
-import { output, verbose, CliError, resolveAmount, minimalToVara } from '../utils';
+import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex } from '../utils';
 
 export function registerStateCommand(program: Command): void {
   const state = program.command('state').description('Program state operations');
@@ -9,9 +9,9 @@ export function registerStateCommand(program: Command): void {
   state
     .command('read')
     .description('Read program state via calculateReply')
-    .argument('<programId>', 'program ID (0x...)')
+    .argument('<programId>', 'program ID (hex or SS58)')
     .option('--payload <payload>', 'state query payload (hex or JSON)', '0x')
-    .option('--origin <address>', 'origin address for the query')
+    .option('--origin <address>', 'origin address for the query (hex or SS58)')
     .option('--at <blockHash>', 'block hash to query state at')
     .action(async (programId: string, options: {
       payload: string;
@@ -21,13 +21,13 @@ export function registerStateCommand(program: Command): void {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
 
-      let origin: string;
+      let origin: `0x${string}`;
       if (options.origin) {
-        origin = options.origin;
+        origin = addressToHex(options.origin);
       } else {
         try {
           const account = await resolveAccount(opts);
-          origin = account.address;
+          origin = addressToHex(account.address);
         } catch {
           throw new CliError(
             'Provide --origin address or configure an account for state read',
@@ -36,11 +36,12 @@ export function registerStateCommand(program: Command): void {
         }
       }
 
-      verbose(`Reading state from program ${programId}`);
+      const programIdHex = addressToHex(programId);
+      verbose(`Reading state from program ${programIdHex}`);
 
       const replyInfo = await api.message.calculateReply({
         origin,
-        destination: programId,
+        destination: programIdHex,
         payload: options.payload,
         at: options.at as `0x${string}` | undefined,
       });

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
 import { loadSails } from '../services/sails';
-import { output, verbose, CliError, resolveAmount, minimalToVara } from '../utils';
+import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex } from '../utils';
 
 export function registerVftCommand(program: Command): void {
   const vft = program.command('vft').description('VFT (fungible token) operations');
@@ -10,26 +10,27 @@ export function registerVftCommand(program: Command): void {
   vft
     .command('balance')
     .description('Query VFT token balance')
-    .argument('<tokenProgram>', 'VFT program ID (0x...)')
-    .argument('[account]', 'account address to query (defaults to configured account)')
+    .argument('<tokenProgram>', 'VFT program ID (hex or SS58)')
+    .argument('[account]', 'account address to query, hex or SS58 (defaults to configured account)')
     .option('--idl <path>', 'path to local IDL file')
     .action(async (tokenProgram: string, account: string | undefined, options: { idl?: string }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
+      const tokenProgramHex = addressToHex(tokenProgram);
       const address = await resolveAddress(account, opts);
 
-      const sails = await loadSails(api, { programId: tokenProgram, idl: options.idl });
+      const sails = await loadSails(api, { programId: tokenProgramHex, idl: options.idl });
 
       // Find the VFT service — could be named "Vft", "Service", etc.
       const serviceName = findVftService(sails, 'BalanceOf');
 
-      verbose(`Querying VFT balance for ${address} on ${tokenProgram}`);
+      verbose(`Querying VFT balance for ${address} on ${tokenProgramHex}`);
 
       const query = sails.services[serviceName].queries['BalanceOf'];
       const result = await query(address).call();
 
       output({
-        tokenProgram,
+        tokenProgram: tokenProgramHex,
         account: address,
         balance: String(result),
       });
@@ -38,22 +39,23 @@ export function registerVftCommand(program: Command): void {
   vft
     .command('transfer')
     .description('Transfer VFT tokens')
-    .argument('<tokenProgram>', 'VFT program ID (0x...)')
-    .argument('<to>', 'destination address')
+    .argument('<tokenProgram>', 'VFT program ID (hex or SS58)')
+    .argument('<to>', 'destination address (hex or SS58)')
     .argument('<amount>', 'amount to transfer')
     .option('--idl <path>', 'path to local IDL file')
     .action(async (tokenProgram: string, to: string, amount: string, options: { idl?: string }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
+      const toHex = addressToHex(to);
 
-      const sails = await loadSails(api, { programId: tokenProgram, idl: options.idl });
+      const sails = await loadSails(api, { programId: addressToHex(tokenProgram), idl: options.idl });
       const serviceName = findVftService(sails, 'Transfer');
 
-      verbose(`Transferring ${amount} tokens to ${to}`);
+      verbose(`Transferring ${amount} tokens to ${toHex}`);
 
       const func = sails.services[serviceName].functions['Transfer'];
-      const txBuilder = func(to, BigInt(amount));
+      const txBuilder = func(toHex, BigInt(amount));
 
       txBuilder.withAccount(account);
       await txBuilder.calculateGas();
@@ -72,22 +74,23 @@ export function registerVftCommand(program: Command): void {
   vft
     .command('approve')
     .description('Approve VFT token spending')
-    .argument('<tokenProgram>', 'VFT program ID (0x...)')
-    .argument('<spender>', 'spender address')
+    .argument('<tokenProgram>', 'VFT program ID (hex or SS58)')
+    .argument('<spender>', 'spender address (hex or SS58)')
     .argument('<amount>', 'amount to approve')
     .option('--idl <path>', 'path to local IDL file')
     .action(async (tokenProgram: string, spender: string, amount: string, options: { idl?: string }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
+      const spenderHex = addressToHex(spender);
 
-      const sails = await loadSails(api, { programId: tokenProgram, idl: options.idl });
+      const sails = await loadSails(api, { programId: addressToHex(tokenProgram), idl: options.idl });
       const serviceName = findVftService(sails, 'Approve');
 
-      verbose(`Approving ${amount} tokens for ${spender}`);
+      verbose(`Approving ${amount} tokens for ${spenderHex}`);
 
       const func = sails.services[serviceName].functions['Approve'];
-      const txBuilder = func(spender, BigInt(amount));
+      const txBuilder = func(spenderHex, BigInt(amount));
 
       txBuilder.withAccount(account);
       await txBuilder.calculateGas();

--- a/src/commands/voucher.ts
+++ b/src/commands/voucher.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, AccountOptions } from '../services/account';
 import { executeTx } from '../services/tx-executor';
-import { output, verbose, resolveAmount, minimalToVara } from '../utils';
+import { output, verbose, resolveAmount, minimalToVara, addressToHex } from '../utils';
 
 export function registerVoucherCommand(program: Command): void {
   const voucher = program.command('voucher').description('Voucher operations');
@@ -10,7 +10,7 @@ export function registerVoucherCommand(program: Command): void {
   voucher
     .command('issue')
     .description('Issue a voucher for a spender')
-    .argument('<spender>', 'spender address')
+    .argument('<spender>', 'spender address (hex or SS58)')
     .argument('<value>', 'voucher value (in VARA)')
     .option('--units <units>', 'amount units: vara (default) or raw')
     .option('--duration <blocks>', 'voucher duration in blocks')
@@ -28,13 +28,14 @@ export function registerVoucherCommand(program: Command): void {
 
       const duration = options.duration ? parseInt(options.duration, 10) : undefined;
       const programs = options.programs
-        ? options.programs.split(',').map((p) => p.trim() as `0x${string}`)
+        ? options.programs.split(',').map((p) => addressToHex(p.trim()))
         : undefined;
 
-      verbose(`Issuing voucher for ${spender} with value ${minimalToVara(amount)} VARA`);
+      const spenderHex = addressToHex(spender);
+      verbose(`Issuing voucher for ${spenderHex} with value ${minimalToVara(amount)} VARA`);
 
       const { extrinsic, voucherId } = await api.voucher.issue(
-        spender as `0x${string}`,
+        spenderHex,
         amount,
         duration,
         programs,
@@ -44,7 +45,7 @@ export function registerVoucherCommand(program: Command): void {
 
       output({
         voucherId,
-        spender,
+        spender: spenderHex,
         value: minimalToVara(amount),
         valueRaw: amount.toString(),
         duration: duration || null,
@@ -57,17 +58,18 @@ export function registerVoucherCommand(program: Command): void {
   voucher
     .command('list')
     .description('List vouchers for an account')
-    .argument('<account>', 'account address')
+    .argument('<account>', 'account address (hex or SS58)')
     .option('--program <id>', 'filter by program ID')
     .action(async (accountAddr: string, options: { program?: string }) => {
       const opts = program.optsWithGlobals() as { ws?: string };
       const api = await getApi(opts.ws);
 
-      verbose(`Fetching vouchers for ${accountAddr}`);
+      const accountHex = addressToHex(accountAddr);
+      verbose(`Fetching vouchers for ${accountHex}`);
 
       const vouchers = await api.voucher.getAllForAccount(
-        accountAddr,
-        options.program as `0x${string}` | undefined,
+        accountHex,
+        options.program ? addressToHex(options.program) : undefined,
       );
 
       const items = Object.entries(vouchers).map(([voucherId, details]) => ({
@@ -84,16 +86,17 @@ export function registerVoucherCommand(program: Command): void {
   voucher
     .command('revoke')
     .description('Revoke a voucher')
-    .argument('<spender>', 'spender address')
+    .argument('<spender>', 'spender address (hex or SS58)')
     .argument('<voucherId>', 'voucher ID')
     .action(async (spender: string, voucherId: string) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
 
+      const spenderHex = addressToHex(spender);
       verbose(`Revoking voucher ${voucherId}`);
 
-      const tx = api.voucher.revoke(spender, voucherId);
+      const tx = api.voucher.revoke(spenderHex, voucherId);
       const txResult = await executeTx(api, tx, account);
 
       output({

--- a/src/commands/voucher.ts
+++ b/src/commands/voucher.ts
@@ -101,7 +101,7 @@ export function registerVoucherCommand(program: Command): void {
 
       output({
         voucherId,
-        spender,
+        spender: spenderHex,
         txHash: txResult.txHash,
         blockHash: txResult.blockHash,
       });

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,18 +1,19 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
-import { outputNdjson, verbose } from '../utils';
+import { outputNdjson, verbose, addressToHex } from '../utils';
 
 export function registerWatchCommand(program: Command): void {
   program
     .command('watch')
     .description('Stream program events as NDJSON')
-    .argument('<programId>', 'program ID to watch (0x...)')
+    .argument('<programId>', 'program ID to watch (hex or SS58)')
     .option('--event <type>', 'event type to filter (UserMessageSent, MessageQueued, etc.)')
     .action(async (programId: string, options: { event?: string }) => {
       const opts = program.optsWithGlobals() as { ws?: string };
       const api = await getApi(opts.ws);
 
-      verbose(`Watching events for program ${programId}`);
+      const programIdHex = addressToHex(programId);
+      verbose(`Watching events for program ${programIdHex}`);
 
       if (options.event) {
         // Subscribe to a specific event type
@@ -30,7 +31,7 @@ export function registerWatchCommand(program: Command): void {
       } else {
         // Default: subscribe to UserMessageSent filtered by source program
         await api.gearEvents.subscribeToUserMessageSentByActor(
-          { from: programId as `0x${string}` },
+          { from: programIdHex },
           (event) => {
             const data = event.data;
             outputNdjson({

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -1,6 +1,6 @@
 import { GearKeyring } from '@gear-js/api';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { CliError, verbose } from '../utils';
+import { CliError, verbose, addressToHex } from '../utils';
 import { readConfig } from './config';
 import { loadWallet, isEncrypted, readPassphraseFile } from './wallet-store';
 
@@ -105,15 +105,16 @@ export async function resolveAccount(options: AccountOptions): Promise<KeyringPa
 /**
  * Resolve account address for read-only queries.
  * Falls back to a provided address string if no account is configured.
+ * Always returns a normalized hex address (0x...).
  */
-export async function resolveAddress(addressOrOptions: string | undefined, options: AccountOptions): Promise<string> {
+export async function resolveAddress(addressOrOptions: string | undefined, options: AccountOptions): Promise<`0x${string}`> {
   if (addressOrOptions) {
-    return addressOrOptions;
+    return addressToHex(addressOrOptions);
   }
 
   try {
     const account = await resolveAccount(options);
-    return account.address;
+    return addressToHex(account.address);
   } catch {
     throw new CliError(
       'No address specified. Provide an address argument or configure an account.',

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -2,7 +2,7 @@ import { GearApi } from '@gear-js/api';
 import { Sails } from 'sails-js';
 import { SailsIdlParser } from 'sails-js-parser';
 import * as fs from 'fs';
-import { CliError, verbose } from '../utils';
+import { CliError, verbose, addressToHex } from '../utils';
 import { readConfig } from './config';
 
 let parserPromise: Promise<SailsIdlParser> | null = null;
@@ -33,10 +33,11 @@ export async function loadSails(
   const parser = await getParser();
   const sails = new Sails(parser);
 
-  const idlString = await resolveIdl(api, options);
+  const programId = addressToHex(options.programId);
+  const idlString = await resolveIdl(api, { ...options, programId });
   sails.parseIdl(idlString);
   sails.setApi(api);
-  sails.setProgramId(options.programId as `0x${string}`);
+  sails.setProgramId(programId);
 
   return sails;
 }

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,0 +1,15 @@
+import { decodeAddress } from '@polkadot/util-crypto';
+import { u8aToHex } from '@polkadot/util';
+import { CliError } from './errors';
+
+/** Normalize SS58 or hex address to 0x-prefixed hex. */
+export function addressToHex(input: string): `0x${string}` {
+  try {
+    return u8aToHex(decodeAddress(input)) as `0x${string}`;
+  } catch {
+    throw new CliError(
+      `Invalid address: "${input}". Expected hex (0x...) or SS58 address.`,
+      'INVALID_ADDRESS',
+    );
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { output, outputNdjson, verbose, setOutputOptions } from './output';
 export { CliError, outputError, formatError, installGlobalErrorHandler } from './errors';
 export { varaToMinimal, minimalToVara, resolveAmount } from './units';
+export { addressToHex } from './address';


### PR DESCRIPTION
## Summary

This PR adds support for accepting both hexadecimal (0x...) and SS58 address formats as CLI arguments across all commands. Addresses are normalized to hex format internally.

## Changes

- **New utility function** `addressToHex()` in `src/utils/address.ts` that converts both SS58 and hex addresses to normalized hex format
- **Updated all commands** to accept and normalize addresses:
  - `balance`, `call`, `discover`, `mailbox`, `message`, `program`, `state`, `vft`, `voucher`, `watch`
- **Updated services** (`account.ts`, `sails.ts`) to use address normalization
- **Updated CLI help text** to indicate that addresses can be in hex or SS58 format
- **Improved address resolution** in `resolveAddress()` to always return normalized hex addresses

## Benefits

- Users can now provide addresses in either format, improving usability
- Consistent internal handling of addresses as hex format
- Better error messages for invalid addresses
- Reduced manual address format conversion in command implementations