### PR TITLE
feat: add sails-js 1.0.0-beta.1 support with dual IDL v1/v2 loaders

### DIFF
--- a/docs/sails-js-upstream-proposals.md
+++ b/docs/sails-js-upstream-proposals.md
@@ -1,0 +1,351 @@
+# Proposals for sails-js upstream
+
+Notes collected while integrating `sails-js@1.0.0-beta.1` into vara-wallet as the
+first dual-IDL (v1 + v2) consumer. Each item is something the library should
+handle or expose so consumers don't have to reach into private fields or
+reimplement logic the library already has internally.
+
+Reference integration: [feat/sails-js-1.0.0-beta-dual-idl](https://github.com/gear-foundation/vara-wallet/pull/29).
+
+---
+
+## 1. Expose a public way to enumerate user-defined types (P1)
+
+**What we do now.** Both vara-wallet's hex-coercion walker and its `describe` helper
+need the raw `struct` / `enum` / `alias` definitions so they can walk fields and
+resolve user types. sails-js builds that data internally in `TypeResolver._userTypes`
+and in the parsed `IIdlDoc`, but neither is public. Our workaround is a
+`getRegistryTypes(program)` helper that reads `(program as any)._doc.program.types`
+and `(program as any)._doc.services[i].types`.
+
+**Why this matters.** Any consumer that wants to do its own payload validation,
+pretty-printing, dead-typed-arg detection, or custom arg coercion runs into this
+wall. The escape hatch — reaching into `_doc` — is fragile across beta releases
+and every consumer that does it will break the same way at the same time.
+
+**Proposal.** Add public accessors on `SailsProgram`:
+
+```ts
+// Program-level types (ambient), indexed by name.
+program.programTypes: ReadonlyMap<string, Type>
+
+// Service-local types. Two services can legitimately declare the same-named
+// type with different shapes — keying by service avoids cross-service
+// collision in a flat global map (see proposal #2).
+program.serviceTypes(serviceName: string): ReadonlyMap<string, Type>
+
+// Or equivalent: program.services[name].types as a Record<string, Type>.
+```
+
+Bonus: export the `Type` / `TypeDecl` / `ITypeStruct` / `ITypeEnum` / `ITypeAlias`
+type definitions from the top-level `sails-js` entry (they exist in
+`sails-js-types` but that package is private/workspace-only). Consumers today
+have to redeclare these unions locally (see our `V2TypeDecl` duplicate in
+`src/utils/hex-bytes.ts`).
+
+---
+
+## 2. Service-scoped type resolution as a first-class concept (P1)
+
+**What we do now.** We take a `serviceName` parameter in our `coerceArgsV2` and
+use it to narrow the lookup map: program-level types + that service's types
+only, never cross-service flattened. Without this, two services declaring the
+same-named struct silently overwrite each other in the type map and arg
+coercion runs against the wrong shape.
+
+**Why this matters.** IDL v2 makes service-local types idiomatic
+(the spec literally has a per-service `types { ... }` block), yet the library
+doesn't provide a resolver scoped to "I'm calling into service X — what does
+`Packet` mean in this context?". Every consumer that resolves types must
+either flatten (bug) or rebuild this scoping themselves.
+
+**Proposal.** Extend `TypeResolver` with scope awareness:
+
+```ts
+class TypeResolver {
+  // Resolve a TypeDecl to its concrete definition in the context of a service.
+  // Program-level types are always visible; service-local types shadow only
+  // within that service's scope.
+  resolveInService(serviceName: string, typeDecl: TypeDecl): Type | undefined
+
+  // Scoped struct-field / enum-variant expansion.
+  getTypeDeclStringInService(serviceName: string, typeDecl: TypeDecl, nameKind?: NameKind): string
+}
+```
+
+Alternative shape: hang the resolver off each service exposed on
+`SailsProgram.services[name]`:
+
+```ts
+interface SailsService {
+  resolveType(typeDecl: TypeDecl): Type | undefined
+  renderType(typeDecl: TypeDecl, nameKind?: NameKind): string
+}
+```
+
+---
+
+## 3. Generic-parameter substitution in TypeResolver / TypeDecl walker (P1)
+
+**What we do now.** A v2 struct like `Packet<T> { payload: T }` used as
+`Packet<[u8]>` leaves hex strings uncoerced in our walker because we never
+substitute `T → [u8]` before recursing into `field.type`. Fix is straightforward
+(thread a substitutions `Map<string, TypeDecl>` through the recursion and
+resolve each generic through the current scope before entering the next), but
+every consumer that walks v2 types has to reinvent this.
+
+**Why this matters.** `TypeResolver.getTypeDeclString` already does generic
+substitution internally when rendering a name. It just doesn't expose a
+"resolve a TypeDecl to its fully-substituted form" method that consumers can
+feed to their own walkers.
+
+**Proposal.** Add a public substitution helper:
+
+```ts
+class TypeResolver {
+  // Substitute generics recursively. Returns a TypeDecl with all type_params
+  // replaced by their resolved forms. Idempotent.
+  substituteGenerics(typeDecl: TypeDecl, generics?: TypeDecl[], paramNames?: string[]): TypeDecl
+}
+```
+
+Or: a walker callback API:
+
+```ts
+class TypeResolver {
+  walkTypeDecl(
+    typeDecl: TypeDecl,
+    visitor: {
+      onPrimitive?(name: PrimitiveType, ctx: WalkerCtx): void;
+      onSlice?(item: TypeDecl, ctx: WalkerCtx): void;
+      onArray?(item: TypeDecl, len: number, ctx: WalkerCtx): void;
+      onTuple?(types: TypeDecl[], ctx: WalkerCtx): void;
+      onStruct?(def: ITypeStruct, resolvedFields: IStructField[], ctx: WalkerCtx): void;
+      onEnum?(def: ITypeEnum, resolvedVariants: IEnumVariant[], ctx: WalkerCtx): void;
+    },
+    ctx?: { serviceName?: string; generics?: Map<string, TypeDecl> }
+  ): void
+}
+```
+
+The walker handles substitution, user-type lookup, alias expansion, and service
+scoping so consumers never touch `_doc` or re-implement the resolution logic.
+
+---
+
+## 4. Stringifier for named-field events (P2)
+
+**What we do now.** `SailsProgram.services[x].events[y].type` is a pre-rendered
+string for unit variants (`'Null'`) and single-unnamed payloads (`'u32'`), but
+an object (from `TypeResolver.getStructDef(fields)`) for events with named
+fields like `Walked { from: (i32,i32), to: (i32,i32) }`. Consumers that want a
+uniform string representation fall through to `typeDef`, which is an
+`IServiceEvent`, not a `TypeDecl` — so `TypeResolver.getTypeDeclString` rejects
+it. vara-wallet's `discover` output renders such events as `"unknown"`.
+
+**Proposal.** Make `event.type` always a string (or expose
+`event.typeString` as a stable getter). Internally call
+`TypeResolver.getStructDef(event.fields, {}, /* stringify */ true)` for the
+named-field case — that code already exists at
+`js/src/sails-idl-v2.ts:509-511`. Just default `stringify` to `true` for the
+public field.
+
+Alternative: expose `event.render(nameKind?)` as a method that consumers can
+call; keep the object form available for those who want structured access.
+
+---
+
+## 5. Cycle detection in TypeResolver for recursive user types (P2)
+
+**What we do now.** Our walker recurses into alias and user-defined types
+without cycle detection. A pathological IDL with `type Foo = Foo` (or mutual
+recursion `Foo → Bar → Foo` via aliases) would stack-overflow the process.
+The sails parser probably rejects this at parse time, but consumers take
+parsed output at face value.
+
+**Proposal.** Have the parser reject cyclic aliases explicitly and document it.
+Or add a `TypeResolver.detectCycles()` diagnostic that consumers can call
+after parsing.
+
+---
+
+## 6. Publish sails-js-types (or re-export its types from sails-js) (P2)
+
+**What we do now.** `TypeDecl`, `Type`, `ITypeStruct`, `ITypeEnum`, `ITypeAlias`,
+`IFuncParam`, `IServiceEvent` etc. live in the private workspace package
+`sails-js-types`. Consumers who want typed access to the IDL AST (for
+inspection, validation, codegen, custom encoding) have to either:
+- re-declare the union (what we did — see `V2TypeDecl` in `src/utils/hex-bytes.ts`), or
+- peek at the deep import path `sails-js/lib/types` which isn't part of the `exports` field.
+
+**Proposal.** Either publish `sails-js-types` to npm alongside `sails-js`, or
+re-export the full AST typings from `sails-js` itself:
+
+```ts
+// sails-js top-level exports
+export type {
+  TypeDecl, Type, PrimitiveType,
+  ITypeStruct, ITypeEnum, ITypeAlias, ITypeParameter,
+  IStructField, IEnumVariant,
+  IFuncParam, IServiceFunc, IServiceEvent, IServiceUnit,
+  ICtorFunc, IProgramUnit, IIdlDoc,
+} from 'sails-js-types';
+```
+
+This also lets consumers write AST-aware code without `as any`.
+
+---
+
+## 7. Typed parse errors (P3)
+
+**What we do now.** When `parser.parse(idl)` fails, it throws a plain `Error`
+with message `"Error code: N, Error details: ..."`. Consumers can't
+programmatically distinguish "syntax error" from "validation error"
+(e.g., computed-vs-declared `interface_id` mismatch) from "WASM runtime
+failure" except by parsing the message string.
+
+**Proposal.** Export typed error classes:
+
+```ts
+class SailsIdlParseError extends Error {
+  code: 'SYNTAX' | 'VALIDATION' | 'WASM_RUNTIME' | 'UNKNOWN';
+  // For validation errors, structured fields:
+  service?: string;          // e.g., "A"
+  expectedInterfaceId?: `0x${string}`;
+  computedInterfaceId?: `0x${string}`;
+}
+```
+
+Consumers can then do `err instanceof SailsIdlParseError` and branch on
+`err.code`. vara-wallet currently reparses error messages in
+`detectIdlVersion`'s fallback path — fragile.
+
+---
+
+## 8. Parser singleton helper / init recovery (P3)
+
+**What we do now.** `SailsIdlParser` (v2 variant) requires a two-step
+construction: `new SailsIdlParser(); await parser.init()`. Consumers who want
+to share one parser across a process have to hand-roll a singleton, AND they
+have to remember that a rejected `init()` promise must be reset — otherwise a
+transient WASM-decompression hiccup wedges the process on a permanently
+rejected Promise.
+
+**Proposal.** Ship a `SailsIdlParser.getOrInit()` static helper that caches
+the initialized parser per-process and resets the cache on failure. Or at
+minimum, document the init contract explicitly — "single init() call, cache
+the result yourself, reset on rejection."
+
+```ts
+class SailsIdlParser {
+  // Process-wide singleton with automatic recovery on init failure.
+  static getOrInit(): Promise<SailsIdlParser>
+}
+```
+
+---
+
+## 9. Make v1 IDLs self-identify (P3 / optional)
+
+**What we do now.** v2 IDLs carry `!@sails: <version>` on their first
+non-blank line; v1 IDLs have no marker. We detect v2 via regex and fall back
+to "try v1 parser, if that fails try v2" for the ambiguous case. Works, but
+means a v1 IDL that embeds `!@sails:` in a doc comment (e.g.,
+`/// Example: !@sails: 1.0.0-beta.1`) gets misclassified and fails without
+fallback.
+
+**Proposal.** Either:
+- Require the directive at document start only (line 1 after leading blanks),
+  tightening the spec, OR
+- Add a mirror marker `!@sails: 0.x` to v1 IDLs retroactively so detection is
+  unambiguous, OR
+- Publish a `detectVersion(idlText): 'v1' | 'v2' | 'unknown'` helper in
+  sails-js so every consumer uses the same algorithm.
+
+The third is cheapest for upstream and removes the risk of consumers diverging
+on the detection heuristic.
+
+---
+
+## 10. Unified package or clearer split between v1 and v2 (P3)
+
+**What we do now.** `sails-js-parser@0.5.1` is the v1 parser (separate npm
+package). `sails-js@1.0.0-beta.1` bundles the v2 parser at the `./parser`
+subpath export. Dual-IDL consumers install both packages. The version fields
+don't line up (the v2 parser ships inside a tarball whose `package.json` still
+says `version: 0.5.1` — cosmetic but confusing; `npm ls sails-js` reports
+0.5.1 even though the code is 1.0.0-beta.1 content).
+
+**Proposal.**
+- Publish `sails-js@1.0.0-beta.1` (actually bump the `version` field in the
+  tarball, not just the git tag).
+- Fold the v1 parser into `sails-js` at a `./parser-v1` subpath, keeping the
+  `sails-js-parser` package as a thin re-export. One install, both parsers.
+- Or: deprecate `sails-js-parser` at GA and migrate its exports under
+  `sails-js@1.x`.
+
+---
+
+## 11. Expose interface_id computation (P3)
+
+**What we do now.** The v2 parser rejects an IDL when its declared
+`@0x<interface_id>` doesn't match the content-derived hash, printing the
+expected value. Consumers writing or editing v2 IDLs (tests, codegen, fixtures)
+have to iterate: submit IDL → read error → paste the hex back → retry.
+
+**Proposal.** Export the interface-id algorithm so tooling can compute the
+correct suffix from the service signature without a round-trip through the
+parser:
+
+```ts
+import { computeInterfaceId } from 'sails-js/parser';
+
+const id = computeInterfaceId({
+  name: 'Counter',
+  functions: [{ name: 'Add', params: [{ name: 'value', type: 'u32' }], output: 'u32' }],
+  events: [{ name: 'Added', fields: [{ type: 'u32' }] }],
+});
+// → '0x579d6daba41b7d82'
+```
+
+Enables codegen, editor tooling, and test fixtures that don't drift when a
+signature changes.
+
+---
+
+## 12. Lazy WASM load (P4, bundle-size)
+
+**What we do now.** Both parsers ship their Rust WASM as a base64-encoded
+gzipped blob in a JS module. Bundling the v2 parser adds ~145KB of base64 to
+the bundle (plus ~97KB for v1). For the sails-js-consuming CLI at vara-wallet,
+`dist/app.js` weighs 3.3 MB — a meaningful fraction of that is the two WASM
+blobs, even though any given invocation only exercises one parser.
+
+**Proposal.** Emit the WASM as a sibling `.wasm` asset and load it lazily via
+`fs.readFileSync` (Node) or `fetch` (browser). Bundlers that support
+`import.meta.url` can inline when needed. Halves the at-startup parse cost of
+the base64 string in V8 and lets tree-shakers skip the unused parser when a
+consumer opts in to only one version.
+
+---
+
+## Summary of priorities
+
+| # | Proposal | Priority | Consumer pain level |
+|---|----------|----------|---------------------|
+| 1 | Public type-map accessors | **P1** | High — forces private `_doc` access across the codebase |
+| 2 | Service-scoped type resolution | **P1** | High — silent mis-coercion on name collisions |
+| 3 | Generic substitution helper | **P1** | High — silent mis-coercion when generics are used |
+| 4 | Always-string event `.type` | P2 | Medium — discover output gap |
+| 5 | Cycle detection | P2 | Low — pathological IDL only |
+| 6 | Publish / re-export types | P2 | Medium — forces type-decl duplication |
+| 7 | Typed parse errors | P3 | Medium — fragile message parsing in detection fallback |
+| 8 | Parser singleton helper | P3 | Low — easy to hand-roll once it's documented |
+| 9 | Unambiguous version marker | P3 | Low — our detection is permissive by design |
+| 10 | Unified package shape | P3 | Low — cosmetic, once npm publish lands |
+| 11 | Exposed `computeInterfaceId` | P3 | Medium — high DX win for IDL authors and tooling |
+| 12 | Lazy WASM load | P4 | Low — bundle-size concern only |
+
+Proposals #1, #2, and #3 together would let us delete ~350 lines of workaround
+code in vara-wallet and eliminate three classes of silent correctness bugs.
+#4–#6 remove the need for `as any` and private-field access entirely.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "vara-wallet": "dist/app.js"
       },
       "devDependencies": {
-        "@gear-js/api": "^0.44.2",
+        "@gear-js/api": "^0.45.0",
         "@polkadot/api": "^16.5.4",
         "@polkadot/util": "^14.0.2",
         "@types/better-sqlite3": "^7.6.0",
@@ -26,7 +26,7 @@
         "commander": "^14.0.3",
         "esbuild": "^0.24.0",
         "jest": "^30.2.0",
-        "sails-js": "^0.5.1",
+        "sails-js": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.1/sails-js.tgz",
         "sails-js-parser": "^0.5.1",
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.0",
@@ -1016,13 +1016,13 @@
       }
     },
     "node_modules/@gear-js/api": {
-      "version": "0.44.2",
-      "resolved": "https://registry.npmjs.org/@gear-js/api/-/api-0.44.2.tgz",
-      "integrity": "sha512-367E+S5pfgxrTj+QY21qLGu+4CocKAUdbqXyYUVIPBJhkBXLBvcM9iGh6T0jXI2HC7hWncRFtne3DWvd6V6Rng==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@gear-js/api/-/api-0.45.0.tgz",
+      "integrity": "sha512-imJnKGSI119REQUvbm4e9i0KDQEeGNPHZzzQz87i0DLDF03Msxl0/KkrrQGciKWIXJjXcqEXL8m3+4LOkwR9MA==",
       "dev": true,
       "license": "GPL-3.0",
       "peerDependencies": {
-        "@polkadot/api": "^16.4.1",
+        "@polkadot/api": "^16.5.1",
         "@polkadot/wasm-crypto": "^7.5.1",
         "rxjs": "^7.8.2"
       }
@@ -5533,20 +5533,14 @@
     },
     "node_modules/sails-js": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/sails-js/-/sails-js-0.5.1.tgz",
-      "integrity": "sha512-mM334OJTLAQFwlaZRucITUcrbR4QXojUDMEns/fk3f4lsV2TSe43PRZvMD/Wp5rSL0qInAcEJrgMLiEKLvVmYQ==",
+      "resolved": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.1/sails-js.tgz",
+      "integrity": "sha512-Hny07M8B3GPq3gbjT4al6V2SPDCFjdWNL+gz1qa1d5AlkNXZM+eHfwj/1I5xYuaLjz4ZrH9eGvzxDsIARpjGfg==",
       "dev": true,
       "license": "GPL-3.0",
-      "dependencies": {
-        "sails-js-util": "0.5.1"
-      },
-      "optionalDependencies": {
-        "sails-js-types": "0.5.1"
-      },
       "peerDependencies": {
-        "@gear-js/api": "^0.44.1",
-        "@polkadot/api": "^16.4.1",
-        "@polkadot/util": "^13.5.1"
+        "@gear-js/api": "^0.45.0",
+        "@polkadot/api": "^16.5.1",
+        "@polkadot/util": "^14.0.1"
       }
     },
     "node_modules/sails-js-parser": {
@@ -5568,12 +5562,6 @@
       "integrity": "sha512-A8z9YO9ovpOcM0leHm/I0rATRkw2y54AauIGvFqJzrvOnQTZ2MAZCoISccC0BsRKMyg1UnflblkpdY040mJDMw==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/sails-js-util": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/sails-js-util/-/sails-js-util-0.5.1.tgz",
-      "integrity": "sha512-51QtU3t95Mtu0Mda7MXmFD3Nhyx0R1jBme2bWbzNgsXwY+DxRn2a6wJ/8pgZoL4SRO5s63aNS72ifnRtuBHj1A==",
-      "dev": true
     },
     "node_modules/scale-ts": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   "scripts": {
     "build": "rm -rf dist && node scripts/build.mjs",
     "start": "node dist/app.js",
-    "dev": "ts-node src/app.ts",
+    "dev": "ts-node --transpile-only src/app.ts",
     "test": "jest",
+    "test:smoke": "node scripts/smoke.mjs",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build"
   },
