### PR TITLE
feat: add block numbers and readable values to CLI outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -51,6 +51,7 @@ export function registerBalanceCommand(program: Command): void {
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
+        blockNumber: result.blockNumber,
         from: account.address,
         to,
         amount: minimalToVara(amountMinimal),

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
 import { loadSails, describeSailsProgram } from '../services/sails';
+import { resolveBlockNumber } from '../services/tx-executor';
 import { output, verbose, CliError, resolveAmount, minimalToVara } from '../utils';
 
 export function registerCallCommand(program: Command): void {
@@ -145,10 +146,12 @@ async function executeFunction(
 
   const result = await txBuilder.signAndSend();
   const response = await result.response();
+  const blockNumber = await resolveBlockNumber(api, result.blockHash);
 
   output({
     txHash: result.txHash,
     blockHash: result.blockHash,
+    blockNumber,
     messageId: result.msgId,
     result: response,
   });

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -32,6 +32,7 @@ export function registerCodeCommand(program: Command): void {
         codeId: codeHash,
         txHash: txResult.txHash,
         blockHash: txResult.blockHash,
+        blockNumber: txResult.blockNumber,
         events: txResult.events,
       });
     });

--- a/src/commands/mailbox.ts
+++ b/src/commands/mailbox.ts
@@ -30,7 +30,8 @@ export function registerMailboxCommand(program: Command): void {
           source: msgJson.source,
           destination: msgJson.destination,
           payload: msgJson.payload,
-          value: msgJson.value?.toString(),
+          value: String(msgJson.value ?? '0'),
+          valueVara: minimalToVara(BigInt(String(msgJson.value ?? '0'))),
           start: intervalJson.start,
           finish: intervalJson.finish,
         };
@@ -57,6 +58,7 @@ export function registerMailboxCommand(program: Command): void {
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
+        blockNumber: result.blockNumber,
         messageId,
         events: result.events,
       });

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -88,6 +88,7 @@ export function registerMessageCommand(program: Command): void {
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
+        blockNumber: result.blockNumber,
         messageId: messageId || null,
         events: result.events,
       });
@@ -155,6 +156,7 @@ export function registerMessageCommand(program: Command): void {
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
+        blockNumber: result.blockNumber,
         events: result.events,
       });
     });

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -80,6 +80,7 @@ export function registerProgramCommand(program: Command): void {
         salt: uploadResult.salt,
         txHash: txResult.txHash,
         blockHash: txResult.blockHash,
+        blockNumber: txResult.blockNumber,
         events: txResult.events,
       });
     });
@@ -148,6 +149,7 @@ export function registerProgramCommand(program: Command): void {
         salt: createResult.salt,
         txHash: txResult.txHash,
         blockHash: txResult.blockHash,
+        blockNumber: txResult.blockNumber,
         events: txResult.events,
       });
     });

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -46,6 +46,7 @@ export function registerTxCommand(program: Command): void {
         method,
         txHash: txResult.txHash,
         blockHash: txResult.blockHash,
+        blockNumber: txResult.blockNumber,
         events: txResult.events,
       });
     });

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
 import { loadSails } from '../services/sails';
+import { resolveBlockNumber } from '../services/tx-executor';
 import { output, verbose, CliError, resolveAmount, minimalToVara } from '../utils';
 
 export function registerVftCommand(program: Command): void {
@@ -28,10 +29,26 @@ export function registerVftCommand(program: Command): void {
       const query = sails.services[serviceName].queries['BalanceOf'];
       const result = await query(address).call();
 
+      // Try to query token decimals for human-readable formatting
+      let decimals: number | null = null;
+      try {
+        const decQuery = sails.services[serviceName].queries['Decimals'];
+        if (decQuery) {
+          const dec = await decQuery().call();
+          decimals = Number(dec);
+        }
+      } catch {
+        // Not all VFT contracts expose Decimals
+      }
+
       output({
         tokenProgram,
         account: address,
-        balance: String(result),
+        balance: decimals !== null
+          ? minimalToVara(BigInt(result), decimals)
+          : String(result),
+        balanceRaw: String(result),
+        ...(decimals !== null && { decimals }),
       });
     });
 
@@ -60,10 +77,12 @@ export function registerVftCommand(program: Command): void {
 
       const result = await txBuilder.signAndSend();
       const response = await result.response();
+      const blockNumber = await resolveBlockNumber(api, result.blockHash);
 
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
+        blockNumber,
         messageId: result.msgId,
         result: response,
       });
