### PR TITLE
fix: resolve SURI import for wallet import --seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-03-27
+
+### Fixed
+- `wallet import --seed '//Alice'` (and other SURI strings) now works correctly — Commander.js was consuming `--seed` at the global level before the subcommand could parse it, causing a `MISSING_IMPORT_SOURCE` error
+- Same fix applies to `--mnemonic` on the import subcommand
+
 ## [0.5.0] - 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -57,7 +57,7 @@ export function registerWalletCommand(program: Command): void {
     .action(async (options: { name: string; mnemonic?: string; seed?: string; json?: string; passphrase?: string; encrypt: boolean }, command: Command) => {
       // Merge with global opts so --seed/--mnemonic work regardless of which
       // Commander level parsed them (global program vs. subcommand).
-      const allOpts = command.optsWithGlobals();
+      const allOpts = command.optsWithGlobals() as typeof options;
       let keyring;
 
       if (allOpts.mnemonic) {

--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -54,18 +54,21 @@ export function registerWalletCommand(program: Command): void {
     .option('--json <path>', 'path to JSON keystore file')
     .option('--passphrase <passphrase>', 'passphrase to encrypt the imported wallet')
     .option('--no-encrypt', 'store unencrypted (not recommended)')
-    .action(async (options: { name: string; mnemonic?: string; seed?: string; json?: string; passphrase?: string; encrypt: boolean }) => {
+    .action(async (options: { name: string; mnemonic?: string; seed?: string; json?: string; passphrase?: string; encrypt: boolean }, command: Command) => {
+      // Merge with global opts so --seed/--mnemonic work regardless of which
+      // Commander level parsed them (global program vs. subcommand).
+      const allOpts = command.optsWithGlobals();
       let keyring;
 
-      if (options.mnemonic) {
-        keyring = await GearKeyring.fromMnemonic(options.mnemonic, options.name);
-      } else if (options.seed) {
-        keyring = await GearKeyring.fromSuri(options.seed, options.name);
-      } else if (options.json) {
+      if (allOpts.mnemonic) {
+        keyring = await GearKeyring.fromMnemonic(allOpts.mnemonic, allOpts.name);
+      } else if (allOpts.seed) {
+        keyring = await GearKeyring.fromSuri(allOpts.seed, allOpts.name);
+      } else if (allOpts.json) {
         const fs = await import('fs');
-        const raw = fs.readFileSync(options.json, 'utf-8');
+        const raw = fs.readFileSync(allOpts.json, 'utf-8');
         const jsonData = JSON.parse(raw);
-        const importPassphrase = options.passphrase || readPassphraseFile() || process.env.VARA_PASSPHRASE || undefined;
+        const importPassphrase = allOpts.passphrase || readPassphraseFile() || process.env.VARA_PASSPHRASE || undefined;
         try {
           keyring = GearKeyring.fromJson(jsonData, importPassphrase);
         } catch {
@@ -82,20 +85,20 @@ export function registerWalletCommand(program: Command): void {
       }
 
       let passphrase: string | undefined;
-      if (options.encrypt) {
-        passphrase = options.passphrase || readPassphraseFile() || process.env.VARA_PASSPHRASE || undefined;
+      if (allOpts.encrypt) {
+        passphrase = allOpts.passphrase || readPassphraseFile() || process.env.VARA_PASSPHRASE || undefined;
         if (!passphrase) {
           passphrase = ensurePassphraseFile();
         }
       }
 
       const json = keyring.toJson(passphrase);
-      const filePath = saveWallet(options.name, json);
+      const filePath = saveWallet(allOpts.name, json);
 
       output({
         address: keyring.address,
-        name: options.name,
-        encrypted: options.encrypt,
+        name: allOpts.name,
+        encrypted: allOpts.encrypt,
         path: filePath,
       });
     });


### PR DESCRIPTION
## Summary
- Fix `wallet import --seed '//Alice'` (and `--mnemonic`) failing with `MISSING_IMPORT_SOURCE` error
- Root cause: Commander.js consumed `--seed` at the global program level before the `wallet import` subcommand could parse it
- Fix: use `optsWithGlobals()` to merge global and local options in the import handler

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Jest tests pass (144 tests, 11 suites)
- [x] Commander.js option resolution verified via simulation (`optsWithGlobals()` returns seed correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)