### PR TITLE
chore: release v0.11.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,14 @@ vara-wallet transfer <to> 1500000000 --units raw   # same amount in raw units
 
 The existential deposit (minimum balance) is typically 10 VARA on mainnet.
 
+### Draining an account
+
+```bash
+vara-wallet transfer <to> --all        # sends full balance, closes the sender's account
+```
+
+`--all` uses Substrate's native `transferAll` extrinsic with `keepAlive=false`, so there's no client-side fee/ED math to get wrong. The source account is reaped after the call. Regular transfers (without `--all`) use `transferKeepAlive` and leave at least the existential deposit behind. `--all` and an explicit amount are mutually exclusive.
+
 ## Error Handling
 
 Every error returns `{ error: "message", code: "ERROR_CODE" }` on stderr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2026-04-22
+
+### Added
+- `wallet keys <name>` command: export raw key material (`address`, `publicKey`, `secretKeyPkcs8`, `type`) for use with Polkadot tooling
+- `transfer --all` flag: drain the entire account via Substrate's native `transferAll` extrinsic (no client-side fee/ED math)
+
+### Changed
+- **CLI is now bundled with esbuild into a single `dist/app.js`.** Runtime dependencies shrink from ~120 transitive packages to 2 (`better-sqlite3`, `smoldot`). Fixes reports of `npm install -g vara-wallet` hanging for minutes on slow networks, where npm's retry policy turned stalled tarball fetches into multi-minute retry storms. Global install is now ~2 MB gzipped and a few seconds on any network.
+- **Node.js 20 or newer is now required** (`engines: { node: ">=20" }`). Matches the existing CI matrix.
+- Build script: `npm run build` now invokes `node scripts/build.mjs` instead of `tsc`.
+
 ## [0.10.0] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ vara-wallet call <programId> Service/Upload --args '["0xdeadbeef"]'
 
 ## Installation
 
+Requires Node.js 20 or newer.
+
 ```bash
 npm install -g vara-wallet
 ```
+
+The CLI ships as a single bundled file (~2 MB gzipped) with only two runtime dependencies (`better-sqlite3` and `smoldot`), so global install is a few seconds on any network.
 
 ### From source
 
@@ -137,6 +141,8 @@ vara-wallet wallet keys <name>
 vara-wallet wallet default [name]
 ```
 
+`wallet keys` outputs the raw key material: `{ address, publicKey, secretKeyPkcs8, type }`. The PKCS8 blob contains the full secret key and can be used with Polkadot tooling to reconstruct the keypair. This is a sensitive operation — the secret key is exposed in the output. For a redacted export suitable for sharing, use `wallet export`.
+
 ### `node`
 
 ```bash
@@ -148,7 +154,10 @@ vara-wallet node info
 ```bash
 vara-wallet balance [address]
 vara-wallet transfer <to> <amount> [--units vara|raw]
+vara-wallet transfer <to> --all
 ```
+
+`--all` drains the entire account via Substrate's native `transferAll` extrinsic (no client-side fee/ED math). Without `--all`, transfers use `transferKeepAlive`. `--all` and an explicit amount are mutually exclusive.
 
 ### `message`
 
@@ -168,8 +177,6 @@ vara-wallet program deploy <codeId> [--payload <hex>] [--idl <path>] [--init <na
 vara-wallet program info <programId>
 vara-wallet program list [--count <n>] [--all]
 ```
-
-`wallet keys` outputs the raw key material: `{ address, publicKey, secretKeyPkcs8, type }`. The PKCS8 blob contains the full secret key and can be used with Polkadot tooling to reconstruct the keypair. This is a sensitive operation — the secret key is exposed in the output.
 
 Use `--idl` to auto-encode the constructor payload from a Sails IDL file. The constructor is auto-selected if the IDL has only one; use `--init <name>` when multiple constructors exist. `--args` passes constructor arguments as a JSON array. `--payload` and `--idl` are mutually exclusive.
 
@@ -408,10 +415,13 @@ The `--hex` flag treats input as 0x-prefixed hex bytes (strict validation: even-
 ## Development
 
 ```bash
-npm run build        # Compile TypeScript
+npm run build        # Bundle CLI with esbuild → dist/app.js
+npm run dev          # Run from source via ts-node
 npm test             # Run tests
 npx tsc --noEmit     # Type check only
 ```
+
+The published artifact is a single bundled file (`dist/app.js`) built by `scripts/build.mjs`. `better-sqlite3` and `smoldot` are kept external because they ship native binaries / WASM that cannot be inlined.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -71,7 +71,8 @@ The passphrase is stored at `~/.vara-wallet/.passphrase` (0600). The agent never
 
 | Command | Purpose |
 |---------|---------|
-| `$VW transfer <to> <amount>` | Transfer VARA tokens |
+| `$VW transfer <to> <amount>` | Transfer VARA tokens (keep-alive, safe default) |
+| `$VW transfer <to> --all` | Drain the entire account (`transferAll`, closes the account) |
 | `$VW program upload <wasm> [--idl <path>] [--init <name>] [--args <json>] [--payload <hex>] [--value <v>]` | Upload + init program (use --idl for auto-encoding) |
 | `$VW program deploy <codeId> [--idl <path>] [--init <name>] [--args <json>] [--payload <hex>] [--value <v>]` | Deploy from existing code (use --idl for auto-encoding) |
 | `$VW code upload <wasm>` | Upload code blob only |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vara-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {


### PR DESCRIPTION
Release PR for **v0.11.0**. Rolls up the three PRs merged since v0.10.0.

## What's in this release

### Added
- `wallet keys <name>` (#24) — export raw key material (`address`, `publicKey`, `secretKeyPkcs8`, `type`) for use with Polkadot tooling
- `transfer --all` (#25) — drain the entire account via Substrate's native `transferAll` extrinsic

### Changed
- **CLI is now bundled with esbuild into a single `dist/app.js`** (#26). Runtime dependencies shrink from ~120 transitive packages to 2 (`better-sqlite3`, `smoldot`). Fixes `npm install -g vara-wallet` hangs on slow networks.
- **Node.js 20 or newer is now required** (`engines: { node: ">=20" }`). Matches the existing CI matrix.
- Build: `npm run build` now invokes `node scripts/build.mjs` instead of `tsc`.

## Changes in this PR

- `package.json` → `0.11.0`
- `package-lock.json` → regenerated
- `CHANGELOG.md` → new `[0.11.0]` section
- `README.md`:
  - Added "Requires Node.js 20 or newer" to Installation
  - Documented `transfer --all` under the transfer command
  - Moved the `wallet keys` explanation from the `program` section (where it was stranded) to the `wallet` section where it belongs
  - Updated Development section to describe the esbuild build

## Post-merge

1. Refresh the `NODE_AUTH_TOKEN` GitHub secret if the npm access token has expired.
2. Tag `v0.11.0` on `main` and push the tag — `.github/workflows/release.yml` will run `npm run build && npm test && npm publish --access public`.

```
git checkout main && git pull
git tag v0.11.0
git push origin v0.11.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)