### PR TITLE
ci(release): auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -22,3 +22,21 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Extract changelog for this tag
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { flag=1; next }
+            flag && /^## \[/ { exit }
+            flag { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "No changelog section found for v$VERSION — using tag message." >&2
+            git tag -l --format='%(contents:body)' "$GITHUB_REF_NAME" > release-notes.md
+          fi
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md
+          name: ${{ github.ref_name }}


### PR DESCRIPTION
## Why

\`release.yml\` previously only ran \`npm publish\`, so pushing a \`v*\` tag updated npm but left the GitHub Releases page empty. Both \`v0.10.0\` and \`v0.11.0\` shipped this way and needed manual \`gh release create\` backfill. From v0.12.0 onward, tagging should be the only manual step.

## What

- Add a \`softprops/action-gh-release@v2\` step that fires after a successful \`npm publish\`.
- Extract the matching \`## [X.Y.Z]\` section from \`CHANGELOG.md\` using \`awk\` (no external deps). Falls back to the annotated tag body if the section is missing.
- Bump workflow permissions from \`contents: read\` to \`contents: write\` so the action can create the release.

## Sequencing

The release step runs **after** \`npm publish\`, so if the publish fails (e.g. stale \`NPM_TOKEN\`), no GitHub Release is created — the tag and code are the only artifacts and the workflow can be re-run after fixing the token.

## Test plan

- [ ] Next release tag (\`v0.12.0\` or a test \`v0.11.1\` patch tag) should auto-create a Release with the CHANGELOG body populated
- [ ] If CHANGELOG is missing the section, Release body should fall back to the tag annotation

## Related

Fixes the Releases-page gap noted after #27. The v0.11.0 npm publish separately failed with a 404 (token auth issue) — unrelated to this change, needs \`NPM_TOKEN\` secret refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)