### PR TITLE
feat: add subscribe command with SQLite event persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,25 @@ vara-wallet watch 0x1234...
 # Streams NDJSON: one JSON object per line per event
 ```
 
+### Subscribing to events (with persistence)
+
+`subscribe` streams events like `watch`, but also saves them to a local SQLite database (`~/.vara-wallet/events.db`). This means you can query events between runs — critical for mailbox messages that disappear after ~1 block.
+
+```bash
+# Watch for mailbox messages (they vanish after 1 block — subscribe catches them)
+vara-wallet subscribe mailbox kGioe8b7...
+
+# Wait for exactly 1 transfer event, then exit
+vara-wallet subscribe transfers --count 1 --timeout 30
+
+# Stream new blocks
+vara-wallet subscribe blocks --finalized
+
+# Query captured events later
+vara-wallet inbox list --since 1h
+vara-wallet events list --type mailbox --limit 10
+```
+
 ### VFT (Fungible Token) operations
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -212,9 +212,45 @@ Wait for a reply to a message.
 vara-wallet wait <messageId> [--timeout <seconds>]
 ```
 
+### `subscribe`
+
+Subscribe to on-chain events with NDJSON streaming and optional SQLite persistence. Events are stored in `~/.vara-wallet/events.db` so they survive between runs.
+
+```bash
+vara-wallet subscribe blocks [--finalized]
+vara-wallet subscribe messages <programId> [--type <eventName>] [--from-block <n>]
+vara-wallet subscribe mailbox <address>
+vara-wallet subscribe balance <address>
+vara-wallet subscribe transfers [--from <addr>] [--to <addr>]
+vara-wallet subscribe program <programId>
+```
+
+**Global subscribe options:**
+- `--count <n>` — exit after N events (useful for scripting)
+- `--timeout <seconds>` — exit after N seconds
+- `--no-persist` — stream only, skip SQLite persistence
+
+### `inbox`
+
+Query captured mailbox messages from the event store.
+
+```bash
+vara-wallet inbox list [--since <duration>] [--limit <n>]
+vara-wallet inbox read <messageId>
+```
+
+### `events`
+
+Query and manage all captured events from the event store.
+
+```bash
+vara-wallet events list [--type <type>] [--since <duration>] [--program <id>] [--limit <n>]
+vara-wallet events prune [--older-than <duration>]
+```
+
 ### `watch`
 
-Stream program events as NDJSON.
+Stream program events as NDJSON. For persistent event capture with SQLite storage, see `subscribe` above.
 
 ```bash
 vara-wallet watch <programId> [--event <type>]
@@ -233,6 +269,7 @@ vara-wallet decode <type> <hex> [--metadata <path>] [--idl <path>] [--program <i
 ~/.vara-wallet/
   config.json          # wsEndpoint, defaultAccount, metaStorageUrl
   .passphrase          # Auto-generated or human-provided (0600)
+  events.db            # SQLite event store (subscribe/inbox/events)
   wallets/
     default.json       # Encrypted keystore (0600)
     *.json

--- a/SKILL.md
+++ b/SKILL.md
@@ -57,6 +57,10 @@ The passphrase is stored at `~/.vara-wallet/.passphrase` (0600). The agent never
 | `$VW discover <pid> --idl <path>` | Introspect Sails services, methods, events |
 | `$VW state read <pid>` | Read raw program state |
 | `$VW mailbox read [address]` | Read mailbox messages |
+| `$VW inbox list [--since <duration>] [--limit <n>]` | Query captured mailbox messages from event store |
+| `$VW inbox read <messageId>` | Read a specific captured message |
+| `$VW events list [--type <t>] [--since <d>] [--program <id>]` | Query captured events from event store |
+| `$VW events prune [--older-than <duration>]` | Delete old events |
 | `$VW query <pallet> <method> [args...]` | Generic storage query |
 | `$VW vft balance <token> [account] --idl <path>` | Fungible token balance |
 
@@ -84,6 +88,12 @@ The passphrase is stored at `~/.vara-wallet/.passphrase` (0600). The agent never
 |---------|---------|
 | `$VW wait <messageId> [--timeout <s>]` | Wait for message reply |
 | `$VW watch <pid>` | Stream program events (NDJSON) |
+| `$VW subscribe blocks [--finalized]` | Stream new/finalized blocks (NDJSON + SQLite) |
+| `$VW subscribe messages <pid> [--type <event>]` | Stream program messages/events |
+| `$VW subscribe mailbox <address>` | Capture mailbox messages (survives between runs) |
+| `$VW subscribe balance <address>` | Stream balance changes |
+| `$VW subscribe transfers [--from <a>] [--to <a>]` | Stream transfer events |
+| `$VW subscribe program <pid>` | Stream program state changes |
 
 ### Wallet Management
 
@@ -131,6 +141,20 @@ echo $REPLY | jq .payload
 $VW watch $PROGRAM_ID | while read -r line; do
   echo "$line" | jq .
 done
+```
+
+### Subscribe to events (with persistence)
+
+```bash
+# Catch mailbox messages (they vanish after ~1 block)
+$VW subscribe mailbox $MY_ADDRESS
+
+# Wait for exactly 1 transfer, then exit (agent-friendly)
+$VW subscribe transfers --count 1 --timeout 30
+
+# Query captured events between runs
+$VW inbox list --since 1h
+$VW events list --type mailbox --limit 10
 ```
 
 ### Token operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "vara-wallet",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@gear-js/api": "^0.44.2",
         "@polkadot/api": "^16.5.4",
         "@polkadot/util": "^14.0.2",
+        "better-sqlite3": "^11.0.0",
         "chalk": "^4",
         "commander": "^14.0.3",
         "sails-js": "^0.5.1",
@@ -22,6 +23,7 @@
         "vara-wallet": "dist/app.js"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.10.1",
         "jest": "^30.2.0",
@@ -1818,6 +1820,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
@@ -2361,6 +2373,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -2372,6 +2404,37 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bn.js": {
@@ -2447,6 +2510,30 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2520,6 +2607,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -2722,6 +2815,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -2737,6 +2845,15 @@
         }
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2745,6 +2862,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -2790,6 +2916,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -2882,6 +3017,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
@@ -2940,6 +3084,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2982,6 +3132,12 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3047,6 +3203,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -3125,6 +3287,26 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3171,7 +3353,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -4083,6 +4270,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4103,7 +4302,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4119,6 +4317,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mock-socket": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
@@ -4132,6 +4336,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -4176,6 +4386,30 @@
       },
       "engines": {
         "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -4257,7 +4491,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4457,6 +4690,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
@@ -4494,6 +4754,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -4511,12 +4781,50 @@
       ],
       "license": "MIT"
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4559,6 +4867,26 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/sails-js": {
       "version": "0.5.1",
@@ -4653,6 +4981,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4711,6 +5084,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -4915,6 +5297,34 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5068,6 +5478,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5190,6 +5612,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -5347,7 +5775,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@gear-js/api": "^0.44.2",
     "@polkadot/api": "^16.5.4",
     "@polkadot/util": "^14.0.2",
+    "better-sqlite3": "^11.0.0",
     "chalk": "^4",
     "commander": "^14.0.3",
     "sails-js": "^0.5.1",
@@ -28,6 +29,7 @@
     "smoldot": "https://github.com/ukint-vs/smoldot-gear/releases/download/v2.0.40-gear/smoldot-2.0.40.tgz"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",
     "jest": "^30.2.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,9 @@ import { registerVftCommand } from './commands/vft';
 import { registerVoucherCommand } from './commands/voucher';
 import { registerEncodeCommand } from './commands/encode';
 import { registerTxCommand } from './commands/tx';
+import { registerSubscribeCommand } from './commands/subscribe';
+import { registerInboxCommand } from './commands/inbox';
+import { registerEventsCommand } from './commands/events';
 
 installGlobalErrorHandler();
 