@@ -94,10 +113,12 @@ export function registerVftCommand(program: Command): void {
 
       const result = await txBuilder.signAndSend();
       const response = await result.response();
+      const blockNumber = await resolveBlockNumber(api, result.blockHash);
 
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
+        blockNumber,
         messageId: result.msgId,
         result: response,
       });

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -38,7 +38,7 @@ export function registerVftCommand(program: Command): void {
           decimals = Number(dec);
         }
       } catch {
-        // Not all VFT contracts expose Decimals
+        verbose(`Could not query token decimals for program ${tokenProgram}`);
       }
 
       output({

--- a/src/commands/voucher.ts
+++ b/src/commands/voucher.ts
@@ -51,6 +51,7 @@ export function registerVoucherCommand(program: Command): void {
         programs: programs || null,
         txHash: txResult.txHash,
         blockHash: txResult.blockHash,
+        blockNumber: txResult.blockNumber,
       });
     });
 
@@ -101,6 +102,7 @@ export function registerVoucherCommand(program: Command): void {
         spender,
         txHash: txResult.txHash,
         blockHash: txResult.blockHash,
+        blockNumber: txResult.blockNumber,
       });
     });
 }

--- a/src/services/tx-executor.ts
+++ b/src/services/tx-executor.ts
@@ -21,6 +21,18 @@ export interface TxEvent {
 
 const TX_TIMEOUT_MS = 60_000;
 
+export async function resolveBlockNumber(
+  api: GearApi,
+  blockHash: string,
+): Promise<number | undefined> {
+  try {
+    const header = await api.rpc.chain.getHeader(blockHash);
+    return header.number.toNumber();
+  } catch {
+    return undefined;
+  }
+}
+
 export async function executeTx(
   api: GearApi,
   extrinsic: AnyExtrinsic,
@@ -68,10 +80,13 @@ export async function executeTx(
             return;
           }
 
-          resolve({
-            txHash: extrinsic.hash.toHex(),
-            blockHash,
-            events: txEvents,
+          resolveBlockNumber(api, blockHash).then((blockNumber) => {
+            resolve({
+              txHash: extrinsic.hash.toHex(),
+              blockHash,
+              blockNumber,
+              events: txEvents,
+            });
           });
         }
       })

--- a/src/services/tx-executor.ts
+++ b/src/services/tx-executor.ts
@@ -29,6 +29,7 @@ export async function resolveBlockNumber(
     const header = await api.rpc.chain.getHeader(blockHash);
     return header.number.toNumber();
   } catch {
+    verbose(`Failed to resolve block number for hash ${blockHash}`);
     return undefined;
   }
 }

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -18,18 +18,20 @@ export function varaToMinimal(amount: string): bigint {
 }
 
 /**
- * Convert minimal units to human-readable VARA amount.
- * Returns a string with up to 12 decimal places, trailing zeros trimmed.
+ * Convert minimal units to human-readable amount.
+ * Returns a string with up to `decimals` decimal places, trailing zeros trimmed.
+ * Defaults to 12 decimals (VARA).
  */
-export function minimalToVara(minimal: bigint): string {
-  const whole = minimal / MULTIPLIER;
-  const fractional = minimal % MULTIPLIER;
+export function minimalToVara(minimal: bigint, decimals: number = VARA_DECIMALS): string {
+  const multiplier = 10n ** BigInt(decimals);
+  const whole = minimal / multiplier;
+  const fractional = minimal % multiplier;
 
   if (fractional === 0n) {
     return whole.toString();
   }
 
-  const fractionalStr = fractional.toString().padStart(VARA_DECIMALS, '0').replace(/0+$/, '');
+  const fractionalStr = fractional.toString().padStart(decimals, '0').replace(/0+$/, '');
   return `${whole}.${fractionalStr}`;
 }
 


### PR DESCRIPTION
## Changes

- **Version bump**: Updated to v0.2.0
- **Block numbers**: Added `blockNumber` field to all command outputs by querying block headers via `resolveBlockNumber()`
- **Readable values**: Enhanced VFT balance command to display human-readable token amounts with decimals support
- **Unit conversion**: Updated `minimalToVara()` to accept configurable decimals parameter (defaults to 12 for VARA)
- **Value formatting**: Improved mailbox message value display with both raw and VARA-converted values
- **Commands updated**: balance, call, code, mailbox, message, program, tx, vft, voucher commands now include block numbers in their outputs

## Technical Details

- Added `resolveBlockNumber()` utility function to fetch block numbers from block hashes
- Extended `minimalToVara()` function signature to support arbitrary token decimals
- VFT balance queries now attempt to fetch token decimals for proper conversion
- All transaction results now include resolved block numbers