@@ -25,7 +26,7 @@
     "smoldot": "https://github.com/ukint-vs/smoldot-gear/releases/download/v2.0.40-gear/smoldot-2.0.40.tgz"
   },
   "devDependencies": {
-    "@gear-js/api": "^0.44.2",
+    "@gear-js/api": "^0.45.0",
     "@polkadot/api": "^16.5.4",
     "@polkadot/util": "^14.0.2",
     "@types/better-sqlite3": "^7.6.0",
@@ -35,7 +36,7 @@
     "commander": "^14.0.3",
     "esbuild": "^0.24.0",
     "jest": "^30.2.0",
-    "sails-js": "^0.5.1",
+    "sails-js": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.1/sails-js.tgz",
     "sails-js-parser": "^0.5.1",
     "ts-jest": "^29.4.5",
     "ts-node": "^10.9.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "node dist/app.js",
     "dev": "ts-node --transpile-only src/app.ts",
     "test": "jest",
-    "test:smoke": "node scripts/smoke.mjs",
+    "test:smoke": "npm run build && node scripts/smoke.mjs",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,85 @@
+// Post-build smoke test. Validates the bundled `dist/app.js` can load both
+// IDL v1 and v2 fixtures end-to-end — catches CJS/ESM interop drift, missing
+// WASM assets, or esbuild-mangled module imports that unit tests (which run
+// from source) would miss.
+//
+// Run via `npm run test:smoke` after `npm run build`.
+//
+// Exits non-zero on any failure so CI can gate on it.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const BUNDLE = join(REPO_ROOT, 'dist', 'app.js');
+
+if (!existsSync(BUNDLE)) {
+  console.error(`smoke: dist/app.js not found — run \`npm run build\` first.`);
+  process.exit(1);
+}
+
+const ZERO_ID =
+  '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+function runDiscover(idlPath, label) {
+  const result = spawnSync(
+    process.execPath,
+    [BUNDLE, 'discover', ZERO_ID, '--idl', idlPath, '--json'],
+    { encoding: 'utf-8', timeout: 30_000 },
+  );
+  if (result.status !== 0) {
+    console.error(`smoke[${label}] FAILED — exit ${result.status}`);
+    if (result.stderr) console.error('stderr:', result.stderr.slice(0, 2000));
+    if (result.stdout) console.error('stdout:', result.stdout.slice(0, 2000));
+    process.exit(1);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (err) {
+    console.error(`smoke[${label}] FAILED — non-JSON output: ${result.stdout.slice(0, 500)}`);
+    process.exit(1);
+  }
+  const services = parsed?.services;
+  const serviceCount = services ? Object.keys(services).length : 0;
+  if (serviceCount === 0) {
+    console.error(`smoke[${label}] FAILED — no services listed`);
+    process.exit(1);
+  }
+  console.log(
+    `smoke[${label}] OK — version=${parsed.idlVersion} services=${Object.keys(services).join(',')}`,
+  );
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'vara-wallet-smoke-'));
+try {
+  // v1: extract the first bundled VFT IDL and write it to a temp file.
+  const bundledSrc = readFileSync(
+    join(REPO_ROOT, 'src', 'idl', 'bundled-idls.ts'),
+    'utf-8',
+  );
+  const match = bundledSrc.match(/export const VFT_EXTENDED_IDL\s*=\s*`([\s\S]*?)`/);
+  if (!match) {
+    console.error('smoke: could not extract VFT_EXTENDED_IDL from bundled-idls.ts');
+    process.exit(1);
+  }
+  const v1Path = join(tmp, 'vft-v1.idl');
+  writeFileSync(v1Path, match[1]);
+  runDiscover(v1Path, 'v1');
+
+  // v2: use the test fixture shipped with the repo.
+  const v2Path = join(REPO_ROOT, 'src', '__tests__', 'fixtures', 'sample-v2.idl');
+  if (!existsSync(v2Path)) {
+    console.error(`smoke: v2 fixture missing at ${v2Path}`);
+    process.exit(1);
+  }
+  runDiscover(v2Path, 'v2');
+
+  console.log('smoke: all checks passed');
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/src/__tests__/bundled-dex-idls.test.ts
+++ b/src/__tests__/bundled-dex-idls.test.ts
@@ -1,12 +1,18 @@
 import { SailsIdlParser } from 'sails-js-parser';
 import { Sails } from 'sails-js';
 import { DEX_FACTORY_IDL, DEX_PAIR_IDL } from '../idl/bundled-idls';
+import { detectIdlVersion, getSailsVersion } from '../services/sails';
 
 describe('bundled DEX IDLs', () => {
   let parser: SailsIdlParser;
 
   beforeAll(async () => {
     parser = await SailsIdlParser.new();
+  });
+
+  it('are detected as IDL v1 (no !@sails: directive)', () => {
+    expect(detectIdlVersion(DEX_FACTORY_IDL)).toBe('unknown');
+    expect(detectIdlVersion(DEX_PAIR_IDL)).toBe('unknown');
   });
 
   describe('DEX_FACTORY_IDL', () => {
@@ -19,6 +25,10 @@ describe('bundled DEX IDLs', () => {
 
     it('parses without error', () => {
       expect(sails.services).toBeDefined();
+    });
+
+    it('is a v1 Sails instance', () => {
+      expect(getSailsVersion(sails)).toBe('v1');
     });
 
     it('has a Factory service', () => {

--- a/src/__tests__/bundled-idls.test.ts
+++ b/src/__tests__/bundled-idls.test.ts
@@ -1,12 +1,18 @@
 import { SailsIdlParser } from 'sails-js-parser';
 import { Sails } from 'sails-js';
 import { VFT_EXTENDED_IDL, VFT_STANDARD_IDL } from '../idl/bundled-idls';
+import { detectIdlVersion, getSailsVersion } from '../services/sails';
 
 describe('bundled VFT IDLs', () => {
   let parser: SailsIdlParser;
 
   beforeAll(async () => {
     parser = await SailsIdlParser.new();
+  });
+
+  it('are detected as IDL v1 (no !@sails: directive)', () => {
+    expect(detectIdlVersion(VFT_EXTENDED_IDL)).toBe('unknown');
+    expect(detectIdlVersion(VFT_STANDARD_IDL)).toBe('unknown');
   });
 
   describe('VFT_EXTENDED_IDL (single Vft service)', () => {
@@ -19,6 +25,10 @@ describe('bundled VFT IDLs', () => {
 
     it('parses without error', () => {
       expect(sails.services).toBeDefined();
+    });
+
+    it('is a v1 Sails instance', () => {
+      expect(getSailsVersion(sails)).toBe('v1');
     });
 
     it('has a Vft service', () => {

--- a/src/__tests__/describe-type-v2.test.ts
+++ b/src/__tests__/describe-type-v2.test.ts
@@ -1,0 +1,87 @@
+import * as path from 'path';
+import { parseIdlFileV2, describeType } from '../services/sails';
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-v2.idl');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function load(): Promise<any> {
+  return parseIdlFileV2(FIXTURE_PATH);
+}
+
+describe('describeType (v2)', () => {
+  it('renders primitives as their literal names', async () => {
+    const program = await load();
+    expect(describeType(program, 'u32')).toBe('u32');
+    expect(describeType(program, 'String')).toBe('String');
+    expect(describeType(program, 'bool')).toBe('bool');
+    // TypeResolver unwraps ActorId → underlying [u8;32] representation.
+    expect(describeType(program, 'ActorId')).toBe('[u8;32]');
+  });
+
+  it('renders Vec<u8> from slice shape', async () => {
+    const program = await load();
+    const typeDef = { kind: 'slice', item: 'u8' };
+    expect(describeType(program, typeDef)).toBe('Vec<u8>');
+  });
+
+  it('renders [u8; 32] from array shape', async () => {
+    const program = await load();
+    const typeDef = { kind: 'array', item: 'u8', len: 32 };
+    expect(describeType(program, typeDef)).toBe('[u8;32]');
+  });
+
+  it('renders tuples', async () => {
+    const program = await load();
+    const typeDef = { kind: 'tuple', types: ['u32', 'String'] };
+    expect(describeType(program, typeDef)).toBe('(u32,String)');
+  });
+
+  it('renders Option<T> as a named wrapper', async () => {
+    const program = await load();
+    const typeDef = { kind: 'named', name: 'Option', generics: ['u32'] };
+    expect(describeType(program, typeDef)).toBe('Option<u32>');
+  });
+
+  it('renders Result<T, E> as a named wrapper', async () => {
+    const program = await load();
+    const typeDef = { kind: 'named', name: 'Result', generics: ['String', 'String'] };
+    expect(describeType(program, typeDef)).toBe('Result<String,String>');
+  });
+
+  it('renders nested composites (Option<Vec<u8>>)', async () => {
+    const program = await load();
+    const typeDef = {
+      kind: 'named',
+      name: 'Option',
+      generics: [{ kind: 'slice', item: 'u8' }],
+    };
+    expect(describeType(program, typeDef)).toBe('Option<Vec<u8>>');
+  });
+
+  it('renders user-defined struct by name', async () => {
+    const program = await load();
+    const typeDef = { kind: 'named', name: 'Packet' };
+    expect(describeType(program, typeDef)).toBe('Packet');
+  });
+
+  it('renders user-defined enum by name', async () => {
+    const program = await load();
+    const typeDef = { kind: 'named', name: 'Action' };
+    expect(describeType(program, typeDef)).toBe('Action');
+  });
+
+  it('returns "unknown" for unresolvable input', async () => {
+    const program = await load();
+    // A malformed TypeDecl the TypeResolver can't parse.
+    expect(describeType(program, { kind: 'bogus' } as unknown)).toBe('unknown');
+  });
+
+  it('matches the pre-rendered .type string on method args', async () => {
+    const program = await load();
+    const echo = program.services.Demo.functions.Echo;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [dataArg, hashArg] = echo.args as Array<{ type: string; typeDef: any }>;
+    expect(describeType(program, dataArg.typeDef)).toBe(dataArg.type);
+    expect(describeType(program, hashArg.typeDef)).toBe(hashArg.type);
+  });
+});

--- a/src/__tests__/event-render-v2.test.ts
+++ b/src/__tests__/event-render-v2.test.ts
@@ -1,5 +1,4 @@
 /**
- * Regression test for Finding C from the /review pass:
  * describeSailsProgram must render v2 events with all three payload
  * shapes — unit variant, single unnamed payload, named-field struct —
  * as useful strings, not "unknown".

--- a/src/__tests__/event-render-v2.test.ts
+++ b/src/__tests__/event-render-v2.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for Finding C from the /review pass:
+ * describeSailsProgram must render v2 events with all three payload
+ * shapes — unit variant, single unnamed payload, named-field struct —
+ * as useful strings, not "unknown".
+ */
+import * as path from 'path';
+import { parseIdlFileV2, describeSailsProgram } from '../services/sails';
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-events.idl');
+
+interface EventDesc { type: string; docs: string | null }
+interface ServiceDesc { events: Record<string, EventDesc> }
+
+describe('describeSailsProgram — v2 event payload rendering', () => {
+  it('renders all three event shapes without "unknown"', async () => {
+    const program = await parseIdlFileV2(FIXTURE);
+    const desc = describeSailsProgram(program) as Record<string, ServiceDesc>;
+    const events = desc.Walker.events;
+
+    // Unit variant.
+    expect(events.Stopped.type).toBe('Null');
+
+    // Single unnamed payload — pre-rendered by TypeResolver.
+    expect(events.StepCount.type).toBe('u32');
+
+    // Named-field event — our custom renderer handles this.
+    expect(events.Walked.type).toMatch(/from:\s*\(i32,\s*i32\),\s*to:\s*\(i32,\s*i32\)/);
+    expect(events.Walked.type).not.toBe('unknown');
+
+    // Doc strings propagated for all three.
+    expect(events.Stopped.docs).toContain('Unit variant');
+    expect(events.Walked.docs).toContain('Named-field event');
+  });
+});

--- a/src/__tests__/fixtures/sample-v2-collision.idl
+++ b/src/__tests__/fixtures/sample-v2-collision.idl
@@ -1,0 +1,36 @@
+
+!@sails: 1.0.0-beta.1
+
+// Collision fixture: two services declare a same-named `Packet` struct
+// with different byte-field lengths. Used to verify that coerceArgsV2
+// scopes lookups by service (see Finding A in the PR review).
+
+service A@0xa667a3b129e57f5c {
+    functions {
+        Set(p: Packet);
+    }
+    types {
+        struct Packet {
+            payload: [u8; 4],
+        }
+    }
+}
+
+service B@0x8b02064fa4f2f602 {
+    functions {
+        Set(p: Packet);
+    }
+    types {
+        struct Packet {
+            payload: [u8; 8],
+        }
+    }
+}
+
+program Demo {
+    constructors { Default(); }
+    services {
+        A@0xa667a3b129e57f5c,
+        B@0x8b02064fa4f2f602,
+    }
+}

--- a/src/__tests__/fixtures/sample-v2-events.idl
+++ b/src/__tests__/fixtures/sample-v2-events.idl
@@ -1,0 +1,31 @@
+
+!@sails: 1.0.0-beta.1
+
+// Event-shapes fixture: exercises the three v2 event payload shapes
+// (unit variant, single unnamed payload, named-field struct) in
+// describeSailsProgram's event renderer (see Finding C in the PR
+// review).
+
+service Walker@0x8b8f80fc72de9b90 {
+    events {
+        /// Unit variant event.
+        Stopped,
+        /// Single unnamed payload.
+        StepCount(u32),
+        /// Named-field event — Finding C regression.
+        Walked {
+            from: (i32, i32),
+            to: (i32, i32),
+        },
+    }
+    functions {
+        Walk(dx: i32, dy: i32);
+    }
+}
+
+program Demo {
+    constructors { Default(); }
+    services {
+        Walker@0x8b8f80fc72de9b90,
+    }
+}

--- a/src/__tests__/fixtures/sample-v2-generics.idl
+++ b/src/__tests__/fixtures/sample-v2-generics.idl
@@ -1,0 +1,29 @@
+
+!@sails: 1.0.0-beta.1
+
+// Generics fixture: exercises type_param substitution in the v2
+// hex-bytes walker (see Finding B in the PR review). A generic
+// struct `Envelope<T>` used as `Envelope<[u8]>` and `Envelope<[u8; 8]>`
+// must coerce the payload hex into bytes; without substitution the
+// walker would leave hex strings uncoerced because it'd recurse into
+// the literal type_param `T` rather than the caller's chosen type.
+
+service Gen@0xd80c9eabb287b035 {
+    functions {
+        SetPayload(p: Envelope<[u8]>);
+        SetFixed(p: Envelope<[u8; 8]>);
+    }
+    types {
+        struct Envelope<T> {
+            id: u32,
+            payload: T,
+        }
+    }
+}
+
+program Demo {
+    constructors { Default(); }
+    services {
+        Gen@0xd80c9eabb287b035,
+    }
+}

--- a/src/__tests__/fixtures/sample-v2.idl
+++ b/src/__tests__/fixtures/sample-v2.idl
@@ -1,5 +1,13 @@
 !@sails: 1.0.0-beta.1
 
+// IMPORTANT: the @0x... interface_id after each service name is
+// content-derived by the sails-js v2 parser from the full service
+// signature (name + methods + events + types). If you change any
+// signature below, the parser will reject the file with a
+// "Validation error: service `X` computed interface_id 0x... is
+// not equal to 0x... in IDL" message — copy the computed hex from
+// that error into the corresponding `@0x...` suffix.
+
 /// Byte-heavy service used to exercise the v2 hex-bytes walker and
 /// describe-type-v2 covering primitives, Vec<u8>, [u8; N], structs with
 /// byte fields, enums, options, tuples, and user-defined types.

--- a/src/__tests__/fixtures/sample-v2.idl
+++ b/src/__tests__/fixtures/sample-v2.idl
@@ -1,0 +1,66 @@
+!@sails: 1.0.0-beta.1
+
+/// Byte-heavy service used to exercise the v2 hex-bytes walker and
+/// describe-type-v2 covering primitives, Vec<u8>, [u8; N], structs with
+/// byte fields, enums, options, tuples, and user-defined types.
+service Demo@0xd13dee2d603257ad {
+    functions {
+        /// Echo bytes — tests Vec<u8> + [u8; 32] coercion.
+        Echo(data: [u8], hash: [u8; 32]) -> [u8];
+        /// Store a nested struct — tests struct field recursion + inner bytes.
+        SetPacket(packet: Packet);
+        /// Pass an enum with a byte payload — tests enum variant recursion.
+        SetAction(action: Action);
+        /// Pass an optional struct — tests Option<T> recursion.
+        SetMaybe(maybe: Option<Packet>);
+        /// Return various composite types — tests describeType on nested shapes.
+        @query
+        GetPacket() -> Packet;
+        @query
+        GetMaybe() -> Option<Packet>;
+        @query
+        GetPair() -> (u32, Packet);
+        @query
+        GetResult() -> Result<Packet, String>;
+    }
+    events {
+        /// Unit variant event.
+        Ping,
+        /// Single unnamed payload.
+        PacketStored(Packet),
+        /// Typed payload.
+        Counted(u32),
+    }
+    types {
+        /// Struct with a byte field.
+        struct Packet {
+            id: u32,
+            payload: [u8],
+            tag: [u8; 8],
+        }
+        /// Enum with mixed unit, tuple, and struct-shaped payloads.
+        enum Action {
+            /// Unit variant.
+            Noop,
+            /// Variant with an unnamed payload (single field).
+            Tag([u8; 4]),
+            /// Variant with a struct-shaped payload.
+            Store {
+                key: String,
+                value: [u8],
+            },
+        }
+    }
+}
+
+program DemoV2 {
+    constructors {
+        /// Default constructor — no args.
+        Default();
+        /// Constructor with Option<T> arg.
+        New(initial: Option<u32>);
+    }
+    services {
+        Demo@0xd13dee2d603257ad,
+    }
+}

--- a/src/__tests__/hex-bytes-v2-generics.test.ts
+++ b/src/__tests__/hex-bytes-v2-generics.test.ts
@@ -1,7 +1,6 @@
 /**
- * Regression tests for Finding B from the /review pass:
- * generic user types must substitute type_params before coercing
- * byte fields. Without substitution, `Envelope<[u8]>.payload` stays
+ * Generic user types must substitute type_params before coercing byte
+ * fields. Without substitution, `Envelope<[u8]>.payload` would stay
  * as a hex string instead of being converted to bytes.
  */
 import * as path from 'path';

--- a/src/__tests__/hex-bytes-v2-generics.test.ts
+++ b/src/__tests__/hex-bytes-v2-generics.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for Finding B from the /review pass:
+ * generic user types must substitute type_params before coercing
+ * byte fields. Without substitution, `Envelope<[u8]>.payload` stays
+ * as a hex string instead of being converted to bytes.
+ */
+import * as path from 'path';
+import { parseIdlFileV2 } from '../services/sails';
+import { coerceArgsV2, coerceHexToBytesV2 } from '../utils/hex-bytes';
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-generics.idl');
+
+describe('v2 generic substitution', () => {
+  it('Envelope<[u8]>.payload coerces hex to bytes via type_param substitution', async () => {
+    const program = await parseIdlFileV2(FIXTURE);
+    const setPayload = program.services.Gen.functions.SetPayload;
+    const out = coerceArgsV2(
+      [{ id: 7, payload: '0xdeadbeef' }],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setPayload.args as any,
+      program,
+      'Gen',
+    )[0] as { id: number; payload: number[] };
+    expect(out.id).toBe(7);
+    expect(out.payload).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it('Envelope<[u8; 8]>.payload validates fixed-size bytes', async () => {
+    const program = await parseIdlFileV2(FIXTURE);
+    const setFixed = program.services.Gen.functions.SetFixed;
+
+    // Correct length → bytes.
+    const ok = coerceArgsV2(
+      [{ id: 1, payload: '0x' + '11'.repeat(8) }],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setFixed.args as any,
+      program,
+      'Gen',
+    )[0] as { payload: number[] };
+    expect(ok.payload).toHaveLength(8);
+
+    // Wrong length → the length-mismatch error from the fixed-array branch
+    // only surfaces when substitution actually fires; a regression that
+    // skipped substitution would silently leave the hex string intact.
+    expect(() =>
+      coerceArgsV2(
+        [{ id: 1, payload: '0xaa' }],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        setFixed.args as any,
+        program,
+        'Gen',
+      ),
+    ).toThrow(/\[u8; 8\]/);
+  });
+
+  it('substitutes type_params directly via the walker', async () => {
+    // Minimal direct test: simulate a call site handing a generic
+    // reference {name:'T'} with a substitution map. This documents the
+    // one-level lookup semantics that the broader substitution walk
+    // builds on.
+    const typeMap = new Map<string, unknown>();
+    const subs = new Map<string, unknown>([['T', { kind: 'slice', item: 'u8' }]]);
+    const out = coerceHexToBytesV2(
+      '0xabcd',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { kind: 'named', name: 'T' } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      typeMap as any,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      subs as any,
+    );
+    expect(out).toEqual([0xab, 0xcd]);
+  });
+});

--- a/src/__tests__/hex-bytes-v2.test.ts
+++ b/src/__tests__/hex-bytes-v2.test.ts
@@ -1,0 +1,218 @@
+import * as path from 'path';
+import { parseIdlFileV2 } from '../services/sails';
+import { coerceHexToBytesV2, coerceArgsV2, coerceArgsAuto } from '../utils/hex-bytes';
+import type { SailsProgram } from 'sails-js';
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-v2.idl');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type V2TypeMap = Map<string, any>;
+
+async function setupProgram() {
+  const program = await parseIdlFileV2(FIXTURE_PATH);
+  // Types in v2 live per-service (doc.services[i].types) plus optional
+  // ambient types on doc.program.types. Merge both into a single map.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const doc = (program as any)._doc;
+  const typeMap: V2TypeMap = new Map();
+  for (const t of doc?.program?.types ?? []) typeMap.set(t.name, t);
+  for (const svc of doc?.services ?? []) {
+    for (const t of svc.types ?? []) typeMap.set(t.name, t);
+  }
+  return { program, typeMap };
+}
+
+// Get the TypeDecl for a specific arg of a specific method.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function argType(program: SailsProgram, service: string, method: string, argIndex: number): any {
+  const m = program.services[service].functions[method] ?? program.services[service].queries[method];
+  return (m.args[argIndex] as { typeDef: unknown }).typeDef;
+}
+
+describe('coerceHexToBytesV2', () => {
+  const EMPTY_MAP: V2TypeMap = new Map();
+
+  describe('Vec<u8> slice', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let dataType: any;
+    beforeAll(async () => {
+      const { program } = await setupProgram();
+      dataType = argType(program, 'Demo', 'Echo', 0);
+    });
+
+    it('converts hex string to byte array', () => {
+      expect(coerceHexToBytesV2('0xabcdef', dataType, EMPTY_MAP)).toEqual([0xab, 0xcd, 0xef]);
+    });
+
+    it('passes through 0x with no hex digits', () => {
+      expect(coerceHexToBytesV2('0x', dataType, EMPTY_MAP)).toBe('0x');
+    });
+
+    it('throws on odd-length hex', () => {
+      expect(() => coerceHexToBytesV2('0xabc', dataType, EMPTY_MAP)).toThrow(/Odd-length/);
+    });
+
+    it('throws on invalid hex characters', () => {
+      expect(() => coerceHexToBytesV2('0xzz', dataType, EMPTY_MAP)).toThrow(/Invalid hex/);
+    });
+
+    it('passes through non-string values unchanged', () => {
+      expect(coerceHexToBytesV2([1, 2, 3], dataType, EMPTY_MAP)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('[u8; 32] fixed array', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let hashType: any;
+    beforeAll(async () => {
+      const { program } = await setupProgram();
+      hashType = argType(program, 'Demo', 'Echo', 1);
+    });
+
+    it('converts correct-length hex to bytes', () => {
+      const hex = '0x' + '11'.repeat(32);
+      const bytes = coerceHexToBytesV2(hex, hashType, EMPTY_MAP) as number[];
+      expect(bytes).toHaveLength(32);
+      expect(bytes[0]).toBe(0x11);
+    });
+
+    it('throws on wrong-length hex', () => {
+      expect(() => coerceHexToBytesV2('0xaa', hashType, EMPTY_MAP)).toThrow(/\[u8; 32\]/);
+    });
+  });
+
+  describe('struct with byte fields', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let packetType: any;
+    let typeMap: V2TypeMap;
+    beforeAll(async () => {
+      const setup = await setupProgram();
+      typeMap = setup.typeMap;
+      packetType = argType(setup.program, 'Demo', 'SetPacket', 0);
+    });
+
+    it('recurses into named struct and coerces byte fields', () => {
+      const input = { id: 42, payload: '0xabcd', tag: '0x' + '77'.repeat(8) };
+      const out = coerceHexToBytesV2(input, packetType, typeMap) as {
+        id: number;
+        payload: number[];
+        tag: number[];
+      };
+      expect(out.id).toBe(42);
+      expect(out.payload).toEqual([0xab, 0xcd]);
+      expect(out.tag).toHaveLength(8);
+    });
+
+    it('throws with field name hint when tag length is wrong', () => {
+      const input = { id: 1, payload: '0x', tag: '0xff' };
+      expect(() => coerceHexToBytesV2(input, packetType, typeMap)).toThrow(/"tag"/);
+    });
+  });
+
+  describe('Option<Packet>', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let maybeType: any;
+    let typeMap: V2TypeMap;
+    beforeAll(async () => {
+      const setup = await setupProgram();
+      typeMap = setup.typeMap;
+      maybeType = argType(setup.program, 'Demo', 'SetMaybe', 0);
+    });
+
+    it('recurses into Option<T> payload', () => {
+      const input = { id: 1, payload: '0xaa', tag: '0x' + '00'.repeat(8) };
+      const out = coerceHexToBytesV2(input, maybeType, typeMap) as {
+        payload: number[];
+      };
+      expect(out.payload).toEqual([0xaa]);
+    });
+
+    it('passes through null without error', () => {
+      expect(coerceHexToBytesV2(null, maybeType, typeMap)).toBeNull();
+    });
+  });
+
+  describe('enum variant recursion', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let actionType: any;
+    let typeMap: V2TypeMap;
+    beforeAll(async () => {
+      const setup = await setupProgram();
+      typeMap = setup.typeMap;
+      actionType = argType(setup.program, 'Demo', 'SetAction', 0);
+    });
+
+    it('unit variant passes through unchanged', () => {
+      const input = { Noop: null };
+      expect(coerceHexToBytesV2(input, actionType, typeMap)).toEqual(input);
+    });
+
+    it('variant with unnamed [u8; 4] payload coerces hex', () => {
+      const out = coerceHexToBytesV2({ Tag: '0xdeadbeef' }, actionType, typeMap) as { Tag: number[] };
+      expect(out.Tag).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    });
+
+    it('variant with struct-shaped payload recurses fields', () => {
+      const out = coerceHexToBytesV2(
+        { Store: { key: 'foo', value: '0x0102' } },
+        actionType,
+        typeMap,
+      ) as { Store: { key: string; value: number[] } };
+      expect(out.Store.key).toBe('foo');
+      expect(out.Store.value).toEqual([0x01, 0x02]);
+    });
+  });
+
+  describe('primitive passthrough', () => {
+    it('u32 primitive passes through', () => {
+      // Build a synthetic primitive TypeDecl (string literal in v2).
+      expect(coerceHexToBytesV2(42, 'u32', EMPTY_MAP)).toBe(42);
+      expect(coerceHexToBytesV2('hi', 'String', EMPTY_MAP)).toBe('hi');
+    });
+
+    it('null/undefined pass through', () => {
+      expect(coerceHexToBytesV2(null, 'u32', EMPTY_MAP)).toBeNull();
+      expect(coerceHexToBytesV2(undefined, 'u32', EMPTY_MAP)).toBeUndefined();
+    });
+  });
+});
+
+describe('coerceArgsV2', () => {
+  it('coerces method args based on IDL types', async () => {
+    const { program } = await setupProgram();
+    const echo = program.services.Demo.functions.Echo;
+    const args = coerceArgsV2(
+      ['0xabcdef', '0x' + '11'.repeat(32)],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      echo.args as any,
+      program,
+    );
+    expect(args[0]).toEqual([0xab, 0xcd, 0xef]);
+    expect((args[1] as number[]).length).toBe(32);
+  });
+
+  it('returns args unchanged when types map is missing', () => {
+    const fakeProgram = {} as SailsProgram;
+    const args = coerceArgsV2(['foo'], [{ name: 'x', typeDef: 'String' }], fakeProgram);
+    expect(args).toEqual(['foo']);
+  });
+
+  it('returns empty args array unchanged', async () => {
+    const { program } = await setupProgram();
+    expect(coerceArgsV2([], [], program)).toEqual([]);
+  });
+});
+
+describe('coerceArgsAuto dispatch', () => {
+  it('routes v2 SailsProgram to the v2 walker', async () => {
+    const { program } = await setupProgram();
+    const echo = program.services.Demo.functions.Echo;
+    const args = coerceArgsAuto(
+      ['0xabcdef', '0x' + '11'.repeat(32)],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      echo.args as any,
+      program,
+    );
+    expect(args[0]).toEqual([0xab, 0xcd, 0xef]);
+  });
+});

--- a/src/__tests__/hex-bytes.test.ts
+++ b/src/__tests__/hex-bytes.test.ts
@@ -1,20 +1,18 @@
 import { SailsIdlParser } from 'sails-js-parser';
 import { Sails } from 'sails-js';
 import { coerceHexToBytes, coerceArgs } from '../utils/hex-bytes';
+import { getRegistryTypes } from '../services/sails';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TypeMap = Map<string, any>;
 
-// Helper: parse IDL and return {sails, typeMap, service}
+// Helper: parse IDL and return {sails, typeMap}. Uses the exported
+// `getRegistryTypes` so we don't reach into private `_program.types`.
 async function setup(idl: string) {
   const parser = await SailsIdlParser.new();
   const sails = new Sails(parser);
   sails.parseIdl(idl);
-  const typeMap: TypeMap = new Map();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for (const t of (sails as any)._program.types) {
-    typeMap.set(t.name, t.def);
-  }
+  const typeMap: TypeMap = getRegistryTypes(sails);
   return { sails, typeMap };
 }
 

--- a/src/__tests__/idl-detection.test.ts
+++ b/src/__tests__/idl-detection.test.ts
@@ -1,0 +1,41 @@
+import { detectIdlVersion } from '../services/sails';
+
+describe('detectIdlVersion', () => {
+  it('returns "v2" for IDL with !@sails: directive on the first line', () => {
+    expect(detectIdlVersion('!@sails: 1.0.0-beta.1\nservice Foo@0x00 {}')).toBe('v2');
+  });
+
+  it('returns "v2" when the directive has leading whitespace', () => {
+    expect(detectIdlVersion('   !@sails: 1.0.0-beta.1\nservice Foo@0x00 {}')).toBe('v2');
+  });
+
+  it('returns "v2" when preceded by blank lines', () => {
+    expect(detectIdlVersion('\n\n!@sails: 1.0.0-beta.1\n')).toBe('v2');
+  });
+
+  it('returns "v2" with CRLF line endings', () => {
+    expect(detectIdlVersion('\r\n!@sails: 1.0.0-beta.1\r\nservice Foo@0x00 {}')).toBe('v2');
+  });
+
+  it('returns "v2" when the directive appears mid-file (permissive match)', () => {
+    // Any line starting with !@sails: triggers v2 detection.
+    expect(detectIdlVersion('// comment\n!@sails: 1.0.0-beta.2\nservice Foo@0x00 {}')).toBe('v2');
+  });
+
+  it('returns "unknown" for a classic v1 IDL with no directive', () => {
+    expect(detectIdlVersion('service Foo { query Bar : () -> u32; };')).toBe('unknown');
+  });
+
+  it('returns "unknown" for an empty string', () => {
+    expect(detectIdlVersion('')).toBe('unknown');
+  });
+
+  it('returns "unknown" when the directive is inside a comment', () => {
+    // We match literally at the start of a line; comments don't start a line.
+    expect(detectIdlVersion('// !@sails: 1.0.0-beta.1\nservice Foo {};')).toBe('unknown');
+  });
+
+  it('returns "unknown" for whitespace-only input', () => {
+    expect(detectIdlVersion('   \n\n  \t\n')).toBe('unknown');
+  });
+});

--- a/src/__tests__/idl-fallback.test.ts
+++ b/src/__tests__/idl-fallback.test.ts
@@ -1,13 +1,11 @@
 /**
- * Regression tests for Finding D from the /review pass:
- * when the `!@sails:` directive is present, the loader now tries v2
- * first but falls back to v1 on parse failure (instead of hard-failing
- * without trying v1). When the directive is absent, the order flips:
- * v1 first, fall back to v2.
+ * When the `!@sails:` directive is present, the loader tries v2 first
+ * but falls back to v1 on parse failure. When the directive is absent,
+ * the order flips: v1 first, fall back to v2.
  *
- * We assert this by inspecting the error-message ordering when both
- * parsers reject the input — the parser that was tried FIRST appears
- * first in the combined message.
+ * Asserted by inspecting the error-message ordering when both parsers
+ * reject the input — the parser tried first appears first in the
+ * combined message.
  */
 import * as fs from 'fs';
 import * as os from 'os';

--- a/src/__tests__/idl-fallback.test.ts
+++ b/src/__tests__/idl-fallback.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression tests for Finding D from the /review pass:
+ * when the `!@sails:` directive is present, the loader now tries v2
+ * first but falls back to v1 on parse failure (instead of hard-failing
+ * without trying v1). When the directive is absent, the order flips:
+ * v1 first, fall back to v2.
+ *
+ * We assert this by inspecting the error-message ordering when both
+ * parsers reject the input — the parser that was tried FIRST appears
+ * first in the combined message.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseIdlFileAuto } from '../services/sails';
+
+function writeTmp(name: string, content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'idl-fallback-'));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('parseIdlFileAuto — fallback ordering', () => {
+  it('directive present → tries v2 first (v2 appears before v1 in error)', async () => {
+    const idl = writeTmp(
+      'directive-bad.idl',
+      '!@sails: 1.0.0-beta.1\nthis is not valid syntax for either parser\n',
+    );
+    let err: Error | undefined;
+    try { await parseIdlFileAuto(idl); } catch (e) { err = e as Error; }
+    expect(err).toBeDefined();
+    const msg = err!.message;
+    // Combined error lists both parsers.
+    expect(msg).toMatch(/v1:/);
+    expect(msg).toMatch(/v2:/);
+    // v2 tried first → appears before v1 in the message.
+    expect(msg.indexOf('v2:')).toBeLessThan(msg.indexOf('v1:'));
+  });
+
+  it('no directive → tries v1 first (v1 appears before v2 in error)', async () => {
+    const idl = writeTmp(
+      'no-directive-bad.idl',
+      'this is not valid syntax for either parser',
+    );
+    let err: Error | undefined;
+    try { await parseIdlFileAuto(idl); } catch (e) { err = e as Error; }
+    expect(err).toBeDefined();
+    const msg = err!.message;
+    expect(msg).toMatch(/v1:/);
+    expect(msg).toMatch(/v2:/);
+    expect(msg.indexOf('v1:')).toBeLessThan(msg.indexOf('v2:'));
+  });
+
+  it('directive present + valid v2 → v2 wins (no fallback needed)', async () => {
+    // Minimal valid v2 IDL — parser tolerates empty services block.
+    const idl = writeTmp(
+      'min-v2.idl',
+      '!@sails: 1.0.0-beta.1\nprogram P { constructors { Default(); } services {} }\n',
+    );
+    const loaded = await parseIdlFileAuto(idl);
+    // Using the public isSailsV2 / getSailsVersion helpers via parseIdlFileAuto
+    // is exercised elsewhere; here we just prove it resolves without error.
+    expect(loaded).toBeDefined();
+  });
+});

--- a/src/__tests__/idl-v2.test.ts
+++ b/src/__tests__/idl-v2.test.ts
@@ -1,0 +1,99 @@
+import * as path from 'path';
+import {
+  parseIdlFileAuto,
+  parseIdlFileV2,
+  describeSailsProgram,
+  getSailsVersion,
+  isSailsV2,
+  detectIdlVersion,
+} from '../services/sails';
+import * as fs from 'fs';
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-v2.idl');
+
+describe('IDL v2 façade', () => {
+  it('parses the v2 fixture via parseIdlFileV2', async () => {
+    const program = await parseIdlFileV2(FIXTURE_PATH);
+    expect(isSailsV2(program)).toBe(true);
+    expect(getSailsVersion(program)).toBe('v2');
+    expect(Object.keys(program.services).sort()).toEqual(['Demo']);
+  });
+
+  it('auto-detects v2 from the file directive', async () => {
+    const idl = fs.readFileSync(FIXTURE_PATH, 'utf-8');
+    expect(detectIdlVersion(idl)).toBe('v2');
+    const program = await parseIdlFileAuto(FIXTURE_PATH);
+    expect(getSailsVersion(program)).toBe('v2');
+  });
+
+  it('exposes ctors from the program block', async () => {
+    const program = await parseIdlFileV2(FIXTURE_PATH);
+    if (!isSailsV2(program)) throw new Error('Expected v2');
+    expect(program.ctors).not.toBeNull();
+    expect(Object.keys(program.ctors!).sort()).toEqual(['Default', 'New']);
+  });
+
+  it('exposes functions/queries/events per service', async () => {
+    const program = await parseIdlFileV2(FIXTURE_PATH);
+    if (!isSailsV2(program)) throw new Error('Expected v2');
+    const demo = program.services.Demo;
+    expect(Object.keys(demo.functions).sort()).toEqual(['Echo', 'SetAction', 'SetMaybe', 'SetPacket']);
+    expect(Object.keys(demo.queries).sort()).toEqual(['GetMaybe', 'GetPacket', 'GetPair', 'GetResult']);
+    expect(Object.keys(demo.events).sort()).toEqual(['Counted', 'PacketStored', 'Ping']);
+  });
+
+  it('describeSailsProgram produces the expected shape', async () => {
+    const program = await parseIdlFileAuto(FIXTURE_PATH);
+    const desc = describeSailsProgram(program) as Record<string, {
+      functions: Record<string, { args: Array<{ name: string; type: string }>; returnType: string; docs: string | null }>;
+      queries: Record<string, { args: Array<{ name: string; type: string }>; returnType: string; docs: string | null }>;
+      events: Record<string, { type: string; docs: string | null }>;
+    }>;
+
+    expect(Object.keys(desc)).toEqual(['Demo']);
+    const demo = desc.Demo;
+
+    // Functions: argument and return types rendered as canonical strings.
+    expect(demo.functions.Echo.args).toEqual([
+      { name: 'data', type: 'Vec<u8>' },
+      { name: 'hash', type: '[u8;32]' },
+    ]);
+    expect(demo.functions.Echo.returnType).toBe('Vec<u8>');
+    expect(demo.functions.SetPacket.args).toEqual([{ name: 'packet', type: 'Packet' }]);
+    expect(demo.functions.SetMaybe.args).toEqual([{ name: 'maybe', type: 'Option<Packet>' }]);
+
+    // Queries with composite return types.
+    expect(demo.queries.GetPair.returnType).toBe('(u32,Packet)');
+    expect(demo.queries.GetResult.returnType).toBe('Result<Packet,String>');
+    expect(demo.queries.GetMaybe.returnType).toBe('Option<Packet>');
+
+    // Events: pre-rendered type strings from the TypeResolver.
+    expect(demo.events.Ping.type).toBe('Null');
+    expect(demo.events.PacketStored.type).toBe('Packet');
+    expect(demo.events.Counted.type).toBe('u32');
+
+    // Doc strings propagated (v2 IDL supports `///`).
+    expect(demo.functions.Echo.docs).toContain('Echo bytes');
+    expect(demo.events.PacketStored.docs).toContain('Single unnamed payload');
+  });
+
+  it('encodes a ctor payload to non-empty hex', async () => {
+    const program = await parseIdlFileV2(FIXTURE_PATH);
+    if (!isSailsV2(program)) throw new Error('Expected v2');
+    const ctor = program.ctors!.New;
+    const payload = ctor.encodePayload(42);
+    expect(payload).toMatch(/^0x[0-9a-fA-F]+$/);
+    // v2 ctor payloads start with a 16-byte SailsMessageHeader prefix.
+    expect(payload.length).toBeGreaterThan(2 + 16 * 2);
+  });
+
+  it('encodes the zero-arg ctor', async () => {
+    const program = await parseIdlFileV2(FIXTURE_PATH);
+    if (!isSailsV2(program)) throw new Error('Expected v2');
+    const ctor = program.ctors!.Default;
+    const payload = ctor.encodePayload();
+    expect(payload).toMatch(/^0x[0-9a-fA-F]+$/);
+    // Header-only payload: exactly 16 bytes hex-encoded.
+    expect(payload).toHaveLength(2 + 16 * 2);
+  });
+});

--- a/src/__tests__/parser-cache.test.ts
+++ b/src/__tests__/parser-cache.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Verifies that the lazy parser cache in sails.ts does not permanently
+ * wedge on a transient init failure. See recommendation #1 from the PR
+ * review for context.
+ */
+
+// Count init calls across the whole test file; reset between tests.
+let v2InitCalls = 0;
+let v2FailOnCall: number | null = null;
+let v1NewCalls = 0;
+let v1FailOnCall: number | null = null;
+
+jest.mock('sails-js/parser', () => ({
+  SailsIdlParser: class {
+    async init(): Promise<void> {
+      v2InitCalls += 1;
+      if (v2FailOnCall !== null && v2InitCalls === v2FailOnCall) {
+        throw new Error(`mock v2 init failure (call ${v2InitCalls})`);
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    parse(_idl: string): unknown {
+      return { program: { name: 'Noop', ctors: [], services: [], types: [] }, services: [] };
+    }
+  },
+}));
+
+jest.mock('sails-js-parser', () => {
+  class MockV1Parser {
+    static async new(): Promise<MockV1Parser> {
+      v1NewCalls += 1;
+      if (v1FailOnCall !== null && v1NewCalls === v1FailOnCall) {
+        throw new Error(`mock v1 new failure (call ${v1NewCalls})`);
+      }
+      return new MockV1Parser();
+    }
+  }
+  return { SailsIdlParser: MockV1Parser };
+});
+
+// Stub the Sails class so parseIdl + services don't blow up on the mock
+// parser's empty output. We don't exercise v1 parsing behavior here.
+jest.mock('sails-js', () => {
+  const actual = jest.requireActual<object>('sails-js');
+  return {
+    ...actual,
+    Sails: class {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+      constructor(_parser: any) {}
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      parseIdl(_idl: string): void {}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+      setApi(_api: any): void {}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+      setProgramId(_id: any): void {}
+      services: Record<string, unknown> = {};
+      ctors: Record<string, unknown> = {};
+    },
+    SailsProgram: class {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+      constructor(_doc: any) {}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+      setApi(_api: any): void {}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+      setProgramId(_id: any): void {}
+      services: Record<string, unknown> = {};
+      ctors: Record<string, unknown> | null = null;
+    },
+  };
+});
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseIdlFileV1, parseIdlFileV2, _resetParserCache } from '../services/sails';
+
+function writeIdl(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vara-parser-cache-'));
+  const filePath = path.join(dir, 'test.idl');
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+describe('parser cache recovers from init failure', () => {
+  beforeEach(() => {
+    v2InitCalls = 0;
+    v2FailOnCall = null;
+    v1NewCalls = 0;
+    v1FailOnCall = null;
+    _resetParserCache();
+  });
+
+  it('v2: rejected init() does not poison the cache', async () => {
+    const idlPath = writeIdl('!@sails: 1.0.0-beta.1\nservice S@0x00 {}');
+    v2FailOnCall = 1;
+
+    // First call: init() throws, parseIdlFileV2 should surface the error.
+    await expect(parseIdlFileV2(idlPath)).rejects.toThrow(/mock v2 init failure/);
+    expect(v2InitCalls).toBe(1);
+
+    // Second call: init() succeeds, parser should be reinitialized.
+    v2FailOnCall = null;
+    await expect(parseIdlFileV2(idlPath)).resolves.toBeDefined();
+    expect(v2InitCalls).toBe(2);
+  });
+
+  it('v2: successful init() is cached and not repeated', async () => {
+    const idlPath = writeIdl('!@sails: 1.0.0-beta.1\nservice S@0x00 {}');
+
+    await parseIdlFileV2(idlPath);
+    await parseIdlFileV2(idlPath);
+    await parseIdlFileV2(idlPath);
+
+    expect(v2InitCalls).toBe(1);
+  });
+
+  it('v1: rejected new() does not poison the cache', async () => {
+    const idlPath = writeIdl('service S {};');
+    v1FailOnCall = 1;
+
+    await expect(parseIdlFileV1(idlPath)).rejects.toThrow(/mock v1 new failure/);
+    expect(v1NewCalls).toBe(1);
+
+    v1FailOnCall = null;
+    await expect(parseIdlFileV1(idlPath)).resolves.toBeDefined();
+    expect(v1NewCalls).toBe(2);
+  });
+
+  it('v1: successful new() is cached and not repeated', async () => {
+    const idlPath = writeIdl('service S {};');
+
+    await parseIdlFileV1(idlPath);
+    await parseIdlFileV1(idlPath);
+
+    expect(v1NewCalls).toBe(1);
+  });
+});

--- a/src/__tests__/parser-cache.test.ts
+++ b/src/__tests__/parser-cache.test.ts
@@ -1,7 +1,7 @@
 /**
- * Verifies that the lazy parser cache in sails.ts does not permanently
- * wedge on a transient init failure. See recommendation #1 from the PR
- * review for context.
+ * The lazy parser cache must not wedge permanently on a transient init
+ * failure — a rejected promise must be evicted so the next caller can
+ * retry, while a successful init is still cached for subsequent callers.
  */
 
 // Count init calls across the whole test file; reset between tests.

--- a/src/__tests__/type-scoping-v2.test.ts
+++ b/src/__tests__/type-scoping-v2.test.ts
@@ -1,8 +1,7 @@
 /**
- * Regression test for Finding A from the /review pass:
- * two services declaring same-named user types must not collide in
- * arg coercion. Scoping via `serviceName` narrows the type map to
- * the caller's service + program-level types.
+ * Two services declaring same-named user types must not collide in arg
+ * coercion. Scoping via `serviceName` narrows the type map to the
+ * caller's service plus program-level types.
  */
 import * as path from 'path';
 import { parseIdlFileV2, getRegistryTypes } from '../services/sails';

--- a/src/__tests__/type-scoping-v2.test.ts
+++ b/src/__tests__/type-scoping-v2.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for Finding A from the /review pass:
+ * two services declaring same-named user types must not collide in
+ * arg coercion. Scoping via `serviceName` narrows the type map to
+ * the caller's service + program-level types.
+ */
+import * as path from 'path';
+import { parseIdlFileV2, getRegistryTypes } from '../services/sails';
+import { coerceArgsV2 } from '../utils/hex-bytes';
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-collision.idl');
+
+describe('v2 type scoping across services', () => {
+  it('getRegistryTypes with a service name returns only that service\'s types', async () => {
+    const program = await parseIdlFileV2(FIXTURE);
+
+    const aMap = getRegistryTypes(program, 'A');
+    const bMap = getRegistryTypes(program, 'B');
+    const flat = getRegistryTypes(program);
+
+    // Each scoped map has its own Packet definition.
+    const aPacket = aMap.get('Packet');
+    const bPacket = bMap.get('Packet');
+    expect(aPacket).toBeDefined();
+    expect(bPacket).toBeDefined();
+    expect(aPacket).not.toBe(bPacket);
+
+    // Service A's Packet has [u8; 4], service B's has [u8; 8].
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const aLen = aPacket.fields[0].type.len as number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bLen = bPacket.fields[0].type.len as number;
+    expect(aLen).toBe(4);
+    expect(bLen).toBe(8);
+
+    // Un-scoped flat map collides — last-service-iterated wins.
+    expect(flat.get('Packet')).toBeDefined();
+  });
+
+  it('coerceArgsV2 with service name uses that service\'s type shape', async () => {
+    const program = await parseIdlFileV2(FIXTURE);
+
+    const aSet = program.services.A.functions.Set;
+    const bSet = program.services.B.functions.Set;
+
+    // A expects 4 bytes. 4-byte hex should coerce cleanly; 8-byte
+    // should throw the length-mismatch error.
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      coerceArgsV2([{ payload: '0x01020304' }], aSet.args as any, program, 'A'),
+    ).not.toThrow();
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      coerceArgsV2([{ payload: '0x0102030405060708' }], aSet.args as any, program, 'A'),
+    ).toThrow(/\[u8; 4\]/);
+
+    // B expects 8 bytes — opposite result.
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      coerceArgsV2([{ payload: '0x0102030405060708' }], bSet.args as any, program, 'B'),
+    ).not.toThrow();
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      coerceArgsV2([{ payload: '0x01020304' }], bSet.args as any, program, 'B'),
+    ).toThrow(/\[u8; 8\]/);
+  });
+
+  it('getRegistryTypes memoizes results per (instance, scope) pair', async () => {
+    const program = await parseIdlFileV2(FIXTURE);
+    const first = getRegistryTypes(program, 'A');
+    const second = getRegistryTypes(program, 'A');
+    // Same Map reference on second call — cached.
+    expect(first).toBe(second);
+    // Different scope, different Map.
+    expect(getRegistryTypes(program, 'B')).not.toBe(first);
+  });
+});

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -1,13 +1,10 @@
 import { Command } from 'commander';
-import type { Sails, SailsProgram } from 'sails-js';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
-import { loadSailsAuto, describeSailsProgram } from '../services/sails';
+import { loadSailsAuto, describeSailsProgram, type LoadedSails } from '../services/sails';
 import { resolveBlockNumber } from '../services/tx-executor';
 import { validateVoucher } from '../services/voucher-validator';
 import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex, coerceArgsAuto } from '../utils';
-
-type LoadedSails = Sails | SailsProgram;
 
 export function registerCallCommand(program: Command): void {
   program
@@ -111,7 +108,7 @@ async function executeQuery(
   verbose(`Executing query: ${serviceName}/${methodName}`);
 
   const query = sails.services[serviceName].queries[methodName];
-  args = coerceArgsAuto(args, query.args, sails);
+  args = coerceArgsAuto(args, query.args, sails, serviceName);
   const queryBuilder = query(...args);
 
   // Set origin address if available
@@ -149,7 +146,7 @@ async function executeFunction(
   }
 
   const func = sails.services[serviceName].functions[methodName];
-  args = coerceArgsAuto(args, func.args, sails);
+  args = coerceArgsAuto(args, func.args, sails, serviceName);
   const txBuilder = func(...args);
 
   txBuilder.withAccount(account);

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -1,10 +1,13 @@
 import { Command } from 'commander';
+import type { Sails, SailsProgram } from 'sails-js';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
-import { loadSails, describeSailsProgram } from '../services/sails';
+import { loadSailsAuto, describeSailsProgram } from '../services/sails';
 import { resolveBlockNumber } from '../services/tx-executor';
 import { validateVoucher } from '../services/voucher-validator';
-import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex, coerceArgs } from '../utils';
+import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex, coerceArgsAuto } from '../utils';
+
+type LoadedSails = Sails | SailsProgram;
 
 export function registerCallCommand(program: Command): void {
   program
@@ -41,8 +44,8 @@ export function registerCallCommand(program: Command): void {
       }
       const [serviceName, methodName] = parts;
 
-      // Load Sails
-      const sails = await loadSails(api, { programId, idl: options.idl });
+      // Load Sails (auto-detects v1 vs v2 IDL)
+      const sails = await loadSailsAuto(api, { programId, idl: options.idl });
 
       // Find the service
       const service = sails.services[serviceName];
@@ -99,7 +102,7 @@ export function registerCallCommand(program: Command): void {
 
 async function executeQuery(
   _api: unknown,
-  sails: import('sails-js').Sails,
+  sails: LoadedSails,
   serviceName: string,
   methodName: string,
   args: unknown[],
@@ -108,7 +111,7 @@ async function executeQuery(
   verbose(`Executing query: ${serviceName}/${methodName}`);
 
   const query = sails.services[serviceName].queries[methodName];
-  args = coerceArgs(args, query.args, sails);
+  args = coerceArgsAuto(args, query.args, sails);
   const queryBuilder = query(...args);
 
   // Set origin address if available
@@ -126,7 +129,7 @@ async function executeQuery(
 
 async function executeFunction(
   api: import('@gear-js/api').GearApi,
-  sails: import('sails-js').Sails,
+  sails: LoadedSails,
   serviceName: string,
   methodName: string,
   args: unknown[],
@@ -146,7 +149,7 @@ async function executeFunction(
   }
 
   const func = sails.services[serviceName].functions[methodName];
-  args = coerceArgs(args, func.args, sails);
+  args = coerceArgsAuto(args, func.args, sails);
   const txBuilder = func(...args);
 
   txBuilder.withAccount(account);

--- a/src/commands/discover.ts
+++ b/src/commands/discover.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
-import { loadSails, describeSailsProgram } from '../services/sails';
+import { loadSailsAuto, describeSailsProgram, getSailsVersion } from '../services/sails';
 import { output, verbose, addressToHex } from '../utils';
 
 export function registerDiscoverCommand(program: Command): void {
@@ -16,11 +16,12 @@ export function registerDiscoverCommand(program: Command): void {
       const programIdHex = addressToHex(programId);
       verbose(`Discovering program ${programIdHex}`);
 
-      const sails = await loadSails(api, { programId: programIdHex, idl: options.idl });
+      const sails = await loadSailsAuto(api, { programId: programIdHex, idl: options.idl });
       const description = describeSailsProgram(sails);
 
       output({
         programId: programIdHex,
+        idlVersion: getSailsVersion(sails),
         services: description,
       });
     });

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -1,9 +1,12 @@
 import { Command } from 'commander';
 import { ProgramMetadata } from '@gear-js/api';
+import type { Sails, SailsProgram } from 'sails-js';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
-import { loadSails, parseIdlFile } from '../services/sails';
-import { output, verbose, CliError, tryHexToText, coerceArgs } from '../utils';
+import { loadSailsAuto, parseIdlFileAuto } from '../services/sails';
+import { output, verbose, CliError, tryHexToText, coerceArgsAuto } from '../utils';
+
+type LoadedSails = Sails | SailsProgram;
 
 export function registerEncodeCommand(program: Command): void {
   program
@@ -29,14 +32,15 @@ export function registerEncodeCommand(program: Command): void {
       }
 
       if (options.idl && options.method) {
-        // Sails IDL encoding — works offline when no --program is given
-        let sails: import('sails-js').Sails;
+        // Sails IDL encoding — works offline when no --program is given.
+        // Auto-detects IDL v1 vs v2.
+        let sails: LoadedSails;
         if (options.program) {
           const opts = program.optsWithGlobals() as { ws?: string };
           const api = await getApi(opts.ws);
-          sails = await loadSails(api, { programId: options.program, idl: options.idl });
+          sails = await loadSailsAuto(api, { programId: options.program, idl: options.idl });
         } else {
-          sails = await parseIdlFile(options.idl);
+          sails = await parseIdlFileAuto(options.idl);
         }
 
         const parts = options.method.split('/');
@@ -55,7 +59,7 @@ export function registerEncodeCommand(program: Command): void {
         }
 
         const rawArgs = Array.isArray(parsedValue) ? parsedValue : [parsedValue];
-        const args = coerceArgs(rawArgs, func.args, sails);
+        const args = coerceArgsAuto(rawArgs, func.args, sails);
         const encoded = func.encodePayload(...args);
 
         output({ encoded });
@@ -114,7 +118,7 @@ export function registerEncodeCommand(program: Command): void {
         const api = await getApi(opts.ws);
         const programId = options.program || '0x0000000000000000000000000000000000000000000000000000000000000000';
 
-        const sails = await loadSails(api, { programId, idl: options.idl });
+        const sails = await loadSailsAuto(api, { programId, idl: options.idl });
 
         const parts = options.method.split('/');
         if (parts.length !== 2) {
@@ -131,7 +135,20 @@ export function registerEncodeCommand(program: Command): void {
           throw new CliError(`Method "${methodName}" not found in "${serviceName}"`, 'METHOD_NOT_FOUND');
         }
 
-        const decoded = func.decodeResult(hex as `0x${string}`);
+        let decoded: unknown;
+        try {
+          decoded = func.decodeResult(hex as `0x${string}`);
+        } catch (err) {
+          // v2 decodeResult expects a 16-byte SailsMessageHeader prefix at the
+          // start of the bytes (see sails-js v1.0.0-beta.1 sails-idl-v2.ts).
+          // Surface a clean error so users know what input shape is expected.
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new CliError(
+            `Failed to decode payload: ${msg}\n` +
+            'If this is a v2 IDL, ensure the hex includes the 16-byte SailsMessageHeader prefix that reply messages carry.',
+            'DECODE_ERROR',
+          );
+        }
 
         output({ decoded });
       } else if (options.metadata) {

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -1,12 +1,9 @@
 import { Command } from 'commander';
 import { ProgramMetadata } from '@gear-js/api';
-import type { Sails, SailsProgram } from 'sails-js';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
-import { loadSailsAuto, parseIdlFileAuto, isSailsV2 } from '../services/sails';
+import { loadSailsAuto, parseIdlFileAuto, isSailsV2, type LoadedSails } from '../services/sails';
 import { output, verbose, CliError, tryHexToText, coerceArgsAuto } from '../utils';
-
-type LoadedSails = Sails | SailsProgram;
 
 export function registerEncodeCommand(program: Command): void {
   program
@@ -59,7 +56,7 @@ export function registerEncodeCommand(program: Command): void {
         }
 
         const rawArgs = Array.isArray(parsedValue) ? parsedValue : [parsedValue];
-        const args = coerceArgsAuto(rawArgs, func.args, sails);
+        const args = coerceArgsAuto(rawArgs, func.args, sails, serviceName);
         const encoded = func.encodePayload(...args);
 
         output({ encoded });

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -3,7 +3,7 @@ import { ProgramMetadata } from '@gear-js/api';
 import type { Sails, SailsProgram } from 'sails-js';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
-import { loadSailsAuto, parseIdlFileAuto } from '../services/sails';
+import { loadSailsAuto, parseIdlFileAuto, isSailsV2 } from '../services/sails';
 import { output, verbose, CliError, tryHexToText, coerceArgsAuto } from '../utils';
 
 type LoadedSails = Sails | SailsProgram;
@@ -139,13 +139,16 @@ export function registerEncodeCommand(program: Command): void {
         try {
           decoded = func.decodeResult(hex as `0x${string}`);
         } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
           // v2 decodeResult expects a 16-byte SailsMessageHeader prefix at the
           // start of the bytes (see sails-js v1.0.0-beta.1 sails-idl-v2.ts).
-          // Surface a clean error so users know what input shape is expected.
-          const msg = err instanceof Error ? err.message : String(err);
+          // Surface the hint only when we know the IDL is v2 — v1 users
+          // would find the header reference misleading.
+          const hint = isSailsV2(sails)
+            ? '\nIf this is a v2 reply, ensure the hex includes the 16-byte SailsMessageHeader prefix that reply messages carry.'
+            : '';
           throw new CliError(
-            `Failed to decode payload: ${msg}\n` +
-            'If this is a v2 IDL, ensure the hex includes the 16-byte SailsMessageHeader prefix that reply messages carry.',
+            `Failed to decode payload: ${msg}${hint}`,
             'DECODE_ERROR',
           );
         }

--- a/src/commands/mailbox.ts
+++ b/src/commands/mailbox.ts
@@ -54,8 +54,7 @@ export function registerMailboxCommand(program: Command): void {
 
       verbose(`Claiming value from message ${messageId}`);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tx = (api.mailbox as any).claimValue(messageId as `0x${string}`);
+      const tx = api.mailbox.claimValue(messageId as `0x${string}`);
       const result = await executeTx(api, tx, account);
 
       output({

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -3,9 +3,9 @@ import { ProgramMetadata } from '@gear-js/api';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
 import { resolveAccount, AccountOptions } from '../services/account';
-import { parseIdlFile } from '../services/sails';
+import { parseIdlFileAuto } from '../services/sails';
 import { executeTx } from '../services/tx-executor';
-import { output, verbose, CliError, resolveAmount, addressToHex, coerceArgs } from '../utils';
+import { output, verbose, CliError, resolveAmount, addressToHex, coerceArgsAuto } from '../utils';
 
 export interface InitOptions {
   payload: string;
@@ -25,7 +25,7 @@ export async function resolveInitPayload(options: InitOptions): Promise<string> 
     throw new CliError('--payload and --idl are mutually exclusive. Use --idl with --args for Sails encoding, or --payload for raw hex.', 'MUTUALLY_EXCLUSIVE_OPTIONS');
   }
 
-  const sails = await parseIdlFile(options.idl);
+  const sails = await parseIdlFileAuto(options.idl);
   const ctors = sails.ctors;
   if (!ctors || Object.keys(ctors).length === 0) {
     throw new CliError('IDL has no constructors defined', 'NO_CONSTRUCTORS');
@@ -72,7 +72,7 @@ export async function resolveInitPayload(options: InitOptions): Promise<string> 
   }
 
   verbose(`Encoding constructor "${initName}" with ${args.length} arg(s)`);
-  args = coerceArgs(args, ctor.args || [], sails);
+  args = coerceArgsAuto(args, ctor.args || [], sails);
   try {
     return ctor.encodePayload(...args);
   } catch (err) {

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -145,9 +145,16 @@ export async function loadSailsV2(
 /**
  * Load a Sails IDL, auto-detecting version.
  *
- * Detection strategy: text marker first, then parser-try fallback.
- * If the IDL has no `!@sails:` directive, we try v1 first (no WASM init cost)
- * and fall back to v2 on parse failure, preserving both error messages.
+ * Detection strategy:
+ *   1. If the IDL source contains a `!@sails:` directive, try v2 first.
+ *      On parse failure, fall back to v1 — the directive match is
+ *      permissive (matches on any line) so a v1 IDL that happens to
+ *      embed `!@sails:` in a doc comment still gets a clean load.
+ *   2. Otherwise try v1 first (no WASM init cost), fall back to v2 on
+ *      parse failure.
+ *
+ * When both parsers reject the input, the combined error preserves
+ * both messages so users can see which parser complained about what.
  */
 export async function loadSailsAuto(
   api: GearApi,
@@ -163,21 +170,21 @@ export async function loadSailsAuto(
   const idlString = await resolveIdl(api, { ...options, programId }, null);
   const version = detectIdlVersion(idlString);
 
-  if (version === 'v2') {
-    return buildV2FromIdl(api, programId, idlString);
-  }
+  const primary = version === 'v2' ? buildV2FromIdl : buildV1FromIdl;
+  const secondary = version === 'v2' ? buildV1FromIdl : buildV2FromIdl;
+  const primaryLabel = version === 'v2' ? 'v2' : 'v1';
+  const secondaryLabel = version === 'v2' ? 'v1' : 'v2';
 
-  // 'unknown' — try v1 first (no WASM init), fall back to v2.
   try {
-    return await buildV1FromIdl(api, programId, idlString);
-  } catch (v1Err) {
+    return await primary(api, programId, idlString);
+  } catch (primaryErr) {
     try {
-      return await buildV2FromIdl(api, programId, idlString);
-    } catch (v2Err) {
-      const v1Msg = v1Err instanceof Error ? v1Err.message : String(v1Err);
-      const v2Msg = v2Err instanceof Error ? v2Err.message : String(v2Err);
+      return await secondary(api, programId, idlString);
+    } catch (secondaryErr) {
+      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+      const secondaryMsg = secondaryErr instanceof Error ? secondaryErr.message : String(secondaryErr);
       throw new CliError(
-        `IDL parse failed on both v1 and v2 parsers.\n  v1: ${v1Msg}\n  v2: ${v2Msg}`,
+        `IDL parse failed on both v1 and v2 parsers.\n  ${primaryLabel}: ${primaryMsg}\n  ${secondaryLabel}: ${secondaryMsg}`,
         'IDL_PARSE_ERROR',
       );
     }
@@ -340,38 +347,43 @@ export async function parseIdlFileV2(idlPath: string): Promise<SailsProgram> {
 /**
  * Parse a local IDL file, auto-detecting version.
  * Used by offline flows (ctor encoding, encode/decode commands).
+ *
+ * Uses the same directive-first-with-fallback strategy as `loadSailsAuto`:
+ * when the `!@sails:` directive is present we try v2 first but fall back
+ * to v1 on parse failure (the directive match is permissive, so a v1 IDL
+ * with the directive text in a doc comment still loads). When the
+ * directive is absent we try v1 first, fall back to v2.
  */
+async function buildV1FromIdlString(idlString: string): Promise<Sails> {
+  const parser = await getV1Parser();
+  const sails = new Sails(parser);
+  sails.parseIdl(idlString);
+  return sails;
+}
+async function buildV2FromIdlString(idlString: string): Promise<SailsProgram> {
+  const parser = await getV2Parser();
+  return new SailsProgram(parser.parse(idlString));
+}
+
 export async function parseIdlFileAuto(idlPath: string): Promise<LoadedSails> {
   const idlString = await readIdlFile(idlPath);
   const version = detectIdlVersion(idlString);
 
-  if (version === 'v2') {
-    const parser = await getV2Parser();
-    try {
-      return new SailsProgram(parser.parse(idlString));
-    } catch (err) {
-      throw new CliError(
-        `Failed to parse IDL: ${err instanceof Error ? err.message : String(err)}`,
-        'IDL_PARSE_ERROR',
-      );
-    }
-  }
+  const primary = version === 'v2' ? buildV2FromIdlString : buildV1FromIdlString;
+  const secondary = version === 'v2' ? buildV1FromIdlString : buildV2FromIdlString;
+  const primaryLabel = version === 'v2' ? 'v2' : 'v1';
+  const secondaryLabel = version === 'v2' ? 'v1' : 'v2';
 
-  // 'unknown' — try v1 first, fall back to v2.
   try {
-    const parser = await getV1Parser();
-    const sails = new Sails(parser);
-    sails.parseIdl(idlString);
-    return sails;
-  } catch (v1Err) {
+    return await primary(idlString);
+  } catch (primaryErr) {
     try {
-      const parser = await getV2Parser();
-      return new SailsProgram(parser.parse(idlString));
-    } catch (v2Err) {
-      const v1Msg = v1Err instanceof Error ? v1Err.message : String(v1Err);
-      const v2Msg = v2Err instanceof Error ? v2Err.message : String(v2Err);
+      return await secondary(idlString);
+    } catch (secondaryErr) {
+      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+      const secondaryMsg = secondaryErr instanceof Error ? secondaryErr.message : String(secondaryErr);
       throw new CliError(
-        `IDL parse failed on both v1 and v2 parsers.\n  v1: ${v1Msg}\n  v2: ${v2Msg}`,
+        `IDL parse failed on both v1 and v2 parsers.\n  ${primaryLabel}: ${primaryMsg}\n  ${secondaryLabel}: ${secondaryMsg}`,
         'IDL_PARSE_ERROR',
       );
     }
@@ -406,31 +418,62 @@ export function getSailsVersion(sails: LoadedSails): 'v1' | 'v2' {
 }
 
 /**
+ * Per-instance cache of resolved type maps keyed by service scope.
+ * Scoping matters for v2 because same-name types in different services
+ * would otherwise collide in a flat global map.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const registryTypesCache = new WeakMap<LoadedSails, Map<string, Map<string, any>>>();
+
+/**
  * Get the type-name → user-defined-type map for a loaded Sails instance.
  *
- * - v1: reads `sails._program.types` (existing hex-bytes.ts pattern).
- * - v2: merges both `_doc.program.types` (ambient, rare) and
- *   `_doc.services[i].types` (per-service, the common case in IDL v2).
- *   Both reach into private fields — stable within the 1.0.0-beta line
- *   and mirrors v1's access pattern.
+ * - v1: reads `sails._program.types` (global flat map; v1 has no service
+ *   type scoping). The `serviceName` arg is ignored for v1.
+ * - v2: types live on `_doc.program.types` (program-level, rare) and on
+ *   `_doc.services[i].types` (per-service, the common case). When
+ *   `serviceName` is provided, the result includes program-level types
+ *   PLUS only that service's types — this avoids cross-service
+ *   collisions when two services declare the same-named struct/enum.
+ *   When `serviceName` is omitted, all service types are flattened
+ *   (caller accepts the collision risk; useful for global lookups like
+ *   describeSailsProgram iteration).
+ *
+ * Both branches reach into private fields — stable within the
+ * 1.0.0-beta line and mirrors v1's access pattern. Results are cached
+ * per (instance, scope) pair via a WeakMap so subsequent calls are O(1).
  *
  * Returns an empty map if the IDL has no user-defined types.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getRegistryTypes(sails: LoadedSails): Map<string, any> {
+export function getRegistryTypes(sails: LoadedSails, serviceName?: string): Map<string, any> {
+  const cacheKey = serviceName ?? '__all__';
+  let scopedCache = registryTypesCache.get(sails);
+  if (!scopedCache) {
+    scopedCache = new Map();
+    registryTypesCache.set(sails, scopedCache);
+  }
+  const cached = scopedCache.get(cacheKey);
+  if (cached) return cached;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const map = new Map<string, any>();
   if (isSailsV2(sails)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const doc = (sails as any)._doc;
-    // Ambient types on the program block (rare).
+    // Program-level types (ambient — visible to every service + ctors).
     const programTypes = doc?.program?.types as Array<{ name: string }> | undefined;
     if (programTypes) for (const t of programTypes) map.set(t.name, t);
-    // Per-service types (where IDL v2 most commonly declares them).
-    const services = doc?.services as Array<{ types?: Array<{ name: string }> }> | undefined;
+    // Service-local types.
+    const services = doc?.services as Array<{ name?: string; types?: Array<{ name: string }> }> | undefined;
     if (services) {
-      for (const svc of services) {
-        if (svc.types) for (const t of svc.types) map.set(t.name, t);
+      if (serviceName) {
+        const target = services.find((s) => s.name === serviceName);
+        if (target?.types) for (const t of target.types) map.set(t.name, t);
+      } else {
+        for (const svc of services) {
+          if (svc.types) for (const t of svc.types) map.set(t.name, t);
+        }
       }
     }
   } else {
@@ -440,6 +483,7 @@ export function getRegistryTypes(sails: LoadedSails): Map<string, any> {
       for (const t of types) map.set(t.name, t.def);
     }
   }
+  scopedCache.set(cacheKey, map);
   return map;
 }
 
@@ -540,6 +584,53 @@ interface EventLike {
 }
 
 /**
+ * Render a single event's payload type as a human-readable string.
+ *
+ * sails-js v2 puts the pre-rendered string in `event.type` for unit
+ * variants (`'Null'`) and single-unnamed payloads (`'u32'`). For events
+ * with named fields (`Walked { from: (i32,i32), to: (i32,i32) }`)
+ * `event.type` is a struct-def object and `event.typeDef` is the raw
+ * `IServiceEvent` — neither is a TypeDecl the TypeResolver can stringify.
+ * We walk `typeDef.fields` explicitly and render a `{name: type, ...}`
+ * struct form that matches the v1 output style.
+ *
+ * v1 events have no `.type` field; the v1 walker handles them via
+ * `describeType(sails, event.typeDef)`.
+ */
+function renderEventType(sails: LoadedSails, event: EventLike): string {
+  // v2: fast path when the library already stringified the type.
+  if (typeof event.type === 'string') return event.type;
+
+  // v2 named-field case: typeDef is IServiceEvent with a `fields` array.
+  if (isSailsV2(sails)) {
+    const typeDef = event.typeDef as { fields?: Array<{ name?: string; type: unknown }> } | undefined;
+    const fields = typeDef?.fields;
+    if (Array.isArray(fields) && fields.length > 0) {
+      // All fields named: render as struct.
+      if (fields.every((f) => typeof f.name === 'string' && f.name.length > 0)) {
+        const parts = fields.map((f) => `${f.name}: ${describeType(sails, f.type)}`);
+        return `{ ${parts.join(', ')} }`;
+      }
+      // All fields unnamed: render as tuple.
+      if (fields.every((f) => !f.name)) {
+        const parts = fields.map((f) => describeType(sails, f.type));
+        return parts.length === 1 ? parts[0] : `(${parts.join(', ')})`;
+      }
+      // Mixed: fall back to struct form, skipping unnamed slots.
+      const parts = fields.map((f, i) => `${f.name ?? `_${i}`}: ${describeType(sails, f.type)}`);
+      return `{ ${parts.join(', ')} }`;
+    }
+    // Empty fields on a v2 event means unit variant; library usually
+    // emits 'Null' as the pre-rendered string so we shouldn't hit this
+    // branch, but be defensive.
+    return 'Null';
+  }
+
+  // v1 fallback: walk the v1 TypeDef accessor shape.
+  return describeType(sails, event.typeDef);
+}
+
+/**
  * Build a structured description of all services in a Sails program.
  * Shape is identical across v1 and v2 for consumers like the discover command.
  */
@@ -575,15 +666,8 @@ export function describeSailsProgram(sails: LoadedSails): Record<string, unknown
     }
 
     for (const [eventName, event] of Object.entries(service.events)) {
-      // v2 events expose `.type` as a pre-rendered string from the
-      // TypeResolver (see sails-idl-v2.ts); prefer it when available.
-      // v1 events have no such property — fall back to walking `.typeDef`.
-      const typeStr =
-        typeof event.type === 'string'
-          ? event.type
-          : describeType(sails, event.typeDef);
       events[eventName] = {
-        type: typeStr,
+        type: renderEventType(sails, event),
         docs: event.docs || null,
       };
     }

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -8,27 +8,68 @@ import { readConfig } from './config';
 import { BUNDLED_VFT_IDLS } from '../idl/bundled-idls';
 
 export type LoadedSails = Sails | SailsProgram;
-export type IdlVersion = 'v1' | 'v2' | 'unknown';
+/**
+ * Outcome of the text-level IDL version probe.
+ *
+ * - `'v2'` — the IDL source starts with a `!@sails:` directive.
+ * - `'unknown'` — no directive present. v1 IDLs, malformed IDLs, and
+ *   (hypothetically) a v2 IDL served without the header all land here;
+ *   callers disambiguate by trying the v1 parser first and falling
+ *   back to v2.
+ *
+ * Note: the probe never returns `'v1'` directly because v1 IDLs carry
+ * no version marker. Treating the v1 case as `'unknown'` keeps the
+ * parser-try fallback as the single source of truth.
+ */
+export type IdlVersion = 'v2' | 'unknown';
 
 let v1ParserPromise: Promise<V1Parser> | null = null;
 let v2ParserPromise: Promise<V2Parser> | null = null;
 
-async function getV1Parser(): Promise<V1Parser> {
-  if (!v1ParserPromise) {
-    v1ParserPromise = V1Parser.new();
+/**
+ * Lazily instantiate a parser and cache the in-flight promise so callers
+ * share one initialization. If init rejects we reset the slot to null so
+ * the next caller can retry — otherwise a transient WASM-decompression
+ * hiccup would leave the process permanently wedged on a rejected
+ * promise.
+ */
+async function memoParser<T>(slot: () => Promise<T> | null, set: (p: Promise<T> | null) => void, init: () => Promise<T>): Promise<T> {
+  let promise = slot();
+  if (!promise) {
+    promise = init();
+    set(promise);
+    promise.catch(() => set(null));
   }
-  return v1ParserPromise;
+  return promise;
+}
+
+async function getV1Parser(): Promise<V1Parser> {
+  return memoParser(
+    () => v1ParserPromise,
+    (p) => { v1ParserPromise = p; },
+    () => V1Parser.new(),
+  );
 }
 
 async function getV2Parser(): Promise<V2Parser> {
-  if (!v2ParserPromise) {
-    v2ParserPromise = (async () => {
+  return memoParser(
+    () => v2ParserPromise,
+    (p) => { v2ParserPromise = p; },
+    async () => {
       const parser = new V2Parser();
       await parser.init();
       return parser;
-    })();
-  }
-  return v2ParserPromise;
+    },
+  );
+}
+
+/**
+ * Test-only helper: clear the cached parser promises. Not exported via
+ * utils/index.ts because callers outside of tests should never need it.
+ */
+export function _resetParserCache(): void {
+  v1ParserPromise = null;
+  v2ParserPromise = null;
 }
 
 /**
@@ -125,13 +166,8 @@ export async function loadSailsAuto(
   if (version === 'v2') {
     return buildV2FromIdl(api, programId, idlString);
   }
-  if (version === 'v1') {
-    // Cannot currently happen — detectIdlVersion never returns 'v1' explicitly.
-    // Reserved for future expansion if upstream adds a v1 marker.
-    return buildV1FromIdl(api, programId, idlString);
-  }
 
-  // 'unknown' — try v1 first, fall back to v2.
+  // 'unknown' — try v1 first (no WASM init), fall back to v2.
   try {
     return await buildV1FromIdl(api, programId, idlString);
   } catch (v1Err) {
@@ -159,8 +195,16 @@ async function buildV1FromIdl(api: GearApi, programId: `0x${string}`, idlString:
 
 async function buildV2FromIdl(api: GearApi, programId: `0x${string}`, idlString: string): Promise<SailsProgram> {
   const parser = await getV2Parser();
-  const doc = parser.parse(idlString);
-  const program = new SailsProgram(doc);
+  let program: SailsProgram;
+  try {
+    const doc = parser.parse(idlString);
+    program = new SailsProgram(doc);
+  } catch (err) {
+    throw new CliError(
+      `Failed to parse IDL: ${err instanceof Error ? err.message : String(err)}`,
+      'IDL_PARSE_ERROR',
+    );
+  }
   program.setApi(api);
   program.setProgramId(programId);
   return program;
@@ -303,7 +347,14 @@ export async function parseIdlFileAuto(idlPath: string): Promise<LoadedSails> {
 
   if (version === 'v2') {
     const parser = await getV2Parser();
-    return new SailsProgram(parser.parse(idlString));
+    try {
+      return new SailsProgram(parser.parse(idlString));
+    } catch (err) {
+      throw new CliError(
+        `Failed to parse IDL: ${err instanceof Error ? err.message : String(err)}`,
+        'IDL_PARSE_ERROR',
+      );
+    }
   }
 
   // 'unknown' — try v1 first, fall back to v2.
@@ -358,8 +409,10 @@ export function getSailsVersion(sails: LoadedSails): 'v1' | 'v2' {
  * Get the type-name → user-defined-type map for a loaded Sails instance.
  *
  * - v1: reads `sails._program.types` (existing hex-bytes.ts pattern).
- * - v2: reads `(program as any)._doc.program.types` (private but stable across
- *   the 1.0.0-beta line; mirrors v1's private access pattern).
+ * - v2: merges both `_doc.program.types` (ambient, rare) and
+ *   `_doc.services[i].types` (per-service, the common case in IDL v2).
+ *   Both reach into private fields — stable within the 1.0.0-beta line
+ *   and mirrors v1's access pattern.
  *
  * Returns an empty map if the IDL has no user-defined types.
  */

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -1,18 +1,46 @@
 import { GearApi } from '@gear-js/api';
-import { Sails } from 'sails-js';
-import { SailsIdlParser } from 'sails-js-parser';
+import { Sails, SailsProgram } from 'sails-js';
+import { SailsIdlParser as V1Parser } from 'sails-js-parser';
+import { SailsIdlParser as V2Parser } from 'sails-js/parser';
 import * as fs from 'fs';
 import { CliError, verbose, addressToHex } from '../utils';
 import { readConfig } from './config';
 import { BUNDLED_VFT_IDLS } from '../idl/bundled-idls';
 
-let parserPromise: Promise<SailsIdlParser> | null = null;
+export type LoadedSails = Sails | SailsProgram;
+export type IdlVersion = 'v1' | 'v2' | 'unknown';
 
-async function getParser(): Promise<SailsIdlParser> {
-  if (!parserPromise) {
-    parserPromise = SailsIdlParser.new();
+let v1ParserPromise: Promise<V1Parser> | null = null;
+let v2ParserPromise: Promise<V2Parser> | null = null;
+
+async function getV1Parser(): Promise<V1Parser> {
+  if (!v1ParserPromise) {
+    v1ParserPromise = V1Parser.new();
   }
-  return parserPromise;
+  return v1ParserPromise;
+}
+
+async function getV2Parser(): Promise<V2Parser> {
+  if (!v2ParserPromise) {
+    v2ParserPromise = (async () => {
+      const parser = new V2Parser();
+      await parser.init();
+      return parser;
+    })();
+  }
+  return v2ParserPromise;
+}
+
+/**
+ * Detect IDL version from the source text.
+ *
+ * v2 IDLs start with a `!@sails: <version>` directive. v1 IDLs have no
+ * version marker. Returns 'unknown' when absent — callers should attempt
+ * v1 parse first (no WASM init), then fall back to v2 on failure.
+ */
+export function detectIdlVersion(idlText: string): IdlVersion {
+  if (/^\s*!@sails:\s*/m.test(idlText)) return 'v2';
+  return 'unknown';
 }
 
 export interface SailsSetupOptions {
@@ -20,7 +48,9 @@ export interface SailsSetupOptions {
   programId: string;
   /** Optional validator for bundled IDL fallback. When provided, bundled IDLs
    *  are tried as a last resort; the validator must return true for the IDL to be accepted.
-   *  Callers typically check that the required method exists in some service. */
+   *  Callers typically check that the required method exists in some service.
+   *
+   *  v1 only — bundled fallback is not supported on v2. */
   idlValidator?: (sails: Sails) => boolean;
   /** Optional bundled IDL strings to try as fallback. When provided, these are used
    *  instead of the default VFT bundled IDLs. Requires idlValidator to be set. */
@@ -28,18 +58,18 @@ export interface SailsSetupOptions {
 }
 
 /**
- * Load and parse a Sails IDL, returning a configured Sails instance.
+ * Load a v1 Sails IDL and return a configured Sails instance.
  *
- * IDL resolution:
+ * IDL resolution cascade:
  * 1. --idl <path> flag (local file)
  * 2. Remote fetch from meta-storage using program's codeId
  * 3. Bundled IDL fallback (only when idlValidator is provided)
  */
-export async function loadSails(
+export async function loadSailsV1(
   api: GearApi,
   options: SailsSetupOptions,
 ): Promise<Sails> {
-  const parser = await getParser();
+  const parser = await getV1Parser();
   const sails = new Sails(parser);
 
   const programId = addressToHex(options.programId);
@@ -51,10 +81,101 @@ export async function loadSails(
   return sails;
 }
 
+/**
+ * Load a v2 Sails IDL and return a configured SailsProgram instance.
+ *
+ * Same IDL resolution cascade as loadSailsV1, minus the bundled fallback
+ * (no bundled v2 IDLs ship with vara-wallet).
+ */
+export async function loadSailsV2(
+  api: GearApi,
+  options: SailsSetupOptions,
+): Promise<SailsProgram> {
+  const parser = await getV2Parser();
+  const programId = addressToHex(options.programId);
+  const idlString = await resolveIdl(api, { ...options, programId }, null);
+  const doc = parser.parse(idlString);
+  const program = new SailsProgram(doc);
+  program.setApi(api);
+  program.setProgramId(programId);
+  return program;
+}
+
+/**
+ * Load a Sails IDL, auto-detecting version.
+ *
+ * Detection strategy: text marker first, then parser-try fallback.
+ * If the IDL has no `!@sails:` directive, we try v1 first (no WASM init cost)
+ * and fall back to v2 on parse failure, preserving both error messages.
+ */
+export async function loadSailsAuto(
+  api: GearApi,
+  options: SailsSetupOptions,
+): Promise<LoadedSails> {
+  // Bundled fallback path is v1-only. If the caller provided a validator,
+  // stay on the v1 loader so existing vft/dex flows keep working.
+  if (options.idlValidator) {
+    return loadSailsV1(api, options);
+  }
+
+  const programId = addressToHex(options.programId);
+  const idlString = await resolveIdl(api, { ...options, programId }, null);
+  const version = detectIdlVersion(idlString);
+
+  if (version === 'v2') {
+    return buildV2FromIdl(api, programId, idlString);
+  }
+  if (version === 'v1') {
+    // Cannot currently happen — detectIdlVersion never returns 'v1' explicitly.
+    // Reserved for future expansion if upstream adds a v1 marker.
+    return buildV1FromIdl(api, programId, idlString);
+  }
+
+  // 'unknown' — try v1 first, fall back to v2.
+  try {
+    return await buildV1FromIdl(api, programId, idlString);
+  } catch (v1Err) {
+    try {
+      return await buildV2FromIdl(api, programId, idlString);
+    } catch (v2Err) {
+      const v1Msg = v1Err instanceof Error ? v1Err.message : String(v1Err);
+      const v2Msg = v2Err instanceof Error ? v2Err.message : String(v2Err);
+      throw new CliError(
+        `IDL parse failed on both v1 and v2 parsers.\n  v1: ${v1Msg}\n  v2: ${v2Msg}`,
+        'IDL_PARSE_ERROR',
+      );
+    }
+  }
+}
+
+async function buildV1FromIdl(api: GearApi, programId: `0x${string}`, idlString: string): Promise<Sails> {
+  const parser = await getV1Parser();
+  const sails = new Sails(parser);
+  sails.parseIdl(idlString);
+  sails.setApi(api);
+  sails.setProgramId(programId);
+  return sails;
+}
+
+async function buildV2FromIdl(api: GearApi, programId: `0x${string}`, idlString: string): Promise<SailsProgram> {
+  const parser = await getV2Parser();
+  const doc = parser.parse(idlString);
+  const program = new SailsProgram(doc);
+  program.setApi(api);
+  program.setProgramId(programId);
+  return program;
+}
+
+/**
+ * @deprecated Use loadSailsV1 directly (for vft/dex flows with bundled IDLs) or
+ * loadSailsAuto (for generic flows). Alias preserved to keep vft.ts/dex.ts stable.
+ */
+export const loadSails = loadSailsV1;
+
 async function resolveIdl(
   api: GearApi,
   options: SailsSetupOptions,
-  parser: SailsIdlParser,
+  parser: V1Parser | null,
 ): Promise<string> {
   // 1. Local file
   if (options.idl) {
@@ -102,8 +223,8 @@ async function resolveIdl(
     }
   }
 
-  // 3. Bundled IDL fallback (only when a validator is provided)
-  if (options.idlValidator) {
+  // 3. Bundled IDL fallback (v1 only; requires validator + v1 parser).
+  if (options.idlValidator && parser) {
     const idlsToTry = options.bundledIdls ?? BUNDLED_VFT_IDLS;
     verbose('Trying bundled IDLs as fallback...');
     for (const bundledIdl of idlsToTry) {
@@ -139,22 +260,13 @@ async function resolveIdl(
 }
 
 /**
- * Parse a local IDL file without requiring an API connection or programId.
+ * Parse a local IDL v1 file without requiring an API connection or programId.
  * Useful for encoding constructor payloads before deployment.
  */
-export async function parseIdlFile(idlPath: string): Promise<Sails> {
-  const parser = await getParser();
+export async function parseIdlFileV1(idlPath: string): Promise<Sails> {
+  const parser = await getV1Parser();
   const sails = new Sails(parser);
-  let idlString: string;
-  try {
-    idlString = await fs.promises.readFile(idlPath, 'utf-8');
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') {
-      throw new CliError(`IDL file not found: ${idlPath}`, 'IDL_FILE_NOT_FOUND');
-    }
-    throw new CliError(`Failed to read IDL file: ${idlPath}`, 'IDL_FILE_ERROR');
-  }
+  const idlString = await readIdlFile(idlPath);
   try {
     sails.parseIdl(idlString);
   } catch (err) {
@@ -166,11 +278,139 @@ export async function parseIdlFile(idlPath: string): Promise<Sails> {
   return sails;
 }
 
+/** Parse a local IDL v2 file. */
+export async function parseIdlFileV2(idlPath: string): Promise<SailsProgram> {
+  const parser = await getV2Parser();
+  const idlString = await readIdlFile(idlPath);
+  try {
+    const doc = parser.parse(idlString);
+    return new SailsProgram(doc);
+  } catch (err) {
+    throw new CliError(
+      `Failed to parse IDL: ${err instanceof Error ? err.message : String(err)}`,
+      'IDL_PARSE_ERROR',
+    );
+  }
+}
+
 /**
- * Describe a Sails type definition as a human-readable string.
+ * Parse a local IDL file, auto-detecting version.
+ * Used by offline flows (ctor encoding, encode/decode commands).
+ */
+export async function parseIdlFileAuto(idlPath: string): Promise<LoadedSails> {
+  const idlString = await readIdlFile(idlPath);
+  const version = detectIdlVersion(idlString);
+
+  if (version === 'v2') {
+    const parser = await getV2Parser();
+    return new SailsProgram(parser.parse(idlString));
+  }
+
+  // 'unknown' — try v1 first, fall back to v2.
+  try {
+    const parser = await getV1Parser();
+    const sails = new Sails(parser);
+    sails.parseIdl(idlString);
+    return sails;
+  } catch (v1Err) {
+    try {
+      const parser = await getV2Parser();
+      return new SailsProgram(parser.parse(idlString));
+    } catch (v2Err) {
+      const v1Msg = v1Err instanceof Error ? v1Err.message : String(v1Err);
+      const v2Msg = v2Err instanceof Error ? v2Err.message : String(v2Err);
+      throw new CliError(
+        `IDL parse failed on both v1 and v2 parsers.\n  v1: ${v1Msg}\n  v2: ${v2Msg}`,
+        'IDL_PARSE_ERROR',
+      );
+    }
+  }
+}
+
+/** @deprecated Alias for parseIdlFileV1. */
+export const parseIdlFile = parseIdlFileV1;
+
+async function readIdlFile(idlPath: string): Promise<string> {
+  try {
+    return await fs.promises.readFile(idlPath, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      throw new CliError(`IDL file not found: ${idlPath}`, 'IDL_FILE_NOT_FOUND');
+    }
+    throw new CliError(`Failed to read IDL file: ${idlPath}`, 'IDL_FILE_ERROR');
+  }
+}
+
+/** Runtime check: is this a v2 SailsProgram instance? */
+export function isSailsV2(sails: LoadedSails): sails is SailsProgram {
+  return sails instanceof SailsProgram;
+}
+
+/**
+ * Return the IDL version of a loaded Sails instance.
+ */
+export function getSailsVersion(sails: LoadedSails): 'v1' | 'v2' {
+  return isSailsV2(sails) ? 'v2' : 'v1';
+}
+
+/**
+ * Get the type-name → user-defined-type map for a loaded Sails instance.
+ *
+ * - v1: reads `sails._program.types` (existing hex-bytes.ts pattern).
+ * - v2: reads `(program as any)._doc.program.types` (private but stable across
+ *   the 1.0.0-beta line; mirrors v1's private access pattern).
+ *
+ * Returns an empty map if the IDL has no user-defined types.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function describeType(typeDef: any): string {
+export function getRegistryTypes(sails: LoadedSails): Map<string, any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const map = new Map<string, any>();
+  if (isSailsV2(sails)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doc = (sails as any)._doc;
+    // Ambient types on the program block (rare).
+    const programTypes = doc?.program?.types as Array<{ name: string }> | undefined;
+    if (programTypes) for (const t of programTypes) map.set(t.name, t);
+    // Per-service types (where IDL v2 most commonly declares them).
+    const services = doc?.services as Array<{ types?: Array<{ name: string }> }> | undefined;
+    if (services) {
+      for (const svc of services) {
+        if (svc.types) for (const t of svc.types) map.set(t.name, t);
+      }
+    }
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const types = (sails as any)._program?.types as Array<{ name: string; def: unknown }> | undefined;
+    if (types) {
+      for (const t of types) map.set(t.name, t.def);
+    }
+  }
+  return map;
+}
+
+/**
+ * Describe a Sails type definition as a human-readable string.
+ *
+ * v1 walks the TypeDef accessor shape (isPrimitive/asVec/asStruct/…).
+ * v2 delegates to SailsProgram.typeResolver.getTypeDeclString which already
+ * produces a canonical string representation (e.g. "Option<Vec<u8>>").
+ */
+export function describeType(sails: LoadedSails, typeDef: unknown): string {
+  if (isSailsV2(sails)) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return sails.typeResolver.getTypeDeclString(typeDef as any);
+    } catch {
+      return 'unknown';
+    }
+  }
+  return describeTypeV1(typeDef);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function describeTypeV1(typeDef: any): string {
   if (typeDef.isPrimitive) {
     const p = typeDef.asPrimitive;
     if (p.isBool) return 'bool';
@@ -193,25 +433,25 @@ export function describeType(typeDef: any): string {
     if (p.isNull) return 'null';
     return 'primitive';
   }
-  if (typeDef.isOptional) return `Option<${describeType(typeDef.asOptional.def)}>`;
-  if (typeDef.isVec) return `Vec<${describeType(typeDef.asVec.def)}>`;
+  if (typeDef.isOptional) return `Option<${describeTypeV1(typeDef.asOptional.def)}>`;
+  if (typeDef.isVec) return `Vec<${describeTypeV1(typeDef.asVec.def)}>`;
   if (typeDef.isResult) {
-    return `Result<${describeType(typeDef.asResult.ok.def)}, ${describeType(typeDef.asResult.err.def)}>`;
+    return `Result<${describeTypeV1(typeDef.asResult.ok.def)}, ${describeTypeV1(typeDef.asResult.err.def)}>`;
   }
   if (typeDef.isMap) {
-    return `Map<${describeType(typeDef.asMap.key.def)}, ${describeType(typeDef.asMap.value.def)}>`;
+    return `Map<${describeTypeV1(typeDef.asMap.key.def)}, ${describeTypeV1(typeDef.asMap.value.def)}>`;
   }
   if (typeDef.isFixedSizeArray) {
-    return `[${describeType(typeDef.asFixedSizeArray.def)}; ${typeDef.asFixedSizeArray.len}]`;
+    return `[${describeTypeV1(typeDef.asFixedSizeArray.def)}; ${typeDef.asFixedSizeArray.len}]`;
   }
   if (typeDef.isStruct) {
     const struct = typeDef.asStruct;
     if (struct.isTuple) {
-      const fields = struct.fields.map((f: { def: unknown }) => describeType(f.def));
+      const fields = struct.fields.map((f: { def: unknown }) => describeTypeV1(f.def));
       return `(${fields.join(', ')})`;
     }
     const fields = struct.fields.map(
-      (f: { name: string; def: unknown }) => `${f.name}: ${describeType(f.def)}`,
+      (f: { name: string; def: unknown }) => `${f.name}: ${describeTypeV1(f.def)}`,
     );
     return `{ ${fields.join(', ')} }`;
   }
@@ -219,7 +459,7 @@ export function describeType(typeDef: any): string {
     const variants = typeDef.asEnum.variants.map(
       (v: { name: string; def: { isPrimitive?: boolean; asPrimitive?: { isNull?: boolean } } }) => {
         if (v.def?.isPrimitive && v.def.asPrimitive?.isNull) return v.name;
-        return `${v.name}(${describeType(v.def)})`;
+        return `${v.name}(${describeTypeV1(v.def)})`;
       },
     );
     return variants.join(' | ');
@@ -228,42 +468,69 @@ export function describeType(typeDef: any): string {
   return 'unknown';
 }
 
+/** Minimal shape that both v1 Sails.services[X] and v2 SailsProgram.services[X] satisfy. */
+interface ServiceLike {
+  functions: Record<string, FuncLike>;
+  queries: Record<string, FuncLike>;
+  events: Record<string, EventLike>;
+}
+interface FuncLike {
+  args: Array<{ name: string; typeDef: unknown }>;
+  returnTypeDef: unknown;
+  docs?: string;
+}
+interface EventLike {
+  typeDef: unknown;
+  /** Pre-rendered type string (v2) or undefined (v1). Preferred when present. */
+  type?: unknown;
+  docs?: string;
+}
+
 /**
  * Build a structured description of all services in a Sails program.
+ * Shape is identical across v1 and v2 for consumers like the discover command.
  */
-export function describeSailsProgram(sails: Sails): Record<string, unknown> {
+export function describeSailsProgram(sails: LoadedSails): Record<string, unknown> {
   const services: Record<string, unknown> = {};
+  const allServices = sails.services as Record<string, ServiceLike>;
 
-  for (const [serviceName, service] of Object.entries(sails.services)) {
+  for (const [serviceName, service] of Object.entries(allServices)) {
     const functions: Record<string, unknown> = {};
     const queries: Record<string, unknown> = {};
     const events: Record<string, unknown> = {};
 
     for (const [funcName, func] of Object.entries(service.functions)) {
       functions[funcName] = {
-        args: func.args.map((a: { name: string; typeDef: unknown }) => ({
+        args: func.args.map((a) => ({
           name: a.name,
-          type: describeType(a.typeDef),
+          type: describeType(sails, a.typeDef),
         })),
-        returnType: describeType(func.returnTypeDef),
+        returnType: describeType(sails, func.returnTypeDef),
         docs: func.docs || null,
       };
     }
 
     for (const [queryName, query] of Object.entries(service.queries)) {
       queries[queryName] = {
-        args: query.args.map((a: { name: string; typeDef: unknown }) => ({
+        args: query.args.map((a) => ({
           name: a.name,
-          type: describeType(a.typeDef),
+          type: describeType(sails, a.typeDef),
         })),
-        returnType: describeType(query.returnTypeDef),
+        returnType: describeType(sails, query.returnTypeDef),
         docs: query.docs || null,
       };
     }
 
     for (const [eventName, event] of Object.entries(service.events)) {
+      // v2 events expose `.type` as a pre-rendered string from the
+      // TypeResolver (see sails-idl-v2.ts); prefer it when available.
+      // v1 events have no such property — fall back to walking `.typeDef`.
+      const typeStr =
+        typeof event.type === 'string'
+          ? event.type
+          : describeType(sails, event.typeDef);
       events[eventName] = {
-        type: describeType(event.typeDef),
+        type: typeStr,
         docs: event.docs || null,
       };
     }

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -3,7 +3,7 @@ import { Sails, SailsProgram } from 'sails-js';
 import { SailsIdlParser as V1Parser } from 'sails-js-parser';
 import { SailsIdlParser as V2Parser } from 'sails-js/parser';
 import * as fs from 'fs';
-import { CliError, verbose, addressToHex } from '../utils';
+import { CliError, errorMessage, verbose, addressToHex } from '../utils';
 import { readConfig } from './config';
 import { BUNDLED_VFT_IDLS } from '../idl/bundled-idls';
 
@@ -170,51 +170,20 @@ export async function loadSailsAuto(
   const idlString = await resolveIdl(api, { ...options, programId }, null);
   const version = detectIdlVersion(idlString);
 
-  const primary = version === 'v2' ? buildV2FromIdl : buildV1FromIdl;
-  const secondary = version === 'v2' ? buildV1FromIdl : buildV2FromIdl;
-  const primaryLabel = version === 'v2' ? 'v2' : 'v1';
-  const secondaryLabel = version === 'v2' ? 'v1' : 'v2';
+  const bindApi = <T extends LoadedSails>(builder: (idl: string) => Promise<T>) =>
+    async (idl: string): Promise<T> => {
+      const loaded = await builder(idl);
+      loaded.setApi(api);
+      loaded.setProgramId(programId);
+      return loaded;
+    };
 
-  try {
-    return await primary(api, programId, idlString);
-  } catch (primaryErr) {
-    try {
-      return await secondary(api, programId, idlString);
-    } catch (secondaryErr) {
-      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
-      const secondaryMsg = secondaryErr instanceof Error ? secondaryErr.message : String(secondaryErr);
-      throw new CliError(
-        `IDL parse failed on both v1 and v2 parsers.\n  ${primaryLabel}: ${primaryMsg}\n  ${secondaryLabel}: ${secondaryMsg}`,
-        'IDL_PARSE_ERROR',
-      );
-    }
-  }
-}
-
-async function buildV1FromIdl(api: GearApi, programId: `0x${string}`, idlString: string): Promise<Sails> {
-  const parser = await getV1Parser();
-  const sails = new Sails(parser);
-  sails.parseIdl(idlString);
-  sails.setApi(api);
-  sails.setProgramId(programId);
-  return sails;
-}
-
-async function buildV2FromIdl(api: GearApi, programId: `0x${string}`, idlString: string): Promise<SailsProgram> {
-  const parser = await getV2Parser();
-  let program: SailsProgram;
-  try {
-    const doc = parser.parse(idlString);
-    program = new SailsProgram(doc);
-  } catch (err) {
-    throw new CliError(
-      `Failed to parse IDL: ${err instanceof Error ? err.message : String(err)}`,
-      'IDL_PARSE_ERROR',
-    );
-  }
-  program.setApi(api);
-  program.setProgramId(programId);
-  return program;
+  return tryPrimarySecondary(
+    idlString,
+    version,
+    bindApi(buildV1FromIdlString),
+    bindApi(buildV2FromIdlString),
+  );
 }
 
 /**
@@ -310,69 +279,51 @@ async function resolveIdl(
   );
 }
 
-/**
- * Parse a local IDL v1 file without requiring an API connection or programId.
- * Useful for encoding constructor payloads before deployment.
- */
-export async function parseIdlFileV1(idlPath: string): Promise<Sails> {
-  const parser = await getV1Parser();
-  const sails = new Sails(parser);
-  const idlString = await readIdlFile(idlPath);
-  try {
-    sails.parseIdl(idlString);
-  } catch (err) {
-    throw new CliError(
-      `Failed to parse IDL: ${err instanceof Error ? err.message : String(err)}`,
-      'IDL_PARSE_ERROR',
-    );
-  }
-  return sails;
-}
+// ────────────────────────────────────────────────────────────────────
+// Core builders — build a Sails/SailsProgram from an IDL string only.
+// Parse errors propagate untouched; public entry points wrap them in
+// `CliError(IDL_PARSE_ERROR)` where needed so the combined-error format
+// in `tryPrimarySecondary` doesn't double-wrap.
+// ────────────────────────────────────────────────────────────────────
 
-/** Parse a local IDL v2 file. */
-export async function parseIdlFileV2(idlPath: string): Promise<SailsProgram> {
-  const parser = await getV2Parser();
-  const idlString = await readIdlFile(idlPath);
-  try {
-    const doc = parser.parse(idlString);
-    return new SailsProgram(doc);
-  } catch (err) {
-    throw new CliError(
-      `Failed to parse IDL: ${err instanceof Error ? err.message : String(err)}`,
-      'IDL_PARSE_ERROR',
-    );
-  }
-}
-
-/**
- * Parse a local IDL file, auto-detecting version.
- * Used by offline flows (ctor encoding, encode/decode commands).
- *
- * Uses the same directive-first-with-fallback strategy as `loadSailsAuto`:
- * when the `!@sails:` directive is present we try v2 first but fall back
- * to v1 on parse failure (the directive match is permissive, so a v1 IDL
- * with the directive text in a doc comment still loads). When the
- * directive is absent we try v1 first, fall back to v2.
- */
 async function buildV1FromIdlString(idlString: string): Promise<Sails> {
   const parser = await getV1Parser();
   const sails = new Sails(parser);
   sails.parseIdl(idlString);
   return sails;
 }
+
 async function buildV2FromIdlString(idlString: string): Promise<SailsProgram> {
   const parser = await getV2Parser();
   return new SailsProgram(parser.parse(idlString));
 }
 
-export async function parseIdlFileAuto(idlPath: string): Promise<LoadedSails> {
-  const idlString = await readIdlFile(idlPath);
-  const version = detectIdlVersion(idlString);
+async function wrapParse<T>(build: () => Promise<T>): Promise<T> {
+  try {
+    return await build();
+  } catch (err) {
+    throw new CliError(`Failed to parse IDL: ${errorMessage(err)}`, 'IDL_PARSE_ERROR');
+  }
+}
 
-  const primary = version === 'v2' ? buildV2FromIdlString : buildV1FromIdlString;
-  const secondary = version === 'v2' ? buildV1FromIdlString : buildV2FromIdlString;
-  const primaryLabel = version === 'v2' ? 'v2' : 'v1';
-  const secondaryLabel = version === 'v2' ? 'v1' : 'v2';
+/**
+ * Try primary parser first (selected by `version`), fall back to secondary
+ * on failure. When both parsers reject the input, the combined error
+ * preserves both messages so users can see which parser complained about
+ * what. Used by both `loadSailsAuto` (with API-bound builders) and
+ * `parseIdlFileAuto` (with bare builders).
+ */
+async function tryPrimarySecondary(
+  idlString: string,
+  version: IdlVersion,
+  buildV1: (idl: string) => Promise<Sails>,
+  buildV2: (idl: string) => Promise<SailsProgram>,
+): Promise<LoadedSails> {
+  const primaryIsV2 = version === 'v2';
+  const primary = primaryIsV2 ? buildV2 : buildV1;
+  const secondary = primaryIsV2 ? buildV1 : buildV2;
+  const primaryLabel = primaryIsV2 ? 'v2' : 'v1';
+  const secondaryLabel = primaryIsV2 ? 'v1' : 'v2';
 
   try {
     return await primary(idlString);
@@ -380,14 +331,45 @@ export async function parseIdlFileAuto(idlPath: string): Promise<LoadedSails> {
     try {
       return await secondary(idlString);
     } catch (secondaryErr) {
-      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
-      const secondaryMsg = secondaryErr instanceof Error ? secondaryErr.message : String(secondaryErr);
       throw new CliError(
-        `IDL parse failed on both v1 and v2 parsers.\n  ${primaryLabel}: ${primaryMsg}\n  ${secondaryLabel}: ${secondaryMsg}`,
+        `IDL parse failed on both v1 and v2 parsers.\n  ${primaryLabel}: ${errorMessage(primaryErr)}\n  ${secondaryLabel}: ${errorMessage(secondaryErr)}`,
         'IDL_PARSE_ERROR',
       );
     }
   }
+}
+
+/**
+ * Parse a local IDL v1 file without requiring an API connection or programId.
+ * Useful for encoding constructor payloads before deployment.
+ */
+export async function parseIdlFileV1(idlPath: string): Promise<Sails> {
+  const idlString = await readIdlFile(idlPath);
+  return wrapParse(() => buildV1FromIdlString(idlString));
+}
+
+/** Parse a local IDL v2 file. */
+export async function parseIdlFileV2(idlPath: string): Promise<SailsProgram> {
+  const idlString = await readIdlFile(idlPath);
+  return wrapParse(() => buildV2FromIdlString(idlString));
+}
+
+/**
+ * Parse a local IDL file, auto-detecting version.
+ * Used by offline flows (ctor encoding, encode/decode commands).
+ *
+ * Uses the same directive-first-with-fallback strategy as `loadSailsAuto`:
+ * directive present → v2 first, fall back to v1; otherwise v1 first, fall
+ * back to v2.
+ */
+export async function parseIdlFileAuto(idlPath: string): Promise<LoadedSails> {
+  const idlString = await readIdlFile(idlPath);
+  return tryPrimarySecondary(
+    idlString,
+    detectIdlVersion(idlString),
+    buildV1FromIdlString,
+    buildV2FromIdlString,
+  );
 }
 
 /** @deprecated Alias for parseIdlFileV1. */

--- a/src/types/sails-js-parser.d.ts
+++ b/src/types/sails-js-parser.d.ts
@@ -1,0 +1,11 @@
+// Type shim for the `sails-js/parser` subpath export.
+//
+// sails-js 1.0.0-beta.1 publishes the v2 IDL parser under the `exports` field
+// at "./parser". With `moduleResolution: "node"` TypeScript does not respect
+// package `exports`, so we redirect it here.
+//
+// Safe to delete once we migrate to `moduleResolution: "node16"` or "bundler".
+
+declare module 'sails-js/parser' {
+  export * from 'sails-js/lib/parser';
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,12 @@
+/**
+ * Extract a string message from anything that might be thrown. Preferred
+ * over inline `err instanceof Error ? err.message : String(err)` so error
+ * formatting stays consistent across the codebase.
+ */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export class CliError extends Error {
   constructor(
     message: string,

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -1,5 +1,6 @@
 import { SailsProgram, type Sails } from 'sails-js';
 import { CliError } from './errors';
+import { getRegistryTypes } from '../services/sails';
 
 const HEX_RE = /^0x[0-9a-fA-F]+$/;
 
@@ -237,18 +238,49 @@ function isV2ArrayU8(typeDecl: V2TypeDecl): { match: boolean; len?: number } {
   return { match: false };
 }
 
+type V2Substitutions = Map<string, V2TypeDecl>;
+
+/**
+ * Resolve a single-level type_param reference. If `typeDecl` is a bare
+ * named reference (no generics of its own) and its name matches an entry
+ * in `subs`, return the substituted TypeDecl. Otherwise return `typeDecl`
+ * unchanged.
+ *
+ * One-level only: if `subs` maps T → Option<U> and U itself is also a
+ * type_param, the consumer recursion resolves U when it walks into the
+ * Option's inner type.
+ */
+function resolveV2Subs(typeDecl: V2TypeDecl, subs?: V2Substitutions): V2TypeDecl {
+  if (!subs || typeof typeDecl === 'string') return typeDecl;
+  if (typeDecl.kind === 'named' && (!typeDecl.generics || typeDecl.generics.length === 0) && subs.has(typeDecl.name)) {
+    return subs.get(typeDecl.name) as V2TypeDecl;
+  }
+  return typeDecl;
+}
+
 /**
  * v2 equivalent of coerceHexToBytes.
  * Walks a TypeDecl (v2 IDL shape) and converts hex strings to byte arrays
  * for `vec u8` (slice<u8>, Vec<u8>) and `[u8; N]` fields.
+ *
+ * `substitutions` carries generic type_param bindings down through the
+ * recursion. When a user-defined type has `type_params` and the call site
+ * supplied matching `generics`, we build a new substitution scope for
+ * that type's body. Type-param references inside field/variant types
+ * resolve against the scope when the walker recurses.
  */
 export function coerceHexToBytesV2(
   value: unknown,
   typeDecl: V2TypeDecl,
   typeMap: V2TypeMap,
   fieldHint?: string,
+  substitutions?: V2Substitutions,
 ): unknown {
   if (value === null || value === undefined) return value;
+
+  // Resolve type_param references at entry so every branch below works
+  // on the fully-substituted TypeDecl.
+  typeDecl = resolveV2Subs(typeDecl, substitutions);
 
   // Slice of u8 → bytes
   if (isV2SliceU8(typeDecl)) {
@@ -280,7 +312,7 @@ export function coerceHexToBytesV2(
   // Slice (non-u8): recurse elements
   if (typeDecl.kind === 'slice') {
     if (Array.isArray(value)) {
-      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint));
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint, substitutions));
     }
     return value;
   }
@@ -288,7 +320,7 @@ export function coerceHexToBytesV2(
   // Array (non-u8): recurse elements
   if (typeDecl.kind === 'array') {
     if (Array.isArray(value)) {
-      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint));
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint, substitutions));
     }
     return value;
   }
@@ -296,7 +328,7 @@ export function coerceHexToBytesV2(
   // Tuple: recurse by index
   if (typeDecl.kind === 'tuple') {
     if (Array.isArray(value)) {
-      return typeDecl.types.map((t, i) => coerceHexToBytesV2((value as unknown[])[i], t, typeMap, fieldHint));
+      return typeDecl.types.map((t, i) => coerceHexToBytesV2((value as unknown[])[i], t, typeMap, fieldHint, substitutions));
     }
     return value;
   }
@@ -305,44 +337,59 @@ export function coerceHexToBytesV2(
   if (typeDecl.kind === 'named') {
     const { name, generics } = typeDecl;
 
-    // Well-known wrappers
+    // Well-known wrappers — pass current substitutions through.
     if (name === 'Option' && generics && generics.length === 1) {
-      return coerceHexToBytesV2(value, generics[0], typeMap, fieldHint);
+      return coerceHexToBytesV2(value, generics[0], typeMap, fieldHint, substitutions);
     }
     if (name === 'Result' && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
       const obj = value as Record<string, unknown>;
-      if ('ok' in obj) return { ok: coerceHexToBytesV2(obj.ok, generics[0], typeMap, 'ok') };
-      if ('err' in obj) return { err: coerceHexToBytesV2(obj.err, generics[1], typeMap, 'err') };
+      if ('ok' in obj) return { ok: coerceHexToBytesV2(obj.ok, generics[0], typeMap, 'ok', substitutions) };
+      if ('err' in obj) return { err: coerceHexToBytesV2(obj.err, generics[1], typeMap, 'err', substitutions) };
       return value;
     }
     if (name === 'Vec' && generics && generics.length === 1) {
+      // Resolve once so isV2PrimitiveU8 sees the substituted inner type.
+      const inner = resolveV2Subs(generics[0], substitutions);
       // Vec<u8> → bytes via hex coercion
-      if (isV2PrimitiveU8(generics[0])) {
+      if (isV2PrimitiveU8(inner)) {
         if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
           return hexToBytes(value, fieldHint);
         }
         return value;
       }
       if (Array.isArray(value)) {
-        return value.map((item) => coerceHexToBytesV2(item, generics[0], typeMap, fieldHint));
+        return value.map((item) => coerceHexToBytesV2(item, inner, typeMap, fieldHint, substitutions));
       }
       return value;
     }
     if ((name === 'Map' || name === 'BTreeMap' || name === 'HashMap') && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
       const result: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-        result[k] = coerceHexToBytesV2(v, generics[1], typeMap, k);
+        result[k] = coerceHexToBytesV2(v, generics[1], typeMap, k, substitutions);
       }
       return result;
     }
 
-    // User-defined type: look up in type map and recurse
+    // User-defined type: look up in type map and recurse.
     const userType = typeMap.get(name);
     if (!userType) return value; // Unknown type, pass through
 
-    // Alias: recurse into target
+    // Build a new substitution scope from this type's type_params. Resolve
+    // each supplied generic through the OUTER substitutions first (so
+    // a caller-side `Foo<T>` where T is an outer type_param binds to the
+    // outer value, not to the literal T).
+    let nextSubs = substitutions;
+    const typeParams = (userType.type_params ?? []) as Array<{ name: string }>;
+    if (typeParams.length > 0 && generics && generics.length === typeParams.length) {
+      nextSubs = new Map();
+      for (let i = 0; i < typeParams.length; i++) {
+        nextSubs.set(typeParams[i].name, resolveV2Subs(generics[i], substitutions));
+      }
+    }
+
+    // Alias: recurse into target with the new substitution scope.
     if (userType.kind === 'alias' && userType.target) {
-      return coerceHexToBytesV2(value, userType.target, typeMap, fieldHint);
+      return coerceHexToBytesV2(value, userType.target, typeMap, fieldHint, nextSubs);
     }
 
     // Struct: recurse into fields
@@ -351,7 +398,7 @@ export function coerceHexToBytesV2(
       const result: Record<string, unknown> = { ...(value as Record<string, unknown>) };
       for (const field of fields) {
         if (field.name && field.name in result) {
-          result[field.name] = coerceHexToBytesV2(result[field.name], field.type, typeMap, field.name);
+          result[field.name] = coerceHexToBytesV2(result[field.name], field.type, typeMap, field.name, nextSubs);
         }
       }
       return result;
@@ -360,7 +407,7 @@ export function coerceHexToBytesV2(
     // Struct (tuple-shaped — all fields unnamed): recurse by index
     if (userType.kind === 'struct' && userType.fields && Array.isArray(value)) {
       const fields = userType.fields as Array<{ name?: string; type: V2TypeDecl }>;
-      return fields.map((f, i) => coerceHexToBytesV2((value as unknown[])[i], f.type, typeMap, f.name));
+      return fields.map((f, i) => coerceHexToBytesV2((value as unknown[])[i], f.type, typeMap, f.name, nextSubs));
     }
 
     // Enum: match variant and recurse into payload fields
@@ -375,21 +422,21 @@ export function coerceHexToBytesV2(
           const payload = obj[variant.name];
           if (variant.fields.length === 1 && !variant.fields[0].name) {
             // Single unnamed field: payload is the raw value
-            return { [variant.name]: coerceHexToBytesV2(payload, variant.fields[0].type, typeMap, variant.name) };
+            return { [variant.name]: coerceHexToBytesV2(payload, variant.fields[0].type, typeMap, variant.name, nextSubs) };
           }
           // Struct-shaped variant payload
           if (typeof payload === 'object' && payload !== null && !Array.isArray(payload)) {
             const result: Record<string, unknown> = { ...(payload as Record<string, unknown>) };
             for (const f of variant.fields) {
               if (f.name && f.name in result) {
-                result[f.name] = coerceHexToBytesV2(result[f.name], f.type, typeMap, f.name);
+                result[f.name] = coerceHexToBytesV2(result[f.name], f.type, typeMap, f.name, nextSubs);
               }
             }
             return { [variant.name]: result };
           }
           // Tuple-shaped variant payload (array)
           if (Array.isArray(payload)) {
-            return { [variant.name]: variant.fields.map((f, i) => coerceHexToBytesV2((payload as unknown[])[i], f.type, typeMap, f.name)) };
+            return { [variant.name]: variant.fields.map((f, i) => coerceHexToBytesV2((payload as unknown[])[i], f.type, typeMap, f.name, nextSubs)) };
           }
           return value;
         }
@@ -406,36 +453,27 @@ export function coerceHexToBytesV2(
 /**
  * Coerce args for a Sails v2 method/constructor call.
  *
- * Merges user-defined types from both possible declaration sites in the
- * parsed IDL document (private `_doc` field, stable within the
- * 1.0.0-beta line — mirrors v1's `_program.types` access pattern):
- *   - `_doc.program.types` — program-level / ambient types (rare).
- *   - `_doc.services[i].types` — per-service types, which is where v2
- *     IDLs normally declare struct / enum / alias shapes.
+ * When `serviceName` is provided, the type map is scoped to that
+ * service's types + program-level types — avoiding collisions when
+ * two services declare the same-named struct. Pass undefined for
+ * ctor encoding (ctors are program-level) or when the caller accepts
+ * the flatten-all-services semantics.
+ *
+ * Type lookups route through `getRegistryTypes` (memoized per
+ * instance+scope) so the private-`_doc` walk happens in exactly one
+ * place in the codebase.
  */
 export function coerceArgsV2(
   args: unknown[],
   argDefs: Array<{ name: string; typeDef: V2TypeDecl }>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  program: any,
+  program: SailsProgram,
+  serviceName?: string,
 ): unknown[] {
   if (args.length === 0) return args;
 
   let typeMap: V2TypeMap;
   try {
-    typeMap = new Map();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = (program as any)._doc;
-    // Ambient types on the program block.
-    const programTypes = doc?.program?.types as Array<{ name: string }> | undefined;
-    if (programTypes) for (const t of programTypes) typeMap.set(t.name, t);
-    // Per-service types (v2 usually declares types inside a service block).
-    const services = doc?.services as Array<{ types?: Array<{ name: string }> }> | undefined;
-    if (services) {
-      for (const svc of services) {
-        if (svc.types) for (const t of svc.types) typeMap.set(t.name, t);
-      }
-    }
+    typeMap = getRegistryTypes(program, serviceName);
   } catch {
     return args; // Graceful fallback
   }
@@ -449,15 +487,20 @@ export function coerceArgsV2(
 /**
  * Dispatch coerceArgs to the v1 or v2 walker based on the Sails instance type.
  * This is what generic commands (call, encode, program) should call.
+ *
+ * `serviceName` is v2-only — it narrows the type map to one service's
+ * types to avoid cross-service name collisions. Ignored for v1 (which
+ * has a single global type namespace).
  */
 export function coerceArgsAuto(
   args: unknown[],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   argDefs: Array<{ name: string; typeDef: any }>,
   sails: Sails | SailsProgram,
+  serviceName?: string,
 ): unknown[] {
   if (sails instanceof SailsProgram) {
-    return coerceArgsV2(args, argDefs as Array<{ name: string; typeDef: V2TypeDecl }>, sails);
+    return coerceArgsV2(args, argDefs as Array<{ name: string; typeDef: V2TypeDecl }>, sails, serviceName);
   }
   return coerceArgs(args, argDefs, sails);
 }

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -32,6 +32,16 @@ function isFixedU8Array(typeDef: any): { match: boolean; len?: number } {
 }
 
 /**
+ * Is `value` a non-empty `0x`-prefixed hex string? Used to gate the
+ * coercion branches — the bare `0x` sentinel passes through unchanged
+ * (tested behavior), and anything else is left for downstream encoders
+ * to validate in context.
+ */
+function isNonEmptyHex(value: unknown): value is `0x${string}` {
+  return typeof value === 'string' && value.startsWith('0x') && value.length > 2;
+}
+
+/**
  * Convert a hex string to a byte array, with validation.
  */
 function hexToBytes(value: string, fieldHint?: string): number[] {
@@ -49,6 +59,25 @@ function hexToBytes(value: string, fieldHint?: string): number[] {
     );
   }
   return Array.from(Buffer.from(hex, 'hex'));
+}
+
+/**
+ * If `value` is a `0x`-prefixed hex string, convert it to a byte array.
+ * When `expectedLen` is provided, throw if the decoded length doesn't
+ * match — used by `[u8; N]` and fixed-width array branches. Returns
+ * the value unchanged if it isn't a hex string (so downstream encoders
+ * can accept pre-decoded bytes).
+ */
+function tryHexToBytes(value: unknown, fieldHint?: string, expectedLen?: number): unknown {
+  if (!isNonEmptyHex(value)) return value;
+  const bytes = hexToBytes(value, fieldHint);
+  if (expectedLen !== undefined && bytes.length !== expectedLen) {
+    throw new CliError(
+      `Hex string decodes to ${bytes.length} bytes but [u8; ${expectedLen}] expects ${expectedLen} bytes${fieldHint ? ` for "${fieldHint}"` : ''}`,
+      'INVALID_HEX_BYTES',
+    );
+  }
+  return bytes;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,28 +99,11 @@ export function coerceHexToBytes(value: unknown, typeDef: any, typeMap: TypeMap,
   }
 
   // vec u8: convert hex string to byte array
-  if (isVecU8(typeDef)) {
-    if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
-      return hexToBytes(value, fieldHint);
-    }
-    return value;
-  }
+  if (isVecU8(typeDef)) return tryHexToBytes(value, fieldHint);
 
   // [u8; N]: convert hex string to byte array, validate length
   const fixed = isFixedU8Array(typeDef);
-  if (fixed.match) {
-    if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
-      const bytes = hexToBytes(value, fieldHint);
-      if (bytes.length !== fixed.len) {
-        throw new CliError(
-          `Hex string decodes to ${bytes.length} bytes but [u8; ${fixed.len}] expects ${fixed.len} bytes${fieldHint ? ` for "${fieldHint}"` : ''}`,
-          'INVALID_HEX_BYTES',
-        );
-      }
-      return bytes;
-    }
-    return value;
-  }
+  if (fixed.match) return tryHexToBytes(value, fieldHint, fixed.len);
 
   // Struct: recurse into each field
   if (typeDef.isStruct && typeof value === 'object' && !Array.isArray(value)) {
@@ -283,28 +295,11 @@ export function coerceHexToBytesV2(
   typeDecl = resolveV2Subs(typeDecl, substitutions);
 
   // Slice of u8 → bytes
-  if (isV2SliceU8(typeDecl)) {
-    if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
-      return hexToBytes(value, fieldHint);
-    }
-    return value;
-  }
+  if (isV2SliceU8(typeDecl)) return tryHexToBytes(value, fieldHint);
 
   // Fixed array of u8 → bytes with length validation
   const fixed = isV2ArrayU8(typeDecl);
-  if (fixed.match && fixed.len !== undefined) {
-    if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
-      const bytes = hexToBytes(value, fieldHint);
-      if (bytes.length !== fixed.len) {
-        throw new CliError(
-          `Hex string decodes to ${bytes.length} bytes but [u8; ${fixed.len}] expects ${fixed.len} bytes${fieldHint ? ` for "${fieldHint}"` : ''}`,
-          'INVALID_HEX_BYTES',
-        );
-      }
-      return bytes;
-    }
-    return value;
-  }
+  if (fixed.match && fixed.len !== undefined) return tryHexToBytes(value, fieldHint, fixed.len);
 
   // PrimitiveType (string literal): no byte fields to coerce
   if (typeof typeDecl === 'string') return value;
@@ -351,12 +346,7 @@ export function coerceHexToBytesV2(
       // Resolve once so isV2PrimitiveU8 sees the substituted inner type.
       const inner = resolveV2Subs(generics[0], substitutions);
       // Vec<u8> → bytes via hex coercion
-      if (isV2PrimitiveU8(inner)) {
-        if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
-          return hexToBytes(value, fieldHint);
-        }
-        return value;
-      }
+      if (isV2PrimitiveU8(inner)) return tryHexToBytes(value, fieldHint);
       if (Array.isArray(value)) {
         return value.map((item) => coerceHexToBytesV2(item, inner, typeMap, fieldHint, substitutions));
       }

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -1,3 +1,4 @@
+import type { Sails, SailsProgram } from 'sails-js';
 import { CliError } from './errors';
 
 const HEX_RE = /^0x[0-9a-fA-F]+$/;
@@ -159,7 +160,7 @@ export function coerceHexToBytes(value: unknown, typeDef: any, typeMap: TypeMap,
 }
 
 /**
- * Coerce args for a Sails method/constructor call.
+ * Coerce args for a Sails v1 method/constructor call.
  * Walks the IDL type tree alongside the args, converting hex strings to byte arrays
  * for `vec u8` and `[u8; N]` typed fields.
  *
@@ -191,4 +192,271 @@ export function coerceArgs(
     if (i >= argDefs.length) return arg;
     return coerceHexToBytes(arg, argDefs[i].typeDef, typeMap, argDefs[i].name);
   });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// IDL v2 walker — parallel implementation over the new TypeDecl shape.
+//
+// v2 TypeDecl is a discriminated union:
+//   - PrimitiveType (string literal: 'u8' | 'String' | 'ActorId' | …)
+//   - { kind: 'slice',  item: TypeDecl }
+//   - { kind: 'array',  item: TypeDecl, len: number }
+//   - { kind: 'tuple',  types: TypeDecl[] }
+//   - { kind: 'named',  name: string, generics?: TypeDecl[] }
+//
+// User-defined types (from program.types) are separate `Type` entries:
+//   - { kind: 'struct', name, fields: [{name?, type}] }
+//   - { kind: 'enum',   name, variants: [{name, fields: [{name?, type}]}] }
+//   - { kind: 'alias',  name, target: TypeDecl }
+// ────────────────────────────────────────────────────────────────────────
+
+type V2TypeDecl =
+  | string
+  | { kind: 'slice'; item: V2TypeDecl }
+  | { kind: 'array'; item: V2TypeDecl; len: number }
+  | { kind: 'tuple'; types: V2TypeDecl[] }
+  | { kind: 'named'; name: string; generics?: V2TypeDecl[] };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type V2Type = any; // struct | enum | alias — loose to avoid deep type churn
+
+type V2TypeMap = Map<string, V2Type>;
+
+function isV2PrimitiveU8(typeDecl: V2TypeDecl): boolean {
+  return typeof typeDecl === 'string' && typeDecl === 'u8';
+}
+
+function isV2SliceU8(typeDecl: V2TypeDecl): boolean {
+  return typeof typeDecl === 'object' && typeDecl.kind === 'slice' && isV2PrimitiveU8(typeDecl.item);
+}
+
+function isV2ArrayU8(typeDecl: V2TypeDecl): { match: boolean; len?: number } {
+  if (typeof typeDecl === 'object' && typeDecl.kind === 'array' && isV2PrimitiveU8(typeDecl.item)) {
+    return { match: true, len: typeDecl.len };
+  }
+  return { match: false };
+}
+
+/**
+ * v2 equivalent of coerceHexToBytes.
+ * Walks a TypeDecl (v2 IDL shape) and converts hex strings to byte arrays
+ * for `vec u8` (slice<u8>, Vec<u8>) and `[u8; N]` fields.
+ */
+export function coerceHexToBytesV2(
+  value: unknown,
+  typeDecl: V2TypeDecl,
+  typeMap: V2TypeMap,
+  fieldHint?: string,
+): unknown {
+  if (value === null || value === undefined) return value;
+
+  // Slice of u8 → bytes
+  if (isV2SliceU8(typeDecl)) {
+    if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
+      return hexToBytes(value, fieldHint);
+    }
+    return value;
+  }
+
+  // Fixed array of u8 → bytes with length validation
+  const fixed = isV2ArrayU8(typeDecl);
+  if (fixed.match && fixed.len !== undefined) {
+    if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
+      const bytes = hexToBytes(value, fieldHint);
+      if (bytes.length !== fixed.len) {
+        throw new CliError(
+          `Hex string decodes to ${bytes.length} bytes but [u8; ${fixed.len}] expects ${fixed.len} bytes${fieldHint ? ` for "${fieldHint}"` : ''}`,
+          'INVALID_HEX_BYTES',
+        );
+      }
+      return bytes;
+    }
+    return value;
+  }
+
+  // PrimitiveType (string literal): no byte fields to coerce
+  if (typeof typeDecl === 'string') return value;
+
+  // Slice (non-u8): recurse elements
+  if (typeDecl.kind === 'slice') {
+    if (Array.isArray(value)) {
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint));
+    }
+    return value;
+  }
+
+  // Array (non-u8): recurse elements
+  if (typeDecl.kind === 'array') {
+    if (Array.isArray(value)) {
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint));
+    }
+    return value;
+  }
+
+  // Tuple: recurse by index
+  if (typeDecl.kind === 'tuple') {
+    if (Array.isArray(value)) {
+      return typeDecl.types.map((t, i) => coerceHexToBytesV2((value as unknown[])[i], t, typeMap, fieldHint));
+    }
+    return value;
+  }
+
+  // Named type: well-known generics or user-defined
+  if (typeDecl.kind === 'named') {
+    const { name, generics } = typeDecl;
+
+    // Well-known wrappers
+    if (name === 'Option' && generics && generics.length === 1) {
+      return coerceHexToBytesV2(value, generics[0], typeMap, fieldHint);
+    }
+    if (name === 'Result' && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
+      const obj = value as Record<string, unknown>;
+      if ('ok' in obj) return { ok: coerceHexToBytesV2(obj.ok, generics[0], typeMap, 'ok') };
+      if ('err' in obj) return { err: coerceHexToBytesV2(obj.err, generics[1], typeMap, 'err') };
+      return value;
+    }
+    if (name === 'Vec' && generics && generics.length === 1) {
+      // Vec<u8> → bytes via hex coercion
+      if (isV2PrimitiveU8(generics[0])) {
+        if (typeof value === 'string' && value.startsWith('0x') && value.length > 2) {
+          return hexToBytes(value, fieldHint);
+        }
+        return value;
+      }
+      if (Array.isArray(value)) {
+        return value.map((item) => coerceHexToBytesV2(item, generics[0], typeMap, fieldHint));
+      }
+      return value;
+    }
+    if ((name === 'Map' || name === 'BTreeMap' || name === 'HashMap') && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        result[k] = coerceHexToBytesV2(v, generics[1], typeMap, k);
+      }
+      return result;
+    }
+
+    // User-defined type: look up in type map and recurse
+    const userType = typeMap.get(name);
+    if (!userType) return value; // Unknown type, pass through
+
+    // Alias: recurse into target
+    if (userType.kind === 'alias' && userType.target) {
+      return coerceHexToBytesV2(value, userType.target, typeMap, fieldHint);
+    }
+
+    // Struct: recurse into fields
+    if (userType.kind === 'struct' && userType.fields && typeof value === 'object' && !Array.isArray(value)) {
+      const fields = userType.fields as Array<{ name?: string; type: V2TypeDecl }>;
+      const result: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+      for (const field of fields) {
+        if (field.name && field.name in result) {
+          result[field.name] = coerceHexToBytesV2(result[field.name], field.type, typeMap, field.name);
+        }
+      }
+      return result;
+    }
+
+    // Struct (tuple-shaped — all fields unnamed): recurse by index
+    if (userType.kind === 'struct' && userType.fields && Array.isArray(value)) {
+      const fields = userType.fields as Array<{ name?: string; type: V2TypeDecl }>;
+      return fields.map((f, i) => coerceHexToBytesV2((value as unknown[])[i], f.type, typeMap, f.name));
+    }
+
+    // Enum: match variant and recurse into payload fields
+    if (userType.kind === 'enum' && userType.variants && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      const obj = value as Record<string, unknown>;
+      const variants = userType.variants as Array<{ name: string; fields: Array<{ name?: string; type: V2TypeDecl }> }>;
+      for (const variant of variants) {
+        if (variant.name in obj) {
+          if (!variant.fields || variant.fields.length === 0) {
+            return value; // unit variant
+          }
+          const payload = obj[variant.name];
+          if (variant.fields.length === 1 && !variant.fields[0].name) {
+            // Single unnamed field: payload is the raw value
+            return { [variant.name]: coerceHexToBytesV2(payload, variant.fields[0].type, typeMap, variant.name) };
+          }
+          // Struct-shaped variant payload
+          if (typeof payload === 'object' && payload !== null && !Array.isArray(payload)) {
+            const result: Record<string, unknown> = { ...(payload as Record<string, unknown>) };
+            for (const f of variant.fields) {
+              if (f.name && f.name in result) {
+                result[f.name] = coerceHexToBytesV2(result[f.name], f.type, typeMap, f.name);
+              }
+            }
+            return { [variant.name]: result };
+          }
+          // Tuple-shaped variant payload (array)
+          if (Array.isArray(payload)) {
+            return { [variant.name]: variant.fields.map((f, i) => coerceHexToBytesV2((payload as unknown[])[i], f.type, typeMap, f.name)) };
+          }
+          return value;
+        }
+      }
+      return value;
+    }
+
+    return value;
+  }
+
+  return value;
+}
+
+/**
+ * Coerce args for a Sails v2 method/constructor call.
+ * Reads user-defined types from the v2 `IIdlDoc.program.types` (private field,
+ * stable within the 1.0.0-beta line — mirrors v1's _program.types access pattern).
+ */
+export function coerceArgsV2(
+  args: unknown[],
+  argDefs: Array<{ name: string; typeDef: V2TypeDecl }>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  program: any,
+): unknown[] {
+  if (args.length === 0) return args;
+
+  let typeMap: V2TypeMap;
+  try {
+    typeMap = new Map();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doc = (program as any)._doc;
+    // Ambient types on the program block.
+    const programTypes = doc?.program?.types as Array<{ name: string }> | undefined;
+    if (programTypes) for (const t of programTypes) typeMap.set(t.name, t);
+    // Per-service types (v2 usually declares types inside a service block).
+    const services = doc?.services as Array<{ types?: Array<{ name: string }> }> | undefined;
+    if (services) {
+      for (const svc of services) {
+        if (svc.types) for (const t of svc.types) typeMap.set(t.name, t);
+      }
+    }
+  } catch {
+    return args; // Graceful fallback
+  }
+
+  return args.map((arg, i) => {
+    if (i >= argDefs.length) return arg;
+    return coerceHexToBytesV2(arg, argDefs[i].typeDef, typeMap, argDefs[i].name);
+  });
+}
+
+/**
+ * Dispatch coerceArgs to the v1 or v2 walker based on the Sails instance type.
+ * This is what generic commands (call, encode, program) should call.
+ */
+export function coerceArgsAuto(
+  args: unknown[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  argDefs: Array<{ name: string; typeDef: any }>,
+  sails: Sails | SailsProgram,
+): unknown[] {
+  // Lazy import to avoid a circular type dependency with sails.ts.
+  // Both SailsProgram and Sails are value-level classes so instanceof works.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { SailsProgram: V2Class } = require('sails-js') as { SailsProgram: new (...args: unknown[]) => SailsProgram };
+  if (sails instanceof V2Class) {
+    return coerceArgsV2(args, argDefs as Array<{ name: string; typeDef: V2TypeDecl }>, sails);
+  }
+  return coerceArgs(args, argDefs, sails);
 }

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -1,4 +1,4 @@
-import type { Sails, SailsProgram } from 'sails-js';
+import { SailsProgram, type Sails } from 'sails-js';
 import { CliError } from './errors';
 
 const HEX_RE = /^0x[0-9a-fA-F]+$/;
@@ -405,8 +405,13 @@ export function coerceHexToBytesV2(
 
 /**
  * Coerce args for a Sails v2 method/constructor call.
- * Reads user-defined types from the v2 `IIdlDoc.program.types` (private field,
- * stable within the 1.0.0-beta line — mirrors v1's _program.types access pattern).
+ *
+ * Merges user-defined types from both possible declaration sites in the
+ * parsed IDL document (private `_doc` field, stable within the
+ * 1.0.0-beta line — mirrors v1's `_program.types` access pattern):
+ *   - `_doc.program.types` — program-level / ambient types (rare).
+ *   - `_doc.services[i].types` — per-service types, which is where v2
+ *     IDLs normally declare struct / enum / alias shapes.
  */
 export function coerceArgsV2(
   args: unknown[],
@@ -451,11 +456,7 @@ export function coerceArgsAuto(
   argDefs: Array<{ name: string; typeDef: any }>,
   sails: Sails | SailsProgram,
 ): unknown[] {
-  // Lazy import to avoid a circular type dependency with sails.ts.
-  // Both SailsProgram and Sails are value-level classes so instanceof works.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { SailsProgram: V2Class } = require('sails-js') as { SailsProgram: new (...args: unknown[]) => SailsProgram };
-  if (sails instanceof V2Class) {
+  if (sails instanceof SailsProgram) {
     return coerceArgsV2(args, argDefs as Array<{ name: string; typeDef: V2TypeDecl }>, sails);
   }
   return coerceArgs(args, argDefs, sails);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { output, outputNdjson, verbose, setOutputOptions } from './output';
-export { CliError, outputError, formatError, installGlobalErrorHandler } from './errors';
+export { CliError, errorMessage, outputError, formatError, installGlobalErrorHandler } from './errors';
 export { varaToMinimal, minimalToVara, toMinimalUnits, resolveAmount } from './units';
 export { addressToHex } from './address';
 export { textToHex, tryHexToText, resolvePayload } from './payload';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,4 +3,4 @@ export { CliError, outputError, formatError, installGlobalErrorHandler } from '.
 export { varaToMinimal, minimalToVara, toMinimalUnits, resolveAmount } from './units';
 export { addressToHex } from './address';
 export { textToHex, tryHexToText, resolvePayload } from './payload';
-export { coerceArgs } from './hex-bytes';
+export { coerceArgs, coerceArgsV2, coerceArgsAuto, coerceHexToBytes, coerceHexToBytesV2 } from './hex-bytes';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "resolveJsonModule": true,
     "declaration": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/types/**/*.d.ts"],
   "exclude": ["src/__tests__/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "resolveJsonModule": true,
     "declaration": true
   },
-  "include": ["src/**/*", "src/types/**/*.d.ts"],
+  "include": ["src/**/*"],
   "exclude": ["src/__tests__/**/*"]
 }


### PR DESCRIPTION
## Summary

Pre-adopts `sails-js@1.0.0-beta.1` and wires parallel IDL v1 + v2 runtimes into the generic commands (`call`, `discover`, `encode`, `program`) with automatic version detection via the `!@sails:` directive. Specialized flows (`vft`, `dex`) keep their v1-only code paths.

- New `loadSailsAuto` / `parseIdlFileAuto` + a parallel v2 type-walker in `src/utils/hex-bytes.ts` (`coerceHexToBytesV2`, `coerceArgsV2`, `coerceArgsAuto`).
- `describeType` now dispatches on instance type and delegates v2 rendering to `SailsProgram.typeResolver.getTypeDeclString`.
- v2-aware error hints in the `decode` subcommand (SailsMessageHeader prefix).
- Post-build artifact smoke script (`scripts/smoke.mjs`) runs `discover --idl` against a v1 IDL and a v2 fixture through the bundled `dist/app.js`.
- 5 new offline Jest test files (+55 cases): `idl-detection`, `idl-v2`, `hex-bytes-v2`, `describe-type-v2`, `parser-cache`. Bundled-IDL tests now also assert `version === 'v1'`.

## Dependencies

- `sails-js` pinned to the upstream GitHub release tarball (`https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.1/sails-js.tgz`) because the package hasn't been published to npm yet. **Swap to a normal version range once `sails-js@1.0.0-beta.1` appears on npm** — one-line `package.json` change.
- `@gear-js/api` bumped to `^0.45.0` (peer requirement). Drops the `as any` cast in `mailbox.ts` that's now cleanly typed.
- `sails-js-parser@^0.5.1` kept as-is for IDL v1.

## Scope decisions

- **IDL v2 support is wired into generic commands only**: `call`, `discover`, `encode`, `program upload|deploy`. `vft.ts` and `dex.ts` intentionally stay v1-only — they use bundled v1 IDLs with token-specific validators and there are no v2 VFT/DEX contracts yet. Follow-up PR when that changes.
- Project convention is **offline/unit tests only** (per `CLAUDE.md`); live-network regression is a manual step in the test plan below.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 331/331 non-faucet tests pass (+55 new). 6 pre-existing `faucet.test.ts` failures are unrelated (user-config leak into test env, confirmed on baseline deps).
- [x] `npm run test:smoke` — v1 (VFT bundled) and v2 (sample-v2 fixture) both parse through the bundled `dist/app.js`.
- [x] Bundle size: 3.3 MB (baseline 3.1 MB, +6%; static import of `SailsProgram` avoided a larger hit).
- [ ] **Manual v1 regression** against mainnet VFT: `node dist/app.js call <vft-mainnet-programId> Vft/Balance --args '[\"0x...\"]'`.
- [ ] **Manual v2 regression** once a v2 contract is available on testnet.

## Review notes

This PR was reviewed with `/code-review-graph:review-pr` (Claude + Codex cross-model). All 10 surfaced issues — P2 through P4 — were addressed in the follow-up commit (`refactor: address PR review feedback for dual IDL support`). Highlights:

- **P2:** parser singleton cache now recovers from rejected init (no more permanent wedge on transient WASM failures). Covered by `parser-cache.test.ts`.
- Replaced a dynamic `require('sails-js')` with a static import, which let esbuild tree-shake and trimmed the bundle from 3.8 MB → 3.3 MB.
- v2 parse errors now surface as `CliError(IDL_PARSE_ERROR)` consistently.
- `decode` command's SailsMessageHeader hint is gated on `isSailsV2(sails)` — v1 users no longer see v2-specific advice.

## Follow-ups (non-blocking)

- Flip `sails-js` dependency to a regular npm version range when `1.0.0-beta.1` is published.
- Delete `src/types/sails-js-parser.d.ts` shim after bumping tsconfig `moduleResolution` to `node16` / `bundler` (separate PR).
- Fix the pre-existing `faucet.test.ts` bug (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)