### PR TITLE
feat: fix messageId extraction and add ASCII payload support

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,14 @@
+# TODOs
+
+## Full payload codec system
+**Priority:** P3 | **Effort:** L (human ~2 weeks / CC ~2 hours)
+
+Auto-detect payload type (SCALE-encoded, UTF-8 text, raw binary) and pretty-print
+with optional IDL context. Every payload surface in the CLI would intelligently render
+content based on detected type, with `--format` flags for output control.
+
+**Context:** Currently the CLI supports hex payloads and (as of v0.4.0) ASCII text via
+`--payload-ascii` and `tryHexToText`. The next step is SCALE decoding with IDL context,
+which would let agents read structured program responses without external tooling.
+
+**Depends on:** ASCII payload support (completed).

--- a/src/commands/__tests__/decode-text.test.ts
+++ b/src/commands/__tests__/decode-text.test.ts
@@ -1,0 +1,32 @@
+import { tryHexToText } from '../../utils';
+
+// Tests for the `decode text` codepath in encode.ts
+// The actual command wiring is tested via integration; here we test the core logic.
+
+describe('decode text (via tryHexToText)', () => {
+  it('decodes valid ASCII hex', () => {
+    expect(tryHexToText('0x48656c6c6f')).toBe('Hello');
+  });
+
+  it('decodes hex with spaces and punctuation', () => {
+    expect(tryHexToText('0x48656c6c6f2c20576f726c6421')).toBe('Hello, World!');
+  });
+
+  it('returns undefined for binary payload', () => {
+    // SCALE-encoded data with non-printable bytes
+    expect(tryHexToText('0x00010203')).toBeUndefined();
+  });
+
+  it('returns undefined for empty hex', () => {
+    expect(tryHexToText('0x')).toBeUndefined();
+  });
+
+  it('returns undefined for odd-length hex', () => {
+    expect(tryHexToText('0x486')).toBeUndefined();
+  });
+
+  it('decodes multi-word text with newlines', () => {
+    // "Hello\nWorld"
+    expect(tryHexToText('0x48656c6c6f0a576f726c64')).toBe('Hello\nWorld');
+  });
+});

--- a/src/commands/__tests__/message-id-extraction.test.ts
+++ b/src/commands/__tests__/message-id-extraction.test.ts
@@ -1,0 +1,113 @@
+import { extractMessageId } from '../message';
+import type { TxEvent } from '../../services/tx-executor';
+
+describe('extractMessageId', () => {
+  describe('MessageQueued event', () => {
+    it('extracts from array shape: [messageId, source, destination, entry]', () => {
+      const events: TxEvent[] = [
+        { section: 'system', method: 'ExtrinsicSuccess', data: {} },
+        {
+          section: 'gear',
+          method: 'MessageQueued',
+          data: ['0xabc123', '0xsource', '0xdest', 'Init'],
+        },
+      ];
+      expect(extractMessageId(events)).toBe('0xabc123');
+    });
+
+    it('extracts from object shape: { id, source, destination, entry }', () => {
+      const events: TxEvent[] = [
+        {
+          section: 'gear',
+          method: 'MessageQueued',
+          data: { id: '0xabc123', source: '0xsource', destination: '0xdest', entry: 'Init' },
+        },
+      ];
+      expect(extractMessageId(events)).toBe('0xabc123');
+    });
+  });
+
+  describe('UserMessageSent event (fallback)', () => {
+    it('extracts from array shape: [{ id, ... }, expiration]', () => {
+      const events: TxEvent[] = [
+        { section: 'system', method: 'ExtrinsicSuccess', data: {} },
+        {
+          section: 'gear',
+          method: 'UserMessageSent',
+          data: [
+            {
+              id: '0xmsg456',
+              source: '0xsource',
+              destination: '0xdest',
+              payload: '0x00',
+              value: 0,
+              details: null,
+            },
+            null,
+          ],
+        },
+      ];
+      expect(extractMessageId(events)).toBe('0xmsg456');
+    });
+
+    it('extracts from object shape: { message: { id, ... }, expiration }', () => {
+      const events: TxEvent[] = [
+        {
+          section: 'gear',
+          method: 'UserMessageSent',
+          data: {
+            message: {
+              id: '0xmsg456',
+              source: '0xsource',
+              destination: '0xdest',
+              payload: '0x00',
+              value: 0,
+              details: null,
+            },
+            expiration: null,
+          },
+        },
+      ];
+      expect(extractMessageId(events)).toBe('0xmsg456');
+    });
+  });
+
+  it('prefers MessageQueued over UserMessageSent', () => {
+    const events: TxEvent[] = [
+      {
+        section: 'gear',
+        method: 'MessageQueued',
+        data: ['0xfromMQ', '0xsource', '0xdest', 'Handle'],
+      },
+      {
+        section: 'gear',
+        method: 'UserMessageSent',
+        data: [{ id: '0xfromUMS', source: '0x', destination: '0x', payload: '0x', value: 0, details: null }, null],
+      },
+    ];
+    expect(extractMessageId(events)).toBe('0xfromMQ');
+  });
+
+  it('returns null when neither event is present', () => {
+    const events: TxEvent[] = [
+      { section: 'system', method: 'ExtrinsicSuccess', data: {} },
+      { section: 'balances', method: 'Transfer', data: ['0xa', '0xb', 1000] },
+    ];
+    expect(extractMessageId(events)).toBeNull();
+  });
+
+  it('returns null for empty events array', () => {
+    expect(extractMessageId([])).toBeNull();
+  });
+
+  it('returns null when event data has unexpected shape', () => {
+    const events: TxEvent[] = [
+      {
+        section: 'gear',
+        method: 'MessageQueued',
+        data: 'unexpected_string',
+      },
+    ];
+    expect(extractMessageId(events)).toBeNull();
+  });
+});

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -3,7 +3,7 @@ import { ProgramMetadata } from '@gear-js/api';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
 import { loadSails } from '../services/sails';
