### PR TITLE
fix: surface sails-js program errors instead of [object Object]

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -50,6 +50,14 @@ describe('formatError', () => {
     expect(formatError('oops')).toEqual({ error: 'oops', code: 'UNKNOWN_ERROR' });
   });
 
+  it('serializes plain object non-Error values as JSON', () => {
+    const obj = { method: 'InsufficientBalance', docs: 'Insufficient user balance.' };
+    const result = formatError(obj);
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.error).toContain('InsufficientBalance');
+    expect(result.error).toContain('Insufficient user balance.');
+  });
+
   it('returns INTERNAL_ERROR for unclassified errors', () => {
     const err = new Error('something strange happened');
     expect(formatError(err).code).toBe('INTERNAL_ERROR');

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -176,7 +176,17 @@ async function executeFunction(
   }
 
   const result = await txBuilder.signAndSend();
-  const response = await result.response();
+  let response;
+  try {
+    response = await result.response();
+  } catch (err) {
+    const msg = err instanceof Error
+      ? err.message
+      : typeof err === 'object' && err !== null
+        ? JSON.stringify(err)
+        : String(err);
+    throw new CliError(`Program execution failed: ${msg}`, 'PROGRAM_ERROR');
+  }
   const blockNumber = await resolveBlockNumber(api, result.blockHash);
 
   output({

--- a/src/commands/dex.ts
+++ b/src/commands/dex.ts
@@ -348,7 +348,16 @@ async function ensureApproval(
     resetTx.withAccount(account);
     await resetTx.calculateGas();
     const resetResult = await resetTx.signAndSend();
-    await resetResult.response();
+    try {
+      await resetResult.response();
+    } catch (err) {
+      const msg = err instanceof Error
+        ? err.message
+        : typeof err === 'object' && err !== null
+          ? JSON.stringify(err)
+          : String(err);
+      throw new CliError(`Program execution failed: ${msg}`, 'PROGRAM_ERROR');
+    }
     verbose('Allowance reset to 0');
   }
 
@@ -358,7 +367,16 @@ async function ensureApproval(
   approveTx.withAccount(account);
   await approveTx.calculateGas();
   const result = await approveTx.signAndSend();
-  await result.response();
+  try {
+    await result.response();
+  } catch (err) {
+    const msg = err instanceof Error
+      ? err.message
+      : typeof err === 'object' && err !== null
+        ? JSON.stringify(err)
+        : String(err);
+    throw new CliError(`Program execution failed: ${msg}`, 'PROGRAM_ERROR');
+  }
   verbose(`Approval confirmed in block ${result.blockHash}`);
 }
 
@@ -390,7 +408,17 @@ async function executeDexTx(
   }
 
   const result = await txBuilder.signAndSend();
-  const response = await result.response();
+  let response;
+  try {
+    response = await result.response();
+  } catch (err) {
+    const msg = err instanceof Error
+      ? err.message
+      : typeof err === 'object' && err !== null
+        ? JSON.stringify(err)
+        : String(err);
+    throw new CliError(`Program execution failed: ${msg}`, 'PROGRAM_ERROR');
+  }
   const blockNumber = await resolveBlockNumber(api, result.blockHash);
 
   output({

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -154,7 +154,17 @@ async function executeVftTx(
   }
 
   const result = await txBuilder.signAndSend();
-  const response = await result.response();
+  let response;
+  try {
+    response = await result.response();
+  } catch (err) {
+    const msg = err instanceof Error
+      ? err.message
+      : typeof err === 'object' && err !== null
+        ? JSON.stringify(err)
+        : String(err);
+    throw new CliError(`Program execution failed: ${msg}`, 'PROGRAM_ERROR');
+  }
   const blockNumber = await resolveBlockNumber(api, result.blockHash);
 
   output({

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -23,7 +23,10 @@ export function formatError(error: unknown): { error: string; code: string } {
     return { error: message, code: classifyError(error) };
   }
 
-  return { error: String(error), code: 'UNKNOWN_ERROR' };
+  const msg = typeof error === 'object' && error !== null
+    ? JSON.stringify(error)
+    : String(error);
+  return { error: msg, code: 'UNKNOWN_ERROR' };
 }
 
 function sanitizeErrorMessage(message: string): string {
@@ -78,7 +81,7 @@ export function installGlobalErrorHandler(): void {
 
   process.on('unhandledRejection', (reason) => {
     if (getShutdownStatus()) return;
-    outputError(reason instanceof Error ? reason : new Error(String(reason)));
+    outputError(reason);
     process.exit(1);
   });
 }


### PR DESCRIPTION
## Summary

- Wrap all `result.response()` calls in `call.ts`, `vft.ts`, and `dex.ts` to catch non-Error rejections from sails-js and throw `CliError` with semantic `PROGRAM_ERROR` code
- Fix `formatError()` fallback in `errors.ts` to `JSON.stringify` plain objects instead of `String()` (which produces `[object Object]`)
- Fix `unhandledRejection` handler to pass through to `outputError` directly

Closes #21

## Before / After

**Before:** `{"error":"[object Object]","code":"UNKNOWN_ERROR"}`

**After:** `{"error":"Program execution failed: {\"docs\":\"Insufficient user balance.\",\"method\":\"InsufficientBalance\"}","code":"PROGRAM_ERROR"}`

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (6 pre-existing faucet test failures unrelated)
- [ ] Manual: `vara-wallet call` against a program that panics — verify error message surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)