### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.0] - 2026-03-18
+
+### Added
+- Subscribe command with SQLite event persistence for monitoring on-chain events
+- Block numbers and readable values to CLI outputs
+
+### Fixed
+- Message send to user wallet failing with TX_FAILED
+- Read CLI version from package.json instead of hardcoded string
+
+## [0.2.0] - 2026-03-17
+
+### Added
+- Embedded light client (smoldot) for trustless chain access
+- Accept both hex and SS58 addresses as CLI arguments
+
+### Fixed
+- Use normalized hex address in voucher revoke output
+- Message send accepts any destination, not just programs
+
+## [0.1.2] - 2026-03-17
+
+### Fixed
+- Resolve @polkadot/util duplicate version warnings
+
+## [0.1.1] - 2026-03-17
+
+### Fixed
+- Don't use passphrase on unencrypted wallet
+
+## [0.1.0] - 2026-03-17
+
+### Added
+- Initial release of vara-wallet CLI
+- Wallet management (create, import, list, info)
+- Token transfers and balance queries
+- Program deployment and message sending
+- Voucher management
+- Mailbox operations
+- Sails IDL-based service interaction

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 0.3.0
- Add CHANGELOG.md with full version history (0.1.0 through 0.3.0)

## Changes in v0.3.0
- **feat:** subscribe command with SQLite event persistence
- **feat:** block numbers and readable values to CLI outputs
- **fix:** message send to user wallet failing with TX_FAILED
- **fix:** read CLI version from package.json instead of hardcoded string

## Test plan
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)