-import { output, verbose, CliError } from '../utils';
+import { output, verbose, CliError, tryHexToText } from '../utils';
 
 export function registerEncodeCommand(program: Command): void {
   program
@@ -88,6 +88,23 @@ export function registerEncodeCommand(program: Command): void {
       program?: string;
       method?: string;
     }) => {
+      // Standalone text decoding — no metadata or IDL required
+      if (type === 'text') {
+        const text = tryHexToText(hex);
+        if (text === undefined) {
+          // Fall back to raw UTF-8 decode even if not strict ASCII printable
+          const stripped = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+          if (stripped.length === 0 || stripped.length % 2 !== 0) {
+            throw new CliError('Invalid hex string for text decoding', 'INVALID_HEX');
+          }
+          const raw = Buffer.from(stripped, 'hex').toString('utf-8');
+          output({ decoded: raw, note: 'Contains non-printable or non-ASCII characters' });
+          return;
+        }
+        output({ decoded: text });
+        return;
+      }
+
       if (options.idl && options.method) {
         const opts = program.optsWithGlobals() as { ws?: string };
         const api = await getApi(opts.ws);

--- a/src/commands/mailbox.ts
+++ b/src/commands/mailbox.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
 import { executeTx } from '../services/tx-executor';
-import { output, verbose, minimalToVara } from '../utils';
+import { output, verbose, minimalToVara, tryHexToText } from '../utils';
 
 export function registerMailboxCommand(program: Command): void {
   const mailbox = program.command('mailbox').description('Mailbox operations');
@@ -25,11 +25,14 @@ export function registerMailboxCommand(program: Command): void {
         const [message, interval] = item;
         const msgJson = message.toJSON() as Record<string, unknown>;
         const intervalJson = interval.toJSON() as Record<string, unknown>;
+        const payloadHex = String(msgJson.payload ?? '');
+        const payloadAscii = tryHexToText(payloadHex);
         return {
           id: msgJson.id,
           source: msgJson.source,
           destination: msgJson.destination,
-          payload: msgJson.payload,
+          payload: payloadHex,
+          ...(payloadAscii !== undefined && { payloadAscii }),
           value: String(msgJson.value ?? '0'),
           valueVara: minimalToVara(BigInt(String(msgJson.value ?? '0'))),
           start: intervalJson.start,

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -3,8 +3,51 @@ import { ProgramMetadata } from '@gear-js/api';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
 import { resolveAccount, AccountOptions } from '../services/account';
-import { executeTx } from '../services/tx-executor';
-import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex } from '../utils';
+import { executeTx, TxEvent } from '../services/tx-executor';
+import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex, resolvePayload, tryHexToText } from '../utils';
+
+/**
+ * Extract messageId from transaction events using multi-pattern fallback.
+ *
+ * Event data from toJSON() can be array or object depending on codec version:
+ *   MessageQueued:    array → data[0],          object → data.id
+ *   UserMessageSent:  array → data[0].id,       object → data.message?.id
+ */
+export function extractMessageId(events: TxEvent[]): string | null {
+  // Try MessageQueued first (program destinations)
+  const mqEvent = events.find(
+    (e) => e.section === 'gear' && e.method === 'MessageQueued',
+  );
+  if (mqEvent?.data != null) {
+    const d = mqEvent.data as Record<string, unknown>;
+    // Array shape: [messageId, source, destination, entry]
+    if (Array.isArray(d)) {
+      if (typeof d[0] === 'string') return d[0];
+    }
+    // Object shape: { id, source, destination, entry }
+    if (typeof d.id === 'string') return d.id;
+  }
+
+  // Fall back to UserMessageSent (user destinations)
+  const umsEvent = events.find(
+    (e) => e.section === 'gear' && e.method === 'UserMessageSent',
+  );
+  if (umsEvent?.data != null) {
+    const d = umsEvent.data as Record<string, unknown>;
+    // Array shape: [{ id, source, destination, payload, value, details }, expiration]
+    if (Array.isArray(d) && d[0] && typeof d[0] === 'object') {
+      const msg = d[0] as Record<string, unknown>;
+      if (typeof msg.id === 'string') return msg.id;
+    }
+    // Object shape: { message: { id, ... }, expiration }
+    if (d.message && typeof d.message === 'object') {
+      const msg = d.message as Record<string, unknown>;
+      if (typeof msg.id === 'string') return msg.id;
+    }
+  }
+
+  return null;
+}
 
 export function registerMessageCommand(program: Command): void {
   const message = program.command('message').description('Low-level message operations');
@@ -14,12 +57,14 @@ export function registerMessageCommand(program: Command): void {
     .description('Send a message to any on-chain actor (program, user, wallet)')
     .argument('<destination>', 'destination address or program ID (hex or SS58)')
     .option('--payload <payload>', 'message payload (hex 0x... or JSON string)', '0x')
+    .option('--payload-ascii <text>', 'message payload as plain text (converted to hex)')
     .option('--gas-limit <gas>', 'gas limit (auto-calculated if not set)')
     .option('--value <value>', 'value to send with message (in VARA)', '0')
     .option('--units <units>', 'amount units: vara (default) or raw')
     .option('--metadata <path>', 'path to .meta.txt file for encoding')
     .action(async (destination: string, options: {
       payload: string;
+      payloadAscii?: string;
       gasLimit?: string;
       value: string;
       units?: string;
@@ -38,7 +83,7 @@ export function registerMessageCommand(program: Command): void {
       }
 
       const destinationHex = addressToHex(destination);
-      const payload = options.payload;
+      const payload = resolvePayload(options.payload, options.payloadAscii);
 
       // Auto-calculate gas if not provided
       let gasLimit: bigint;
@@ -74,20 +119,13 @@ export function registerMessageCommand(program: Command): void {
       }, meta);
 
       const result = await executeTx(api, tx, account);
-
-      // Extract message ID from MessageQueued event
-      // Event data is an array: [messageId, source, destination, entry]
-      const mqEvent = result.events.find(
-        (e) => e.section === 'gear' && e.method === 'MessageQueued',
-      );
-      const mqData = mqEvent?.data;
-      const messageId = Array.isArray(mqData) ? mqData[0] : undefined;
+      const messageId = extractMessageId(result.events);
 
       output({
         txHash: result.txHash,
         blockHash: result.blockHash,
         blockNumber: result.blockNumber,
-        messageId: messageId || null,
+        messageId,
         events: result.events,
       });
     });
@@ -97,12 +135,14 @@ export function registerMessageCommand(program: Command): void {
     .description('Send a reply to a message in mailbox')
     .argument('<messageId>', 'message ID to reply to (0x...)')
     .option('--payload <payload>', 'reply payload (hex 0x... or JSON string)', '0x')
+    .option('--payload-ascii <text>', 'reply payload as plain text (converted to hex)')
     .option('--gas-limit <gas>', 'gas limit (auto-calculated if not set)')
     .option('--value <value>', 'value to send with reply (in VARA)', '0')
     .option('--units <units>', 'amount units: vara (default) or raw')
     .option('--metadata <path>', 'path to .meta.txt file for encoding')
     .action(async (messageId: string, options: {
       payload: string;
+      payloadAscii?: string;
       gasLimit?: string;
       value: string;
       units?: string;
@@ -120,7 +160,7 @@ export function registerMessageCommand(program: Command): void {
         meta = ProgramMetadata.from(metaHex);
       }
 
-      const payload = options.payload;
+      const payload = resolvePayload(options.payload, options.payloadAscii);
 
       let gasLimit: bigint;
       if (options.gasLimit) {
@@ -164,12 +204,14 @@ export function registerMessageCommand(program: Command): void {
     .description('Calculate reply from a program without sending a transaction')
     .argument('<programId>', 'destination program ID (hex or SS58)')
     .option('--payload <payload>', 'message payload (hex 0x... or JSON string)', '0x')
+    .option('--payload-ascii <text>', 'message payload as plain text (converted to hex)')
     .option('--value <value>', 'value to simulate (in VARA)', '0')
     .option('--units <units>', 'amount units: vara (default) or raw')
     .option('--origin <address>', 'origin address for the calculation (hex or SS58)')
     .option('--at <blockHash>', 'block hash to query state at')
     .action(async (programId: string, options: {
       payload: string;
+      payloadAscii?: string;
       value: string;
       units?: string;
       origin?: string;
@@ -197,18 +239,23 @@ export function registerMessageCommand(program: Command): void {
       }
 
       const programIdHex = addressToHex(programId);
+      const payload = resolvePayload(options.payload, options.payloadAscii);
       verbose(`Calculating reply from ${programIdHex}`);
 
       const replyInfo = await api.message.calculateReply({
         origin,
         destination: programIdHex,
-        payload: options.payload,
+        payload,
         value,
         at: options.at as `0x${string}` | undefined,
       });
 
+      const replyPayloadHex = replyInfo.payload.toHex();
+      const payloadAscii = tryHexToText(replyPayloadHex);
+
       output({
-        payload: replyInfo.payload.toHex(),
+        payload: replyPayloadHex,
+        ...(payloadAscii !== undefined && { payloadAscii }),
         value: minimalToVara(replyInfo.value.toBigInt()),
         valueRaw: replyInfo.value.toString(),
         code: replyInfo.code.toString(),

--- a/src/commands/subscribe/__tests__/shared.test.ts
+++ b/src/commands/subscribe/__tests__/shared.test.ts
@@ -184,6 +184,26 @@ describe('formatUserMessageSent', () => {
       value: '1000',
       details: null,
     });
+    // Binary payload should NOT have payloadAscii
+    expect(result.payloadAscii).toBeUndefined();
+  });
+
+  it('includes payloadAscii for printable ASCII payloads', () => {
+    const mockEvent = {
+      data: {
+        message: {
+          id: { toHex: () => '0xabc' },
+          source: { toHex: () => '0x111' },
+          destination: { toHex: () => '0x222' },
+          payload: { toHex: () => '0x48656c6c6f' }, // "Hello"
+          value: { toString: () => '1000' },
+          details: { isSome: false },
+        },
+      },
+    };
+
+    const result = formatUserMessageSent(mockEvent as unknown as UserMessageSent);
+    expect(result.payloadAscii).toBe('Hello');
   });
 
   it('extracts reply details when present', () => {

--- a/src/commands/subscribe/shared.ts
+++ b/src/commands/subscribe/shared.ts
@@ -1,5 +1,5 @@
 import { GearApi, type UserMessageSent } from '@gear-js/api';
-import { outputNdjson, verbose, CliError } from '../../utils';
+import { outputNdjson, verbose, CliError, tryHexToText } from '../../utils';
 import { insertEvent, type EventInsert } from '../../services/event-store';
 import { disconnectApi } from '../../services/api';
 
@@ -223,11 +223,14 @@ export async function withReconnect(
  */
 export function formatUserMessageSent(event: UserMessageSent): Record<string, unknown> {
   const { message } = event.data;
+  const payloadHex = message.payload.toHex();
+  const payloadAscii = tryHexToText(payloadHex);
   return {
     messageId: message.id.toHex(),
     source: message.source.toHex(),
     destination: message.destination.toHex(),
-    payload: message.payload.toHex(),
+    payload: payloadHex,
+    ...(payloadAscii !== undefined && { payloadAscii }),
     value: message.value.toString(),
     details: message.details.isSome
       ? {

--- a/src/commands/wait.ts
+++ b/src/commands/wait.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
-import { output, verbose, CliError, minimalToVara } from '../utils';
+import { output, verbose, CliError, minimalToVara, tryHexToText } from '../utils';
 
 const DEFAULT_TIMEOUT_S = 30;
 
@@ -41,11 +41,14 @@ export function registerWaitCommand(program: Command): void {
                   settled = true;
                   clearTimeout(timer);
                   unsubscribe?.();
+                  const payloadHex = data.message.payload.toHex();
+                  const payloadAscii = tryHexToText(payloadHex);
                   resolve({
                     messageId: data.message.id.toHex(),
                     source: data.message.source.toHex(),
                     destination: data.message.destination.toHex(),
-                    payload: data.message.payload.toHex(),
+                    payload: payloadHex,
+                    ...(payloadAscii !== undefined && { payloadAscii }),
                     value: minimalToVara(data.message.value.toBigInt()),
                     replyTo: messageId,
                     replyCode: replyDetails.code.toString(),

--- a/src/utils/__tests__/payload.test.ts
+++ b/src/utils/__tests__/payload.test.ts
@@ -1,0 +1,98 @@
+import { textToHex, tryHexToText, resolvePayload } from '../payload';
+import { CliError } from '../errors';
+
+describe('textToHex', () => {
+  it('converts ASCII text to hex', () => {
+    expect(textToHex('Hello')).toBe('0x48656c6c6f');
+  });
+
+  it('converts empty string to 0x', () => {
+    expect(textToHex('')).toBe('0x');
+  });
+
+  it('converts text with newlines', () => {
+    expect(textToHex('Hi\n')).toBe('0x48690a');
+  });
+
+  it('converts emoji (multi-byte UTF-8)', () => {
+    const hex = textToHex('🦑');
+    expect(hex).toBe('0xf09fa691');
+  });
+
+  it('converts text with spaces and punctuation', () => {
+    expect(textToHex('Hello, World!')).toBe('0x48656c6c6f2c20576f726c6421');
+  });
+});
+
+describe('tryHexToText', () => {
+  it('decodes valid ASCII hex to text', () => {
+    expect(tryHexToText('0x48656c6c6f')).toBe('Hello');
+  });
+
+  it('decodes hex with newlines', () => {
+    expect(tryHexToText('0x48690a')).toBe('Hi\n');
+  });
+
+  it('returns undefined for empty "0x"', () => {
+    expect(tryHexToText('0x')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(tryHexToText('')).toBeUndefined();
+  });
+
+  it('returns undefined for odd-length hex', () => {
+    expect(tryHexToText('0x486')).toBeUndefined();
+  });
+
+  it('returns undefined for binary/non-printable bytes', () => {
+    // NUL byte
+    expect(tryHexToText('0x0048')).toBeUndefined();
+    // Control char (0x01)
+    expect(tryHexToText('0x0148')).toBeUndefined();
+    // DEL (0x7F)
+    expect(tryHexToText('0x7f48')).toBeUndefined();
+  });
+
+  it('returns undefined for high bytes (non-ASCII UTF-8)', () => {
+    // emoji bytes (0xf0 > 0x7e)
+    expect(tryHexToText('0xf09fa691')).toBeUndefined();
+  });
+
+  it('handles uppercase 0X prefix', () => {
+    expect(tryHexToText('0X48656c6c6f')).toBe('Hello');
+  });
+
+  it('handles hex without prefix', () => {
+    expect(tryHexToText('48656c6c6f')).toBe('Hello');
+  });
+
+  it('returns undefined for null/undefined input', () => {
+    expect(tryHexToText(null as unknown as string)).toBeUndefined();
+    expect(tryHexToText(undefined as unknown as string)).toBeUndefined();
+  });
+});
+
+describe('resolvePayload', () => {
+  it('passes through hex payload when no ASCII provided', () => {
+    expect(resolvePayload('0xdeadbeef')).toBe('0xdeadbeef');
+  });
+
+  it('passes through default "0x" when no ASCII provided', () => {
+    expect(resolvePayload('0x')).toBe('0x');
+  });
+
+  it('converts ASCII text when provided', () => {
+    expect(resolvePayload('0x', 'Hello')).toBe('0x48656c6c6f');
+  });
+
+  it('throws when both payload and payload-ascii are provided', () => {
+    expect(() => resolvePayload('0xdeadbeef', 'Hello')).toThrow(CliError);
+    expect(() => resolvePayload('0xdeadbeef', 'Hello')).toThrow('Cannot use both --payload and --payload-ascii');
+  });
+
+  it('allows payload-ascii with default "0x" payload', () => {
+    // Default payload is "0x" — this is not a conflict
+    expect(resolvePayload('0x', 'test')).toBe('0x74657374');
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export { output, outputNdjson, verbose, setOutputOptions } from './output';
 export { CliError, outputError, formatError, installGlobalErrorHandler } from './errors';
 export { varaToMinimal, minimalToVara, resolveAmount } from './units';
 export { addressToHex } from './address';
+export { textToHex, tryHexToText, resolvePayload } from './payload';

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -15,24 +15,26 @@ export function textToHex(text: string): string {
  * Printable rule: every byte must be 0x20-0x7E (printable ASCII) or 0x0A (newline).
  */
 export function tryHexToText(hex: string): string | undefined {
-  if (!hex || hex === '0x' || hex === '0X') return undefined;
+  if (!hex || hex.toLowerCase() === '0x') return undefined;
 
   const stripped = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
   if (stripped.length === 0 || stripped.length % 2 !== 0) return undefined;
 
-  const bytes: number[] = [];
-  for (let i = 0; i < stripped.length; i += 2) {
-    const byte = parseInt(stripped.slice(i, i + 2), 16);
-    if (isNaN(byte)) return undefined;
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(stripped, 'hex');
+  } catch {
+    return undefined;
+  }
+
+  for (const byte of buffer) {
     // Strict ASCII printable (0x20-0x7E) or newline (0x0A)
-    if (byte === 0x0a || (byte >= 0x20 && byte <= 0x7e)) {
-      bytes.push(byte);
-    } else {
+    if (!(byte === 0x0a || (byte >= 0x20 && byte <= 0x7e))) {
       return undefined;
     }
   }
 
-  return Buffer.from(bytes).toString('ascii');
+  return buffer.toString('ascii');
 }
 
 /**

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -1,0 +1,53 @@
+import { CliError } from './errors';
+
+/**
+ * Convert UTF-8 text to a 0x-prefixed hex string.
+ */
+export function textToHex(text: string): string {
+  const bytes = Buffer.from(text, 'utf-8');
+  return '0x' + bytes.toString('hex');
+}
+
+/**
+ * Try to decode a hex string as printable ASCII text.
+ * Returns undefined if the hex is invalid or contains non-printable bytes.
+ *
+ * Printable rule: every byte must be 0x20-0x7E (printable ASCII) or 0x0A (newline).
+ */
+export function tryHexToText(hex: string): string | undefined {
+  if (!hex || hex === '0x' || hex === '0X') return undefined;
+
+  const stripped = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+  if (stripped.length === 0 || stripped.length % 2 !== 0) return undefined;
+
+  const bytes: number[] = [];
+  for (let i = 0; i < stripped.length; i += 2) {
+    const byte = parseInt(stripped.slice(i, i + 2), 16);
+    if (isNaN(byte)) return undefined;
+    // Strict ASCII printable (0x20-0x7E) or newline (0x0A)
+    if (byte === 0x0a || (byte >= 0x20 && byte <= 0x7e)) {
+      bytes.push(byte);
+    } else {
+      return undefined;
+    }
+  }
+
+  return Buffer.from(bytes).toString('ascii');
+}
+
+/**
+ * Resolve --payload vs --payload-ascii into a hex payload string.
+ * Validates mutual exclusion and converts ASCII text if needed.
+ */
+export function resolvePayload(payload: string, payloadAscii?: string): string {
+  if (payloadAscii !== undefined && payload !== '0x') {
+    throw new CliError(
+      'Cannot use both --payload and --payload-ascii. Use one or the other.',
+      'CONFLICTING_PAYLOAD',
+    );
+  }
+  if (payloadAscii !== undefined) {
+    return textToHex(payloadAscii);
+  }
+  return payload;
+}


### PR DESCRIPTION
## Summary
- Fix `messageId: null` when sending messages to user accounts by checking both `MessageQueued` and `UserMessageSent` events with multi-pattern fallback
- Add `--payload-ascii` option to `message send`, `reply`, and `calculate-reply` for sending human-readable text without manual hex encoding
- Add `payloadAscii` field to subscribe, mailbox, wait, and calculate-reply output when payload is printable ASCII
- Add `decode text` subcommand for standalone hex-to-text conversion

## Test plan
- [x] 101 unit tests passing (`npm test`)
- [x] Build compiles cleanly (`npm run build`)
- [ ] Manual: `vara-wallet message send <user> --payload-ascii "Hello" --value 1 --units vara` — verify messageId is populated
- [ ] Manual: `vara-wallet decode text 0x48656c6c6f` — verify output is `"Hello"`
- [ ] Manual: `vara-wallet subscribe messages <program>` — verify `payloadAscii` field appears for text payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)