### PR TITLE
fix: message send to user wallet fails with TX_FAILED

### DIFF
--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -47,21 +47,20 @@ export function registerMessageCommand(program: Command): void {
       } else {
         verbose('Calculating gas...');
         const sourceHex = addressToHex(account.address);
-        const gasInfo = await api.program.calculateGas.handle(
-          sourceHex,
-          destinationHex,
-          payload,
-          value,
-          true,
-          meta,
-        );
-        gasLimit = gasInfo.min_limit.toBigInt();
-        verbose(`Gas limit: ${gasLimit}`);
-
-        if (gasLimit === 0n) {
-          const blockGasLimit = api.blockGasLimit.toBigInt();
-          verbose(`Gas calc returned 0, using block gas limit: ${blockGasLimit}`);
-          gasLimit = blockGasLimit;
+        try {
+          const gasInfo = await api.program.calculateGas.handle(
+            sourceHex,
+            destinationHex,
+            payload,
+            value,
+            true,
+            meta,
+          );
+          gasLimit = gasInfo.min_limit.toBigInt();
+          verbose(`Gas limit: ${gasLimit}`);
+        } catch {
+          verbose('Gas calculation failed (destination may be a user account), using gas limit 0');
+          gasLimit = 0n;
         }
       }
 

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -58,8 +58,8 @@ export function registerMessageCommand(program: Command): void {
           );
           gasLimit = gasInfo.min_limit.toBigInt();
           verbose(`Gas limit: ${gasLimit}`);
-        } catch {
-          verbose('Gas calculation failed (destination may be a user account), using gas limit 0');
+        } catch (error) {
+          verbose(`Gas calculation failed (destination may be a user account), using gas limit 0. Error: ${error}`);
           gasLimit = 0n;
         }
       }


### PR DESCRIPTION
## Summary
- `message send` with `--value` to a user wallet (not a program) failed with TX_FAILED
- Root cause: `calculateGas.handle()` throws for non-program destinations, and the fallback used `blockGasLimit` which reserved excessive gas, exceeding the sender's balance
- Fix: wrap gas calculation in try/catch and default to `gasLimit=0` (correct for user accounts, matches polkadot-js behavior)

## Test plan
- [x] Verified on testnet: `message send kGgQqLXhVVMv85XDy1v5AE6HVBG1tkAwURrdmq1ewbmGMCaGH --value 1 --ws wss://testnet.vara.network` succeeds with `ExtrinsicSuccess`
- [ ] Verify sending message to a program still auto-calculates gas correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)