@@ -74,6 +77,21 @@ registerVftCommand(program);
 registerVoucherCommand(program);
 registerEncodeCommand(program);
 registerTxCommand(program);
+
+// Register commands — Phase 4: Subscriptions & Event Store
+registerSubscribeCommand(program);
+registerInboxCommand(program);
+registerEventsCommand(program);
+
+// Graceful shutdown (moved from api.ts so subscribe/keepAlive can override)
+process.on('SIGINT', () => {
+  disconnectApi();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  disconnectApi();
+  process.exit(0);
+});
 
 async function main(): Promise<void> {
   try {

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -1,0 +1,47 @@
+import { Command } from 'commander';
+import { initEventStore, queryEvents, pruneEvents } from '../services/event-store';
+import { output, addressToHex } from '../utils';
+import { parseDuration } from './subscribe/shared';
+
+export function registerEventsCommand(program: Command): void {
+  const events = program
+    .command('events')
+    .description('Query and manage captured events from the event store');
+
+  events
+    .command('list')
+    .description('List captured events with optional filters')
+    .option('--type <type>', 'filter by event type (block, message, mailbox, balance, transfer, program)')
+    .option('--since <duration>', 'time filter (e.g., 1h, 30m, 7d)')
+    .option('--program <id>', 'filter by program ID')
+    .option('--limit <n>', 'max results (default: 50)', '50')
+    .action((options: { type?: string; since?: string; program?: string; limit: string }) => {
+      initEventStore();
+
+      const since = options.since ? Date.now() - parseDuration(options.since) : undefined;
+      const limit = parseInt(options.limit, 10);
+      const program = options.program ? addressToHex(options.program) : undefined;
+
+      const rows = queryEvents({ type: options.type, since, program, limit });
+      const parsed = rows.map((row) => ({
+        id: row.id,
+        ...JSON.parse(row.data),
+        storedAt: row.created_at,
+      }));
+
+      output(parsed);
+    });
+
+  events
+    .command('prune')
+    .description('Delete old events from the event store')
+    .option('--older-than <duration>', 'delete events older than duration (default: 7d)', '7d')
+    .action((options: { olderThan: string }) => {
+      initEventStore();
+
+      const olderThanMs = parseDuration(options.olderThan);
+      const count = pruneEvents(olderThanMs);
+
+      output({ pruned: count });
+    });
+}

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,0 +1,50 @@
+import { Command } from 'commander';
+import { initEventStore, queryMailbox, readEvent } from '../services/event-store';
+import { output, CliError } from '../utils';
+import { parseDuration } from './subscribe/shared';
+
+export function registerInboxCommand(program: Command): void {
+  const inbox = program
+    .command('inbox')
+    .description('Query captured mailbox messages from the event store');
+
+  inbox
+    .command('list')
+    .description('List captured mailbox messages')
+    .option('--since <duration>', 'time filter (e.g., 1h, 30m, 7d)')
+    .option('--limit <n>', 'max results (default: 50)', '50')
+    .action((options: { since?: string; limit: string }) => {
+      initEventStore();
+
+      const since = options.since ? Date.now() - parseDuration(options.since) : undefined;
+      const limit = parseInt(options.limit, 10);
+
+      const events = queryMailbox({ since, limit });
+      const parsed = events.map((row) => ({
+        id: row.id,
+        ...JSON.parse(row.data),
+        storedAt: row.created_at,
+      }));
+
+      output(parsed);
+    });
+
+  inbox
+    .command('read')
+    .description('Read a specific captured message by ID')
+    .argument('<messageId>', 'message ID (hex)')
+    .action((messageId: string) => {
+      initEventStore();
+
+      const event = readEvent(messageId);
+      if (!event) {
+        throw new CliError(`Message ${messageId} not found in event store`, 'NOT_FOUND');
+      }
+
+      output({
+        id: event.id,
+        ...JSON.parse(event.data),
+        storedAt: event.created_at,
+      });
+    });
+}

--- a/src/commands/subscribe/__tests__/shared.test.ts
+++ b/src/commands/subscribe/__tests__/shared.test.ts
@@ -1,3 +1,4 @@
+import type { UserMessageSent } from '@gear-js/api';
 import {
   validateEventName,
   validateFromBlock,
@@ -174,7 +175,7 @@ describe('formatUserMessageSent', () => {
       },
     };
 
-    const result = formatUserMessageSent(mockEvent);
+    const result = formatUserMessageSent(mockEvent as unknown as UserMessageSent);
     expect(result).toEqual({
       messageId: '0xabc',
       source: '0x111',
@@ -205,7 +206,7 @@ describe('formatUserMessageSent', () => {
       },
     };
 
-    const result = formatUserMessageSent(mockEvent);
+    const result = formatUserMessageSent(mockEvent as unknown as UserMessageSent);
     expect(result.details).toEqual({
       replyTo: '0xreply',
       code: 'Success',

--- a/src/commands/subscribe/__tests__/shared.test.ts
+++ b/src/commands/subscribe/__tests__/shared.test.ts
@@ -1,0 +1,214 @@
+import {
+  validateEventName,
+  validateFromBlock,
+  createEventCounter,
+  parseDuration,
+  formatUserMessageSent,
+  emitSystemEvent,
+  emitAndPersist,
+  safeCallback,
+} from '../shared';
+import { CliError } from '../../../utils';
+
+// Mock outputNdjson to capture output
+const mockOutputNdjson = jest.fn();
+jest.mock('../../../utils', () => {
+  const actual = jest.requireActual('../../../utils');
+  return {
+    ...actual,
+    outputNdjson: (...args: unknown[]) => mockOutputNdjson(...args),
+    verbose: jest.fn(),
+  };
+});
+
+// Mock insertEvent
+const mockInsertEvent = jest.fn();
+jest.mock('../../../services/event-store', () => ({
+  insertEvent: (...args: unknown[]) => mockInsertEvent(...args),
+}));
+
+beforeEach(() => {
+  mockOutputNdjson.mockClear();
+  mockInsertEvent.mockClear();
+});
+
+describe('validateEventName', () => {
+  it('accepts valid gear event names', () => {
+    expect(validateEventName('UserMessageSent')).toBe('UserMessageSent');
+    expect(validateEventName('MessageQueued')).toBe('MessageQueued');
+    expect(validateEventName('ProgramChanged')).toBe('ProgramChanged');
+  });
+
+  it('rejects invalid event names', () => {
+    expect(() => validateEventName('FakeEvent')).toThrow(CliError);
+    expect(() => validateEventName('')).toThrow(CliError);
+  });
+});
+
+describe('validateFromBlock', () => {
+  it('accepts valid block numbers', () => {
+    expect(validateFromBlock('0')).toBe(0);
+    expect(validateFromBlock('100')).toBe(100);
+    expect(validateFromBlock('999999')).toBe(999999);
+  });
+
+  it('rejects invalid values', () => {
+    expect(() => validateFromBlock('-1')).toThrow(CliError);
+    expect(() => validateFromBlock('abc')).toThrow(CliError);
+    expect(() => validateFromBlock('')).toThrow(CliError);
+  });
+});
+
+describe('createEventCounter', () => {
+  it('returns false when no limit is set', () => {
+    const counter = createEventCounter(undefined);
+    expect(counter.increment()).toBe(false);
+    expect(counter.increment()).toBe(false);
+    expect(counter.increment()).toBe(false);
+  });
+
+  it('returns true when limit is reached', () => {
+    const counter = createEventCounter(3);
+    expect(counter.increment()).toBe(false);
+    expect(counter.increment()).toBe(false);
+    expect(counter.increment()).toBe(true); // 3rd event hits limit
+  });
+
+  it('handles limit of 1', () => {
+    const counter = createEventCounter(1);
+    expect(counter.increment()).toBe(true);
+  });
+});
+
+describe('parseDuration', () => {
+  it('parses seconds', () => {
+    expect(parseDuration('30s')).toBe(30000);
+  });
+
+  it('parses minutes', () => {
+    expect(parseDuration('5m')).toBe(300000);
+  });
+
+  it('parses hours', () => {
+    expect(parseDuration('1h')).toBe(3600000);
+  });
+
+  it('parses days', () => {
+    expect(parseDuration('7d')).toBe(604800000);
+  });
+
+  it('rejects invalid formats', () => {
+    expect(() => parseDuration('abc')).toThrow(CliError);
+    expect(() => parseDuration('10')).toThrow(CliError);
+    expect(() => parseDuration('10x')).toThrow(CliError);
+    expect(() => parseDuration('')).toThrow(CliError);
+  });
+});
+
+describe('emitSystemEvent', () => {
+  it('outputs system event as NDJSON', () => {
+    const before = Date.now();
+    emitSystemEvent('subscribed', { subscription: 'blocks' });
+    const after = Date.now();
+
+    expect(mockOutputNdjson).toHaveBeenCalledTimes(1);
+    const arg = mockOutputNdjson.mock.calls[0][0];
+    expect(arg.type).toBe('system');
+    expect(arg.event).toBe('subscribed');
+    expect(arg.subscription).toBe('blocks');
+    expect(arg.timestamp).toBeGreaterThanOrEqual(before);
+    expect(arg.timestamp).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('emitAndPersist', () => {
+  it('outputs NDJSON and persists when persist=true', () => {
+    const data = { type: 'block', number: 1 };
+    const eventInsert = { type: 'block', data };
+
+    emitAndPersist(data, true, eventInsert);
+
+    expect(mockOutputNdjson).toHaveBeenCalledWith(data);
+    expect(mockInsertEvent).toHaveBeenCalledWith(eventInsert);
+  });
+
+  it('outputs NDJSON but skips persist when persist=false', () => {
+    const data = { type: 'block', number: 1 };
+
+    emitAndPersist(data, false, { type: 'block', data });
+
+    expect(mockOutputNdjson).toHaveBeenCalledWith(data);
+    expect(mockInsertEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('safeCallback', () => {
+  it('calls the wrapped function normally', () => {
+    const fn = jest.fn();
+    const safe = safeCallback(fn);
+    safe('test');
+    expect(fn).toHaveBeenCalledWith('test');
+  });
+
+  it('catches errors without rethrowing', () => {
+    const fn = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const safe = safeCallback(fn);
+    expect(() => safe('test')).not.toThrow();
+  });
+});
+
+describe('formatUserMessageSent', () => {
+  it('extracts fields from event data', () => {
+    const mockEvent = {
+      data: {
+        message: {
+          id: { toHex: () => '0xabc' },
+          source: { toHex: () => '0x111' },
+          destination: { toHex: () => '0x222' },
+          payload: { toHex: () => '0xdeadbeef' },
+          value: { toString: () => '1000' },
+          details: { isSome: false },
+        },
+      },
+    };
+
+    const result = formatUserMessageSent(mockEvent);
+    expect(result).toEqual({
+      messageId: '0xabc',
+      source: '0x111',
+      destination: '0x222',
+      payload: '0xdeadbeef',
+      value: '1000',
+      details: null,
+    });
+  });
+
+  it('extracts reply details when present', () => {
+    const mockEvent = {
+      data: {
+        message: {
+          id: { toHex: () => '0xabc' },
+          source: { toHex: () => '0x111' },
+          destination: { toHex: () => '0x222' },
+          payload: { toHex: () => '0x00' },
+          value: { toString: () => '0' },
+          details: {
+            isSome: true,
+            unwrap: () => ({
+              to: { toHex: () => '0xreply' },
+              code: { toString: () => 'Success' },
+            }),
+          },
+        },
+      },
+    };
+
+    const result = formatUserMessageSent(mockEvent);
+    expect(result.details).toEqual({
+      replyTo: '0xreply',
+      code: 'Success',
+    });
+  });
+});

--- a/src/commands/subscribe/balance.ts
+++ b/src/commands/subscribe/balance.ts
@@ -1,0 +1,67 @@
+import { Command } from 'commander';
+import { getApi } from '../../services/api';
+import { resolveAddress, type AccountOptions } from '../../services/account';
+import { initEventStore } from '../../services/event-store';
+import { verbose, minimalToVara } from '../../utils';
+import {
+  emitSystemEvent,
+  emitAndPersist,
+  safeCallback,
+  installEpipeHandler,
+  keepAlive,
+  withReconnect,
+  createEventCounter,
+} from './shared';
+
+export function registerBalanceCommand(parent: Command): void {
+  parent
+    .command('balance')
+    .description('Subscribe to account balance changes')
+    .argument('[address]', 'account address (defaults to configured account)')
+    .action(async (address?: string) => {
+      const opts = parent.parent!.optsWithGlobals() as AccountOptions & { ws?: string; count?: string; timeout?: string; persist?: boolean };
+      const api = await getApi(opts.ws);
+      const persist = opts.persist !== false;
+      if (persist) initEventStore();
+      installEpipeHandler();
+
+      const resolvedAddress = await resolveAddress(address, opts);
+      const counter = createEventCounter(opts.count ? parseInt(opts.count, 10) : undefined);
+
+      verbose(`Subscribing to balance changes for ${resolvedAddress}`);
+
+      const subscribe = async () => {
+        const unsub = await api.gearEvents.subscribeToBalanceChanges(
+          resolvedAddress,
+          safeCallback((balance) => {
+            const data = {
+              type: 'balance' as const,
+              address: resolvedAddress,
+              free: minimalToVara(balance.toBigInt()),
+              freeRaw: balance.toString(),
+              timestamp: Date.now(),
+            };
+
+            emitAndPersist(data, persist, {
+              type: 'balance',
+              data,
+              destination: resolvedAddress,
+            });
+
+            if (counter.increment()) {
+              ka.triggerExit();
+            }
+          }),
+        );
+        return unsub;
+      };
+
+      const unsub = await withReconnect(api, subscribe);
+      emitSystemEvent('subscribed', { subscription: 'balance', address: resolvedAddress });
+
+      const ka = keepAlive([unsub], {
+        timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+      });
+      await ka.promise;
+    });
+}

--- a/src/commands/subscribe/blocks.ts
+++ b/src/commands/subscribe/blocks.ts
@@ -1,0 +1,71 @@
+import { Command } from 'commander';
+import { getApi } from '../../services/api';
+import { initEventStore } from '../../services/event-store';
+import { verbose } from '../../utils';
+import {
+  emitSystemEvent,
+  emitAndPersist,
+  safeCallback,
+  installEpipeHandler,
+  keepAlive,
+  withReconnect,
+  createEventCounter,
+} from './shared';
+
+export function registerBlocksCommand(parent: Command): void {
+  parent
+    .command('blocks')
+    .description('Subscribe to new block headers')
+    .option('--finalized', 'subscribe to finalized blocks only')
+    .action(async (options: { finalized?: boolean }) => {
+      const opts = parent.parent!.optsWithGlobals() as { ws?: string; count?: string; timeout?: string; persist?: boolean };
+      const api = await getApi(opts.ws);
+      const persist = opts.persist !== false;
+      if (persist) initEventStore();
+      installEpipeHandler();
+
+      const counter = createEventCounter(opts.count ? parseInt(opts.count, 10) : undefined);
+      const mode = options.finalized ? 'finalized' : 'latest';
+      verbose(`Subscribing to ${mode} blocks`);
+
+      const subscribe = async () => {
+        const method = options.finalized
+          ? api.rpc.chain.subscribeFinalizedHeads.bind(api.rpc.chain)
+          : api.rpc.chain.subscribeNewHeads.bind(api.rpc.chain);
+
+        const unsub = await method(safeCallback((header) => {
+          const data = {
+            type: 'block' as const,
+            number: header.number.toNumber(),
+            hash: header.hash.toHex(),
+            parentHash: header.parentHash.toHex(),
+            stateRoot: header.stateRoot.toHex(),
+            extrinsicsRoot: header.extrinsicsRoot.toHex(),
+            timestamp: Date.now(),
+          };
+
+          emitAndPersist(data, persist, {
+            type: 'block',
+            event_id: header.hash.toHex(),
+            data,
+            block_number: header.number.toNumber(),
+            block_hash: header.hash.toHex(),
+          });
+
+          if (counter.increment()) {
+            ka.triggerExit();
+          }
+        }));
+
+        return unsub;
+      };
+
+      const unsub = await withReconnect(api, subscribe);
+      emitSystemEvent('subscribed', { subscription: 'blocks', mode });
+
+      const ka = keepAlive([unsub], {
+        timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+      });
+      await ka.promise;
+    });
+}

--- a/src/commands/subscribe/index.ts
+++ b/src/commands/subscribe/index.ts
@@ -1,0 +1,23 @@
+import { Command } from 'commander';
+import { registerBlocksCommand } from './blocks';
+import { registerMessagesCommand } from './messages';
+import { registerMailboxCommand } from './mailbox';
+import { registerBalanceCommand } from './balance';
+import { registerTransfersCommand } from './transfers';
+import { registerProgramCommand } from './program';
+
+export function registerSubscribeCommand(program: Command): void {
+  const subscribe = program
+    .command('subscribe')
+    .description('Subscribe to on-chain events (streams NDJSON, persists to SQLite)')
+    .option('--count <n>', 'exit after N events')
+    .option('--timeout <seconds>', 'exit after N seconds')
+    .option('--no-persist', 'stream only, skip SQLite persistence');
+
+  registerBlocksCommand(subscribe);
+  registerMessagesCommand(subscribe);
+  registerMailboxCommand(subscribe);
+  registerBalanceCommand(subscribe);
+  registerTransfersCommand(subscribe);
+  registerProgramCommand(subscribe);
+}

--- a/src/commands/subscribe/mailbox.ts
+++ b/src/commands/subscribe/mailbox.ts
@@ -1,0 +1,110 @@
+import { Command } from 'commander';
+import { getApi } from '../../services/api';
+import { resolveAddress, type AccountOptions } from '../../services/account';
+import { initEventStore } from '../../services/event-store';
+import { verbose } from '../../utils';
+import {
+  emitSystemEvent,
+  emitAndPersist,
+  safeCallback,
+  installEpipeHandler,
+  keepAlive,
+  withReconnect,
+  createEventCounter,
+} from './shared';
+
+export function registerMailboxCommand(parent: Command): void {
+  parent
+    .command('mailbox')
+    .description('Subscribe to mailbox messages (received and read)')
+    .argument('[address]', 'account address (defaults to configured account)')
+    .action(async (address?: string) => {
+      const opts = parent.parent!.optsWithGlobals() as AccountOptions & { ws?: string; count?: string; timeout?: string; persist?: boolean };
+      const api = await getApi(opts.ws);
+      const persist = opts.persist !== false;
+      if (persist) initEventStore();
+      installEpipeHandler();
+
+      const resolvedAddress = await resolveAddress(address, opts);
+      const counter = createEventCounter(opts.count ? parseInt(opts.count, 10) : undefined);
+
+      verbose(`Subscribing to mailbox for ${resolvedAddress}`);
+
+      const unsubscribers: Array<() => void> = [];
+
+      // Subscription 1: UserMessageSent where destination === our address
+      const subscribeReceived = async () => {
+        const unsub = await api.gearEvents.subscribeToGearEvent(
+          'UserMessageSent',
+          safeCallback((event) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const msgData = (event as any).data;
+            const dest = msgData.message.destination.toHex();
+
+            if (dest !== resolvedAddress) return;
+
+            const data = {
+              type: 'mailbox' as const,
+              action: 'received' as const,
+              messageId: msgData.message.id.toHex(),
+              source: msgData.message.source.toHex(),
+              destination: dest,
+              payload: msgData.message.payload.toHex(),
+              value: msgData.message.value.toString(),
+              timestamp: Date.now(),
+            };
+
+            emitAndPersist(data, persist, {
+              type: 'mailbox',
+              event_id: msgData.message.id.toHex(),
+              data,
+              source: msgData.message.source.toHex(),
+              destination: dest,
+            });
+
+            if (counter.increment()) {
+              ka.triggerExit();
+            }
+          }),
+        );
+        return unsub;
+      };
+
+      // Subscription 2: UserMessageRead (detect claims)
+      const subscribeRead = async () => {
+        const unsub = await api.gearEvents.subscribeToGearEvent(
+          'UserMessageRead',
+          safeCallback((event) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const readData = (event as any).data;
+            const data = {
+              type: 'mailbox' as const,
+              action: 'read' as const,
+              messageId: readData.id.toHex(),
+              reason: readData.reason.toString(),
+              timestamp: Date.now(),
+            };
+
+            emitAndPersist(data, persist, {
+              type: 'mailbox',
+              event_id: readData.id.toHex(),
+              data,
+              destination: resolvedAddress,
+            });
+          }),
+        );
+        return unsub;
+      };
+
+      const unsub1 = await withReconnect(api, subscribeReceived);
+      const unsub2 = await withReconnect(api, subscribeRead);
+      unsubscribers.push(unsub1, unsub2);
+
+      emitSystemEvent('subscribed', { subscription: 'mailbox', address: resolvedAddress });
+
+      const ka = keepAlive(unsubscribers, {
+        timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+      });
+      await ka.promise;
+    });
+}

--- a/src/commands/subscribe/mailbox.ts
+++ b/src/commands/subscribe/mailbox.ts
@@ -37,28 +37,27 @@ export function registerMailboxCommand(parent: Command): void {
         const unsub = await api.gearEvents.subscribeToGearEvent(
           'UserMessageSent',
           safeCallback((event) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const msgData = (event as any).data;
-            const dest = msgData.message.destination.toHex();
+            const { message } = event.data;
+            const dest = message.destination.toHex();
 
             if (dest !== resolvedAddress) return;
 
             const data = {
               type: 'mailbox' as const,
               action: 'received' as const,
-              messageId: msgData.message.id.toHex(),
-              source: msgData.message.source.toHex(),
+              messageId: message.id.toHex(),
+              source: message.source.toHex(),
               destination: dest,
-              payload: msgData.message.payload.toHex(),
-              value: msgData.message.value.toString(),
+              payload: message.payload.toHex(),
+              value: message.value.toString(),
               timestamp: Date.now(),
             };
 
             emitAndPersist(data, persist, {
               type: 'mailbox',
-              event_id: msgData.message.id.toHex(),
+              event_id: message.id.toHex(),
               data,
-              source: msgData.message.source.toHex(),
+              source: message.source.toHex(),
               destination: dest,
             });
 
@@ -75,19 +74,18 @@ export function registerMailboxCommand(parent: Command): void {
         const unsub = await api.gearEvents.subscribeToGearEvent(
           'UserMessageRead',
           safeCallback((event) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const readData = (event as any).data;
+            const { id, reason } = event.data;
             const data = {
               type: 'mailbox' as const,
               action: 'read' as const,
-              messageId: readData.id.toHex(),
-              reason: readData.reason.toString(),
+              messageId: id.toHex(),
+              reason: reason.toString(),
               timestamp: Date.now(),
             };
 
             emitAndPersist(data, persist, {
               type: 'mailbox',
-              event_id: readData.id.toHex(),
+              event_id: id.toHex(),
               data,
               destination: resolvedAddress,
             });

--- a/src/commands/subscribe/messages.ts
+++ b/src/commands/subscribe/messages.ts
@@ -1,0 +1,119 @@
+import { Command } from 'commander';
+import { getApi } from '../../services/api';
+import { initEventStore } from '../../services/event-store';
+import { verbose, addressToHex } from '../../utils';
+import {
+  emitSystemEvent,
+  emitAndPersist,
+  safeCallback,
+  installEpipeHandler,
+  keepAlive,
+  withReconnect,
+  createEventCounter,
+  validateEventName,
+  validateFromBlock,
+  formatUserMessageSent,
+} from './shared';
+
+export function registerMessagesCommand(parent: Command): void {
+  parent
+    .command('messages')
+    .description('Subscribe to program messages and events')
+    .argument('<programId>', 'program ID to watch (hex or SS58)')
+    .option('--type <eventType>', 'specific event type to subscribe to')
+    .option('--from-block <number>', 'backfill from a specific block number')
+    .action(async (programId: string, options: { type?: string; fromBlock?: string }) => {
+      const opts = parent.parent!.optsWithGlobals() as { ws?: string; count?: string; timeout?: string; persist?: boolean };
+      const api = await getApi(opts.ws);
+      const persist = opts.persist !== false;
+      if (persist) initEventStore();
+      installEpipeHandler();
+
+      const programIdHex = addressToHex(programId);
+      const counter = createEventCounter(opts.count ? parseInt(opts.count, 10) : undefined);
+
+      if (options.type) {
+        // Subscribe to a specific event type
+        const eventName = validateEventName(options.type);
+        const fromBlock = options.fromBlock ? validateFromBlock(options.fromBlock) : undefined;
+
+        verbose(`Subscribing to ${eventName} events for program ${programIdHex}`);
+
+        const subscribe = async () => {
+          const unsub = await api.gearEvents.subscribeToGearEvent(
+            eventName,
+            safeCallback((event) => {
+              const eventData = event.data.toJSON();
+              const data = {
+                type: 'message' as const,
+                event: eventName,
+                data: eventData,
+                programId: programIdHex,
+                timestamp: Date.now(),
+              };
+
+              emitAndPersist(data, persist, {
+                type: 'message',
+                data,
+                program_id: programIdHex,
+              });
+
+              if (counter.increment()) {
+                ka.triggerExit();
+              }
+            }),
+            fromBlock,
+          );
+          return unsub;
+        };
+
+        const unsub = await withReconnect(api, subscribe);
+        emitSystemEvent('subscribed', { subscription: 'messages', programId: programIdHex, event: eventName });
+
+        const ka = keepAlive([unsub], {
+          timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+        });
+        await ka.promise;
+      } else {
+        // Default: subscribe to UserMessageSent from this program
+        verbose(`Subscribing to UserMessageSent from ${programIdHex}`);
+
+        const subscribe = async () => {
+          const unsub = await api.gearEvents.subscribeToUserMessageSentByActor(
+            { from: programIdHex },
+            safeCallback((event) => {
+              const msg = formatUserMessageSent(event);
+              const data = {
+                type: 'message' as const,
+                event: 'UserMessageSent',
+                ...msg,
+                timestamp: Date.now(),
+              };
+
+              emitAndPersist(data, persist, {
+                type: 'message',
+                event_id: msg.messageId as string,
+                data,
+                source: msg.source as string,
+                destination: msg.destination as string,
+                program_id: programIdHex,
+              });
+
+              if (counter.increment()) {
+                ka.triggerExit();
+              }
+            }),
+          );
+          return unsub;
+        };
+
+        const unsub = await withReconnect(api, subscribe);
+        emitSystemEvent('subscribed', { subscription: 'messages', programId: programIdHex, event: 'UserMessageSent' });
+
+        const ka = keepAlive([unsub], {
+          timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+        });
+        await ka.promise;
+      }
+    });
+}

--- a/src/commands/subscribe/program.ts
+++ b/src/commands/subscribe/program.ts
@@ -33,16 +33,15 @@ export function registerProgramCommand(parent: Command): void {
         const unsub = await api.gearEvents.subscribeToGearEvent(
           'ProgramChanged',
           safeCallback((event) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const eventData = (event as any).data;
-            const id = eventData.id.toHex();
+            const { id: progId, change } = event.data;
+            const id = progId.toHex();
 
             if (id !== programIdHex) return;
 
             const data = {
               type: 'program' as const,
               programId: id,
-              status: eventData.change.toString(),
+              status: change.toString(),
               timestamp: Date.now(),
             };
 

--- a/src/commands/subscribe/program.ts
+++ b/src/commands/subscribe/program.ts
@@ -1,0 +1,72 @@
+import { Command } from 'commander';
+import { getApi } from '../../services/api';
+import { initEventStore } from '../../services/event-store';
+import { verbose, addressToHex } from '../../utils';
+import {
+  emitSystemEvent,
+  emitAndPersist,
+  safeCallback,
+  installEpipeHandler,
+  keepAlive,
+  withReconnect,
+  createEventCounter,
+} from './shared';
+
+export function registerProgramCommand(parent: Command): void {
+  parent
+    .command('program')
+    .description('Subscribe to program status changes')
+    .argument('<programId>', 'program ID to watch (hex or SS58)')
+    .action(async (programId: string) => {
+      const opts = parent.parent!.optsWithGlobals() as { ws?: string; count?: string; timeout?: string; persist?: boolean };
+      const api = await getApi(opts.ws);
+      const persist = opts.persist !== false;
+      if (persist) initEventStore();
+      installEpipeHandler();
+
+      const programIdHex = addressToHex(programId);
+      const counter = createEventCounter(opts.count ? parseInt(opts.count, 10) : undefined);
+
+      verbose(`Subscribing to ProgramChanged for ${programIdHex}`);
+
+      const subscribe = async () => {
+        const unsub = await api.gearEvents.subscribeToGearEvent(
+          'ProgramChanged',
+          safeCallback((event) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const eventData = (event as any).data;
+            const id = eventData.id.toHex();
+
+            if (id !== programIdHex) return;
+
+            const data = {
+              type: 'program' as const,
+              programId: id,
+              status: eventData.change.toString(),
+              timestamp: Date.now(),
+            };
+
+            emitAndPersist(data, persist, {
+              type: 'program',
+              event_id: id,
+              data,
+              program_id: id,
+            });
+
+            if (counter.increment()) {
+              ka.triggerExit();
+            }
+          }),
+        );
+        return unsub;
+      };
+
+      const unsub = await withReconnect(api, subscribe);
+      emitSystemEvent('subscribed', { subscription: 'program', programId: programIdHex });
+
+      const ka = keepAlive([unsub], {
+        timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+      });
+      await ka.promise;
+    });
+}

--- a/src/commands/subscribe/shared.ts
+++ b/src/commands/subscribe/shared.ts
@@ -1,4 +1,4 @@
-import { GearApi } from '@gear-js/api';
+import { GearApi, type UserMessageSent } from '@gear-js/api';
 import { outputNdjson, verbose, CliError } from '../../utils';
 import { insertEvent, type EventInsert } from '../../services/event-store';
 import { disconnectApi } from '../../services/api';
@@ -221,19 +221,18 @@ export async function withReconnect(
 /**
  * Extract fields from a UserMessageSent event.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function formatUserMessageSent(event: any): Record<string, unknown> {
-  const data = event.data;
+export function formatUserMessageSent(event: UserMessageSent): Record<string, unknown> {
+  const { message } = event.data;
   return {
-    messageId: data.message.id.toHex(),
-    source: data.message.source.toHex(),
-    destination: data.message.destination.toHex(),
-    payload: data.message.payload.toHex(),
-    value: data.message.value.toString(),
-    details: data.message.details.isSome
+    messageId: message.id.toHex(),
+    source: message.source.toHex(),
+    destination: message.destination.toHex(),
+    payload: message.payload.toHex(),
+    value: message.value.toString(),
+    details: message.details.isSome
       ? {
-          replyTo: data.message.details.unwrap().to.toHex(),
-          code: data.message.details.unwrap().code.toString(),
+          replyTo: message.details.unwrap().to.toHex(),
+          code: message.details.unwrap().code.toString(),
         }
       : null,
   };

--- a/src/commands/subscribe/shared.ts
+++ b/src/commands/subscribe/shared.ts
@@ -1,0 +1,257 @@
+import { GearApi } from '@gear-js/api';
+import { outputNdjson, verbose, CliError } from '../../utils';
+import { insertEvent, type EventInsert } from '../../services/event-store';
+import { disconnectApi } from '../../services/api';
+
+// Valid IGearEvent keys
+const VALID_GEAR_EVENTS = [
+  'MessageQueued',
+  'UserMessageSent',
+  'UserMessageRead',
+  'MessagesDispatched',
+  'MessageWaited',
+  'MessageWaken',
+  'CodeChanged',
+  'ProgramChanged',
+  'ProgramResumeSessionStarted',
+] as const;
+
+export type GearEventName = (typeof VALID_GEAR_EVENTS)[number];
+
+/**
+ * Validate an event name against known IGearEvent keys.
+ */
+export function validateEventName(name: string): GearEventName {
+  if (!VALID_GEAR_EVENTS.includes(name as GearEventName)) {
+    throw new CliError(
+      `Unknown event type "${name}". Valid types: ${VALID_GEAR_EVENTS.join(', ')}`,
+      'INVALID_EVENT_TYPE',
+    );
+  }
+  return name as GearEventName;
+}
+
+/**
+ * Validate --from-block as a positive integer.
+ */
+export function validateFromBlock(value: string): number {
+  const num = parseInt(value, 10);
+  if (isNaN(num) || num < 0) {
+    throw new CliError(
+      `Invalid --from-block value "${value}". Must be a non-negative integer.`,
+      'INVALID_FROM_BLOCK',
+    );
+  }
+  return num;
+}
+
+/**
+ * Emit a system lifecycle event via NDJSON.
+ */
+export function emitSystemEvent(event: string, extra?: Record<string, unknown>): void {
+  outputNdjson({ type: 'system', event, timestamp: Date.now(), ...extra });
+}
+
+/**
+ * Output an event via NDJSON and persist to SQLite if enabled.
+ */
+export function emitAndPersist(data: Record<string, unknown>, persist: boolean, eventInsert?: EventInsert): void {
+  outputNdjson(data);
+  if (persist && eventInsert) {
+    insertEvent(eventInsert);
+  }
+}
+
+/**
+ * Wrap a callback in try/catch to prevent subscription death on errors.
+ */
+export function safeCallback<T>(fn: (event: T) => void): (event: T) => void {
+  return (event: T) => {
+    try {
+      fn(event);
+    } catch (err) {
+      verbose(`Warning: Event callback error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+}
+
+/**
+ * Install a handler that exits cleanly on EPIPE (e.g., piping to `head`).
+ */
+export function installEpipeHandler(): void {
+  process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EPIPE') {
+      process.exit(0);
+    }
+  });
+}
+
+/**
+ * Create an event counter for --count support.
+ */
+export function createEventCounter(maxCount?: number): { increment: () => boolean } {
+  let count = 0;
+  return {
+    /** Increment counter. Returns true if limit reached. */
+    increment(): boolean {
+      if (maxCount === undefined) return false;
+      count++;
+      return count >= maxCount;
+    },
+  };
+}
+
+export interface KeepAliveOptions {
+  count?: number;
+  timeout?: number; // seconds
+}
+
+/**
+ * Keep the process alive until SIGINT/SIGTERM, count reached, or timeout.
+ * Calls all unsubscribe functions on exit.
+ */
+export function keepAlive(
+  unsubscribers: Array<() => void>,
+  options?: KeepAliveOptions,
+): { promise: Promise<void>; triggerExit: () => void } {
+  let resolve: () => void;
+  let settled = false;
+
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+
+  const cleanup = () => {
+    if (settled) return;
+    settled = true;
+    for (const unsub of unsubscribers) {
+      try {
+        unsub();
+      } catch {
+        // Ignore unsubscribe errors
+      }
+    }
+    disconnectApi();
+    resolve!();
+  };
+
+  // Override default signal handlers from app.ts
+  process.removeAllListeners('SIGINT');
+  process.removeAllListeners('SIGTERM');
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  // Timeout support
+  if (options?.timeout) {
+    setTimeout(cleanup, options.timeout * 1000);
+  }
+
+  return { promise, triggerExit: cleanup };
+}
+
+const RECONNECT_DEBOUNCE_MS = 5000;
+const RECONNECT_MAX_RETRIES = 3;
+
+/**
+ * Wrap a subscription with auto-reconnect on WebSocket disconnect.
+ * No-op for light client mode (smoldot doesn't reconnect).
+ */
+export async function withReconnect(
+  api: GearApi,
+  subscribeFn: () => Promise<() => void>,
+): Promise<() => void> {
+  const isLightClient = process.env.VARA_LIGHT === '1';
+
+  let currentUnsub = await subscribeFn();
+
+  if (isLightClient) {
+    return currentUnsub;
+  }
+
+  let lastReconnect = 0;
+
+  api.on('connected', () => {
+    const now = Date.now();
+    if (now - lastReconnect < RECONNECT_DEBOUNCE_MS) {
+      verbose('Reconnect debounced (too rapid)');
+      return;
+    }
+    lastReconnect = now;
+
+    emitSystemEvent('reconnected');
+    verbose('WebSocket reconnected, re-subscribing...');
+
+    // Re-subscribe with retries
+    let retries = 0;
+    const resubscribe = async () => {
+      try {
+        // Unsub old subscription
+        try {
+          currentUnsub();
+        } catch {
+          // Ignore
+        }
+        currentUnsub = await subscribeFn();
+        verbose('Re-subscribed successfully');
+      } catch (err) {
+        retries++;
+        if (retries < RECONNECT_MAX_RETRIES) {
+          verbose(`Re-subscribe attempt ${retries} failed, retrying in ${retries * 2}s...`);
+          setTimeout(resubscribe, retries * 2000);
+        } else {
+          emitSystemEvent('resubscribe_failed', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          verbose('Re-subscribe failed after max retries');
+        }
+      }
+    };
+
+    resubscribe();
+  });
+
+  api.on('disconnected', () => {
+    emitSystemEvent('disconnected');
+    verbose('WebSocket disconnected');
+  });
+
+  return currentUnsub;
+}
+
+/**
+ * Extract fields from a UserMessageSent event.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function formatUserMessageSent(event: any): Record<string, unknown> {
+  const data = event.data;
+  return {
+    messageId: data.message.id.toHex(),
+    source: data.message.source.toHex(),
+    destination: data.message.destination.toHex(),
+    payload: data.message.payload.toHex(),
+    value: data.message.value.toString(),
+    details: data.message.details.isSome
+      ? {
+          replyTo: data.message.details.unwrap().to.toHex(),
+          code: data.message.details.unwrap().code.toString(),
+        }
+      : null,
+  };
+}
+
+/**
+ * Parse a duration string like "1h", "30m", "7d" into milliseconds.
+ */
+export function parseDuration(duration: string): number {
+  const match = duration.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) {
+    throw new CliError(
+      `Invalid duration "${duration}". Use format like: 30s, 5m, 1h, 7d`,
+      'INVALID_DURATION',
+    );
+  }
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const multipliers: Record<string, number> = { s: 1000, m: 60000, h: 3600000, d: 86400000 };
+  return value * multipliers[unit];
+}

--- a/src/commands/subscribe/transfers.ts
+++ b/src/commands/subscribe/transfers.ts
@@ -1,0 +1,82 @@
+import { Command } from 'commander';
+import { getApi } from '../../services/api';
+import { type AccountOptions } from '../../services/account';
+import { initEventStore } from '../../services/event-store';
+import { verbose, addressToHex, minimalToVara } from '../../utils';
+import {
+  emitSystemEvent,
+  emitAndPersist,
+  safeCallback,
+  installEpipeHandler,
+  keepAlive,
+  withReconnect,
+  createEventCounter,
+} from './shared';
+
+export function registerTransfersCommand(parent: Command): void {
+  parent
+    .command('transfers')
+    .description('Subscribe to transfer events')
+    .option('--from <address>', 'filter by sender address')
+    .option('--to <address>', 'filter by recipient address')
+    .action(async (options: { from?: string; to?: string }) => {
+      const opts = parent.parent!.optsWithGlobals() as AccountOptions & { ws?: string; count?: string; timeout?: string; persist?: boolean };
+      const api = await getApi(opts.ws);
+      const persist = opts.persist !== false;
+      if (persist) initEventStore();
+      installEpipeHandler();
+
+      const counter = createEventCounter(opts.count ? parseInt(opts.count, 10) : undefined);
+
+      const fromHex = options.from ? addressToHex(options.from) : undefined;
+      const toHex = options.to ? addressToHex(options.to) : undefined;
+
+      verbose(`Subscribing to transfers${fromHex ? ` from ${fromHex}` : ''}${toHex ? ` to ${toHex}` : ''}`);
+
+      const subscribe = async () => {
+        const unsub = await api.gearEvents.subscribeToTransferEvents(
+          safeCallback(({ data: { from, to, amount } }) => {
+            const fromAddr = from.toHex();
+            const toAddr = to.toHex();
+
+            // Client-side filtering
+            if (fromHex && fromAddr !== fromHex) return;
+            if (toHex && toAddr !== toHex) return;
+
+            const data = {
+              type: 'transfer' as const,
+              from: fromAddr,
+              to: toAddr,
+              amount: minimalToVara(amount.toBigInt()),
+              amountRaw: amount.toString(),
+              timestamp: Date.now(),
+            };
+
+            emitAndPersist(data, persist, {
+              type: 'transfer',
+              data,
+              source: fromAddr,
+              destination: toAddr,
+            });
+
+            if (counter.increment()) {
+              ka.triggerExit();
+            }
+          }),
+        );
+        return unsub;
+      };
+
+      const unsub = await withReconnect(api, subscribe);
+      emitSystemEvent('subscribed', {
+        subscription: 'transfers',
+        ...(fromHex && { from: fromHex }),
+        ...(toHex && { to: toHex }),
+      });
+
+      const ka = keepAlive([unsub], {
+        timeout: opts.timeout ? parseInt(opts.timeout, 10) : undefined,
+      });
+      await ka.promise;
+    });
+}

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { outputNdjson, verbose, addressToHex } from '../utils';
+import { keepAlive, installEpipeHandler, formatUserMessageSent } from './subscribe/shared';
 
 export function registerWatchCommand(program: Command): void {
   program
@@ -11,13 +12,16 @@ export function registerWatchCommand(program: Command): void {
     .action(async (programId: string, options: { event?: string }) => {
       const opts = program.optsWithGlobals() as { ws?: string };
       const api = await getApi(opts.ws);
+      installEpipeHandler();
 
       const programIdHex = addressToHex(programId);
       verbose(`Watching events for program ${programIdHex}`);
 
+      let unsub: () => void;
+
       if (options.event) {
         // Subscribe to a specific event type
-        await api.gearEvents.subscribeToGearEvent(
+        unsub = await api.gearEvents.subscribeToGearEvent(
           options.event as 'UserMessageSent',
           (event) => {
             const data = event.data;
@@ -30,23 +34,12 @@ export function registerWatchCommand(program: Command): void {
         );
       } else {
         // Default: subscribe to UserMessageSent filtered by source program
-        await api.gearEvents.subscribeToUserMessageSentByActor(
+        unsub = await api.gearEvents.subscribeToUserMessageSentByActor(
           { from: programIdHex },
           (event) => {
-            const data = event.data;
             outputNdjson({
               event: 'UserMessageSent',
-              messageId: data.message.id.toHex(),
-              source: data.message.source.toHex(),
-              destination: data.message.destination.toHex(),
-              payload: data.message.payload.toHex(),
-              value: data.message.value.toString(),
-              details: data.message.details.isSome
-                ? {
-                    replyTo: data.message.details.unwrap().to.toHex(),
-                    code: data.message.details.unwrap().code.toString(),
-                  }
-                : null,
+              ...formatUserMessageSent(event),
               timestamp: Date.now(),
             });
           },
@@ -55,10 +48,7 @@ export function registerWatchCommand(program: Command): void {
 
       verbose('Streaming events... (Ctrl+C to stop)');
 
-      // Keep process alive until interrupted
-      await new Promise<void>((resolve) => {
-        process.on('SIGINT', () => resolve());
-        process.on('SIGTERM', () => resolve());
-      });
+      const ka = keepAlive([unsub]);
+      await ka.promise;
     });
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -62,13 +62,5 @@ export function disconnectApi(): void {
   }
 }
 
-// Graceful shutdown
+// Clean up on exit (signal handlers are in app.ts)
 process.on('exit', disconnectApi);
-process.on('SIGINT', () => {
-  disconnectApi();
-  process.exit(0);
-});
-process.on('SIGTERM', () => {
-  disconnectApi();
-  process.exit(0);
-});

--- a/src/services/event-store.ts
+++ b/src/services/event-store.ts
@@ -5,6 +5,9 @@ import { getConfigDir } from './config';
 import { verbose } from '../utils';
 
 let db: Database.Database | null = null;
+let insertStmt: Database.Statement | null = null;
+let readStmt: Database.Statement | null = null;
+let pruneStmt: Database.Statement | null = null;
 
 const DEFAULT_PRUNE_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -73,6 +76,14 @@ export function initEventStore(): void {
       CREATE INDEX IF NOT EXISTS idx_events_program_id ON events(program_id);
     `);
 
+    // Prepare cached statements
+    insertStmt = db.prepare(`
+      INSERT INTO events (type, event_id, data, block_number, block_hash, source, destination, program_id, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    readStmt = db.prepare('SELECT * FROM events WHERE event_id = ? ORDER BY created_at DESC LIMIT 1');
+    pruneStmt = db.prepare('DELETE FROM events WHERE created_at < ?');
+
     // Auto-prune old events on startup
     pruneEvents(DEFAULT_PRUNE_AGE_MS);
 
@@ -84,14 +95,10 @@ export function initEventStore(): void {
 }
 
 export function insertEvent(event: EventInsert): void {
-  if (!db) return;
+  if (!insertStmt) return;
 
   try {
-    const stmt = db.prepare(`
-      INSERT INTO events (type, event_id, data, block_number, block_hash, source, destination, program_id, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    stmt.run(
+    insertStmt.run(
       event.type,
       event.event_id ?? null,
       JSON.stringify(event.data),
@@ -157,15 +164,15 @@ export function queryEvents(filters?: EventQueryFilters): EventRow[] {
 }
 
 export function readEvent(eventId: string): EventRow | undefined {
-  if (!db) return undefined;
-  return db.prepare('SELECT * FROM events WHERE event_id = ? ORDER BY created_at DESC LIMIT 1').get(eventId) as EventRow | undefined;
+  if (!readStmt) return undefined;
+  return readStmt.get(eventId) as EventRow | undefined;
 }
 
 export function pruneEvents(olderThanMs: number): number {
-  if (!db) return 0;
+  if (!pruneStmt) return 0;
 
   const cutoff = Date.now() - olderThanMs;
-  const result = db.prepare('DELETE FROM events WHERE created_at < ?').run(cutoff);
+  const result = pruneStmt.run(cutoff);
   if (result.changes > 0) {
     verbose(`Pruned ${result.changes} events older than ${Math.round(olderThanMs / (1000 * 60 * 60))}h`);
   }
@@ -180,5 +187,8 @@ export function closeEventStore(): void {
       // Ignore close errors
     }
     db = null;
+    insertStmt = null;
+    readStmt = null;
+    pruneStmt = null;
   }
 }

--- a/src/services/event-store.ts
+++ b/src/services/event-store.ts
@@ -1,0 +1,184 @@
+import Database from 'better-sqlite3';
+import * as path from 'path';
+import * as fs from 'fs';
+import { getConfigDir } from './config';
+import { verbose } from '../utils';
+
+let db: Database.Database | null = null;
+
+const DEFAULT_PRUNE_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export interface EventRow {
+  id: number;
+  type: string;
+  event_id: string | null;
+  data: string;
+  block_number: number | null;
+  block_hash: string | null;
+  source: string | null;
+  destination: string | null;
+  program_id: string | null;
+  created_at: number;
+}
+
+export interface EventInsert {
+  type: string;
+  event_id?: string;
+  data: Record<string, unknown>;
+  block_number?: number;
+  block_hash?: string;
+  source?: string;
+  destination?: string;
+  program_id?: string;
+}
+
+export interface EventQueryFilters {
+  type?: string;
+  since?: number; // Unix ms timestamp
+  program?: string;
+  destination?: string;
+  limit?: number;
+}
+
+export function initEventStore(): void {
+  if (db) return;
+
+  const configDir = getConfigDir();
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  }
+
+  const dbPath = path.join(configDir, 'events.db');
+  try {
+    db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        event_id TEXT,
+        data TEXT NOT NULL,
+        block_number INTEGER,
+        block_hash TEXT,
+        source TEXT,
+        destination TEXT,
+        program_id TEXT,
+        created_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
+      CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at);
+      CREATE INDEX IF NOT EXISTS idx_events_event_id ON events(event_id);
+      CREATE INDEX IF NOT EXISTS idx_events_destination ON events(destination);
+      CREATE INDEX IF NOT EXISTS idx_events_program_id ON events(program_id);
+    `);
+
+    // Auto-prune old events on startup
+    pruneEvents(DEFAULT_PRUNE_AGE_MS);
+
+    verbose(`Event store initialized at ${dbPath}`);
+  } catch (err) {
+    verbose(`Warning: Failed to initialize event store: ${err instanceof Error ? err.message : String(err)}`);
+    db = null;
+  }
+}
+
+export function insertEvent(event: EventInsert): void {
+  if (!db) return;
+
+  try {
+    const stmt = db.prepare(`
+      INSERT INTO events (type, event_id, data, block_number, block_hash, source, destination, program_id, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      event.type,
+      event.event_id ?? null,
+      JSON.stringify(event.data),
+      event.block_number ?? null,
+      event.block_hash ?? null,
+      event.source ?? null,
+      event.destination ?? null,
+      event.program_id ?? null,
+      Date.now(),
+    );
+  } catch (err) {
+    verbose(`Warning: Failed to persist event: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function queryMailbox(filters?: { since?: number; limit?: number }): EventRow[] {
+  if (!db) return [];
+
+  const conditions = ['type = ?'];
+  const params: unknown[] = ['mailbox'];
+
+  if (filters?.since) {
+    conditions.push('created_at >= ?');
+    params.push(filters.since);
+  }
+
+  const limit = filters?.limit ?? 50;
+  const sql = `SELECT * FROM events WHERE ${conditions.join(' AND ')} ORDER BY created_at DESC LIMIT ?`;
+  params.push(limit);
+
+  return db.prepare(sql).all(...params) as EventRow[];
+}
+
+export function queryEvents(filters?: EventQueryFilters): EventRow[] {
+  if (!db) return [];
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (filters?.type) {
+    conditions.push('type = ?');
+    params.push(filters.type);
+  }
+  if (filters?.since) {
+    conditions.push('created_at >= ?');
+    params.push(filters.since);
+  }
+  if (filters?.program) {
+    conditions.push('program_id = ?');
+    params.push(filters.program);
+  }
+  if (filters?.destination) {
+    conditions.push('destination = ?');
+    params.push(filters.destination);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = filters?.limit ?? 50;
+  const sql = `SELECT * FROM events ${whereClause} ORDER BY created_at DESC LIMIT ?`;
+  params.push(limit);
+
+  return db.prepare(sql).all(...params) as EventRow[];
+}
+
+export function readEvent(eventId: string): EventRow | undefined {
+  if (!db) return undefined;
+  return db.prepare('SELECT * FROM events WHERE event_id = ? ORDER BY created_at DESC LIMIT 1').get(eventId) as EventRow | undefined;
+}
+
+export function pruneEvents(olderThanMs: number): number {
+  if (!db) return 0;
+
+  const cutoff = Date.now() - olderThanMs;
+  const result = db.prepare('DELETE FROM events WHERE created_at < ?').run(cutoff);
+  if (result.changes > 0) {
+    verbose(`Pruned ${result.changes} events older than ${Math.round(olderThanMs / (1000 * 60 * 60))}h`);
+  }
+  return result.changes;
+}
+
+export function closeEventStore(): void {
+  if (db) {
+    try {
+      db.close();
+    } catch {
+      // Ignore close errors
+    }
+    db = null;
+  }
+}


### PR DESCRIPTION
## Overview
Adds a comprehensive `subscribe` command system with SQLite-based event persistence and multiple subscription types.

## Changes

### Core Features
- **Subscribe Command**: New `subscribe` subcommand with multiple event streams:
  - `blocks` - Subscribe to new block headers (latest or finalized)
  - `messages` - Subscribe to program messages and Gear events
  - `mailbox` - Subscribe to received/read mailbox messages
  - `balance` - Subscribe to account balance changes
  - `transfers` - Subscribe to token transfer events
  - `program` - Subscribe to program state changes

- **Event Store**: SQLite database for persistent event capture
  - `insertEvent()` - Store events with metadata
  - `queryEvents()` - Filter and retrieve stored events
  - `queryMailbox()` - Query mailbox messages
  - `readEvent()` - Fetch specific events by ID
  - `pruneEvents()` - Cleanup old records

- **Query Commands**: New CLI commands to interact with stored events
  - `events list` - Query captured events with filtering
  - `events prune` - Delete old events
  - `inbox list` - View mailbox messages
  - `inbox read` - Read specific messages

### Technical Details
- **Dependencies**: Added `better-sqlite3@^11.0.0` for synchronous SQLite operations
- **Output Format**: NDJSON streaming for real-time event consumption
- **Options**: 
  - `--count` - Exit after N events
  - `--timeout` - Exit after N seconds
  - `--no-persist` - Stream only, skip database persistence
- **Resilience**: Automatic reconnection handling and graceful shutdown
- **Testing**: Comprehensive unit tests for validation and helper functions

## Files Added
- `src/commands/subscribe/` - Subscribe command implementations
- `src/commands/events.ts` - Event store query interface
- `src/commands/inbox.ts` - Mailbox message query interface
- `src/services/event-store.ts` - SQLite event persistence layer

## Documentation
- **README.md**: Added `subscribe` (6 subcommands), `inbox`, `events` command sections; added `events.db` to File Structure; added cross-reference from `watch` to `subscribe`
- **AGENTS.md**: Added subscribe workflow section with examples for mailbox persistence, count/timeout, and querying events between runs
- **SKILL.md**: Added `inbox`/`events` to Read table (5 rows), `subscribe` subcommands to Monitor table (6 rows), and subscribe workflow example
