### PR TITLE
feat: accept SS58 addresses in --args for ActorId fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] - 2026-04-23
+
+### Added
+- `call`, `encode`, and `program deploy` now accept SS58 addresses (`5Grw...`) in `--args` for any `ActorId`-typed positional or struct-nested argument. Previously only 32-byte hex was accepted, forcing users to manually decode addresses copied from Subscan before passing them to Sails methods like `Vft/BalanceOf`. Canonical hex input remains byte-identical on the wire. Closes [#31](https://github.com/gear-foundation/vara-wallet/issues/31).
+
+### Fixed
+- Faucet test suite no longer reads the developer's real `~/.vara-wallet/config.json`. The mainnet guard at `faucet.ts:49` was triggering on any dev machine with a mainnet `wsEndpoint` configured, failing 6 tests locally even though CI stayed green.
+
 ## [0.11.0] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ vara-wallet call <programId> Service/Method --args '["arg1", "arg2"]'
 
 # Pass hex strings for binary args — auto-converted to byte arrays
 vara-wallet call <programId> Service/Upload --args '["0xdeadbeef"]'
+
+# Pass SS58 or hex addresses for ActorId args — SS58 auto-normalized to hex
+vara-wallet call <programId> Vft/BalanceOf --args '["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]'
 ```
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/src/__tests__/faucet.test.ts
+++ b/src/__tests__/faucet.test.ts
@@ -25,6 +25,14 @@ jest.mock('../services/account', () => ({
   resolveAddress: jest.fn().mockResolvedValue('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'),
 }));
 
+// Mock readConfig so tests don't read the developer's real ~/.vara-wallet/config.json.
+// Without this, a mainnet wsEndpoint in the dev's local config trips the mainnet guard
+// at src/commands/faucet.ts:49 and every test throws WRONG_NETWORK.
+jest.mock('../services/config', () => ({
+  readConfig: jest.fn().mockReturnValue({}),
+  writeConfig: jest.fn(),
+}));
+
 import { Command } from 'commander';
 import { registerFaucetCommand } from '../commands/faucet';
 import { CliError } from '../utils';

--- a/src/__tests__/hex-bytes-v2.test.ts
+++ b/src/__tests__/hex-bytes-v2.test.ts
@@ -194,6 +194,11 @@ describe('ActorId primitive', () => {
     expect(() => coerceHexToBytesV2('not-an-address', 'ActorId', EMPTY_MAP)).toThrow(/Invalid ActorId/);
   });
 
+  it('throws on wrong-length hex (20-byte Ethereum-style)', () => {
+    expect(() => coerceHexToBytesV2('0x1234567890123456789012345678901234567890', 'ActorId', EMPTY_MAP))
+      .toThrow(/Invalid ActorId/);
+  });
+
   it('passes through non-string unchanged', () => {
     const preDecoded = Array.from({ length: 32 }, (_, i) => i);
     expect(coerceHexToBytesV2(preDecoded, 'ActorId', EMPTY_MAP)).toBe(preDecoded);

--- a/src/__tests__/hex-bytes-v2.test.ts
+++ b/src/__tests__/hex-bytes-v2.test.ts
@@ -177,6 +177,51 @@ describe('coerceHexToBytesV2', () => {
   });
 });
 
+describe('ActorId primitive', () => {
+  const ALICE_SS58 = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+  const ALICE_HEX = '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
+  const EMPTY_MAP: V2TypeMap = new Map();
+
+  it('accepts canonical hex unchanged', () => {
+    expect(coerceHexToBytesV2(ALICE_HEX, 'ActorId', EMPTY_MAP)).toBe(ALICE_HEX);
+  });
+
+  it('converts SS58 to canonical hex', () => {
+    expect(coerceHexToBytesV2(ALICE_SS58, 'ActorId', EMPTY_MAP)).toBe(ALICE_HEX);
+  });
+
+  it('throws on garbage string', () => {
+    expect(() => coerceHexToBytesV2('not-an-address', 'ActorId', EMPTY_MAP)).toThrow(/Invalid ActorId/);
+  });
+
+  it('passes through non-string unchanged', () => {
+    const preDecoded = Array.from({ length: 32 }, (_, i) => i);
+    expect(coerceHexToBytesV2(preDecoded, 'ActorId', EMPTY_MAP)).toBe(preDecoded);
+  });
+
+  it('coerces SS58 inside a struct field (walker recursion)', () => {
+    const typeMap: V2TypeMap = new Map([
+      [
+        'Transfer',
+        {
+          kind: 'struct',
+          name: 'Transfer',
+          fields: [
+            { name: 'to', type: 'ActorId' },
+            { name: 'amount', type: 'u128' },
+          ],
+        },
+      ],
+    ]);
+    const result = coerceHexToBytesV2(
+      { to: ALICE_SS58, amount: 100 },
+      { kind: 'named', name: 'Transfer' },
+      typeMap,
+    );
+    expect(result).toEqual({ to: ALICE_HEX, amount: 100 });
+  });
+});
+
 describe('coerceArgsV2', () => {
   it('coerces method args based on IDL types', async () => {
     const { program } = await setupProgram();

--- a/src/__tests__/hex-bytes.test.ts
+++ b/src/__tests__/hex-bytes.test.ts
@@ -234,6 +234,48 @@ describe('coerceHexToBytes', () => {
   });
 });
 
+describe('actor_id (ActorId)', () => {
+  const ALICE_SS58 = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+  const ALICE_HEX = '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
+  const EMPTY_MAP: TypeMap = new Map();
+  let actorIdDef: unknown;
+
+  beforeAll(async () => {
+    const { sails } = await setup('service S { Test : (who: actor_id) -> bool; };');
+    actorIdDef = getArgTypeDef(sails, 'S', 'Test', 0);
+  });
+
+  it('accepts canonical hex unchanged', () => {
+    expect(coerceHexToBytes(ALICE_HEX, actorIdDef, EMPTY_MAP)).toBe(ALICE_HEX);
+  });
+
+  it('converts SS58 to the same hex as the hex path', () => {
+    expect(coerceHexToBytes(ALICE_SS58, actorIdDef, EMPTY_MAP)).toBe(ALICE_HEX);
+  });
+
+  it('throws INVALID_ADDRESS on garbage string', () => {
+    expect(() => coerceHexToBytes('not-an-address', actorIdDef, EMPTY_MAP)).toThrow(/Invalid ActorId/);
+  });
+
+  it('passes through non-string values unchanged (e.g. pre-decoded u8 array)', () => {
+    const preDecoded = Array.from({ length: 32 }, (_, i) => i);
+    expect(coerceHexToBytes(preDecoded, actorIdDef, EMPTY_MAP)).toBe(preDecoded);
+  });
+
+  it('coerces SS58 inside a struct field (walker recursion)', async () => {
+    const { sails, typeMap } = await setup(`
+      type Transfer = struct {
+        to: actor_id,
+        amount: u128,
+      };
+      service S { Send : (t: Transfer) -> bool; };
+    `);
+    const typeDef = getArgTypeDef(sails, 'S', 'Send', 0);
+    const result = coerceHexToBytes({ to: ALICE_SS58, amount: 100 }, typeDef, typeMap);
+    expect(result).toEqual({ to: ALICE_HEX, amount: 100 });
+  });
+});
+
 describe('coerceArgs', () => {
   it('returns empty array for empty args', () => {
     expect(coerceArgs([], [], {})).toEqual([]);
@@ -251,6 +293,16 @@ describe('coerceArgs', () => {
     const args = ['0xaabb'];
     const argDefs = [{ name: 'data', typeDef: {} }];
     expect(coerceArgs(args, argDefs, fakeSails)).toEqual(args);
+  });
+
+  it('coerces SS58 actor_id arg to the same payload as hex', async () => {
+    const ALICE_SS58 = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+    const ALICE_HEX = '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
+    const { sails } = await setup('service S { Test : (who: actor_id) -> bool; };');
+    const func = sails.services['S'].functions['Test'];
+    const fromSs58 = coerceArgs([ALICE_SS58], func.args, sails);
+    const fromHex = coerceArgs([ALICE_HEX], func.args, sails);
+    expect(fromSs58).toEqual(fromHex);
   });
 
   it('gracefully returns args when _program throws', () => {

--- a/src/__tests__/hex-bytes.test.ts
+++ b/src/__tests__/hex-bytes.test.ts
@@ -257,6 +257,14 @@ describe('actor_id (ActorId)', () => {
     expect(() => coerceHexToBytes('not-an-address', actorIdDef, EMPTY_MAP)).toThrow(/Invalid ActorId/);
   });
 
+  it('throws INVALID_ADDRESS on wrong-length hex (20-byte Ethereum-style)', () => {
+    // decodeAddress accepts arbitrary-length hex — we must reject anything
+    // that isn't exactly 32 bytes at this layer, not let the SCALE encoder
+    // surface a cryptic length error downstream.
+    expect(() => coerceHexToBytes('0x1234567890123456789012345678901234567890', actorIdDef, EMPTY_MAP))
+      .toThrow(/Invalid ActorId/);
+  });
+
   it('passes through non-string values unchanged (e.g. pre-decoded u8 array)', () => {
     const preDecoded = Array.from({ length: 32 }, (_, i) => i);
     expect(coerceHexToBytes(preDecoded, actorIdDef, EMPTY_MAP)).toBe(preDecoded);

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -75,12 +75,22 @@ function hexToBytes(value: string, fieldHint?: string): number[] {
  * with pre-ActorId-SS58 behavior), or SS58 via `addressToHex`. Non-string
  * values pass through so downstream encoders can accept pre-decoded shapes
  * (e.g. `number[]` of length 32).
+ *
+ * `addressToHex` wraps `decodeAddress`, which also accepts arbitrary-length
+ * hex (e.g. 20-byte Ethereum-style strings). Those decode to the wrong
+ * length for an ActorId, so we re-validate the output against the 32-byte
+ * regex and throw at this layer instead of letting the downstream SCALE
+ * encoder produce an opaque length error.
  */
 function tryActorIdToHex(value: unknown, fieldHint?: string): unknown {
   if (typeof value !== 'string') return value;
   if (ACTOR_ID_HEX_RE.test(value)) return value;
   try {
-    return addressToHex(value);
+    const hex = addressToHex(value);
+    if (!ACTOR_ID_HEX_RE.test(hex)) {
+      throw new Error('decoded to non-32-byte length');
+    }
+    return hex;
   } catch {
     throw new CliError(
       `Invalid ActorId${fieldHint ? ` for "${fieldHint}"` : ''}: "${value}". Expected hex (0x… 64 chars) or SS58 address.`,

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -1,8 +1,10 @@
 import { SailsProgram, type Sails } from 'sails-js';
 import { CliError } from './errors';
+import { addressToHex } from './address';
 import { getRegistryTypes } from '../services/sails';
 
 const HEX_RE = /^0x[0-9a-fA-F]+$/;
+const ACTOR_ID_HEX_RE = /^0x[0-9a-fA-F]{64}$/;
 
 /**
  * Check if a typeDef represents `vec u8`.
@@ -68,6 +70,25 @@ function hexToBytes(value: string, fieldHint?: string): number[] {
  * the value unchanged if it isn't a hex string (so downstream encoders
  * can accept pre-decoded bytes).
  */
+/**
+ * Coerce an ActorId arg: accept canonical 32-byte hex as-is (byte-identical
+ * with pre-ActorId-SS58 behavior), or SS58 via `addressToHex`. Non-string
+ * values pass through so downstream encoders can accept pre-decoded shapes
+ * (e.g. `number[]` of length 32).
+ */
+function tryActorIdToHex(value: unknown, fieldHint?: string): unknown {
+  if (typeof value !== 'string') return value;
+  if (ACTOR_ID_HEX_RE.test(value)) return value;
+  try {
+    return addressToHex(value);
+  } catch {
+    throw new CliError(
+      `Invalid ActorId${fieldHint ? ` for "${fieldHint}"` : ''}: "${value}". Expected hex (0x… 64 chars) or SS58 address.`,
+      'INVALID_ADDRESS',
+    );
+  }
+}
+
 function tryHexToBytes(value: unknown, fieldHint?: string, expectedLen?: number): unknown {
   if (!isNonEmptyHex(value)) return value;
   const bytes = hexToBytes(value, fieldHint);
@@ -96,6 +117,11 @@ export function coerceHexToBytes(value: unknown, typeDef: any, typeMap: TypeMap,
     const resolved = typeMap.get(typeDef.asUserDefined.name);
     if (!resolved) return value; // Unknown type, pass through
     return coerceHexToBytes(value, resolved, typeMap, fieldHint);
+  }
+
+  // ActorId primitive: accept SS58 or canonical hex, normalize to hex.
+  if (typeDef.isPrimitive && typeDef.asPrimitive?.isActorId) {
+    return tryActorIdToHex(value, fieldHint);
   }
 
   // vec u8: convert hex string to byte array
@@ -293,6 +319,12 @@ export function coerceHexToBytesV2(
   // Resolve type_param references at entry so every branch below works
   // on the fully-substituted TypeDecl.
   typeDecl = resolveV2Subs(typeDecl, substitutions);
+
+  // ActorId primitive: accept SS58 or canonical hex, normalize to hex.
+  // MUST precede the `typeof typeDecl === 'string'` fallthrough below —
+  // otherwise 'ActorId' matches as a generic string primitive and the
+  // value returns unchanged, silently swallowing SS58 input.
+  if (typeDecl === 'ActorId') return tryActorIdToHex(value, fieldHint);
 
   // Slice of u8 → bytes
   if (isV2SliceU8(typeDecl)) return tryHexToBytes(value, fieldHint);


### PR DESCRIPTION
## Summary

Closes #31.

**Feature:**
- `call`, `encode`, and `program deploy` now accept SS58 addresses (`5Grw...`) in `--args` for any `ActorId`-typed positional or struct-nested argument. Previously only 32-byte hex was accepted, forcing users to manually decode addresses from Subscan before passing them to Sails methods. Canonical hex input stays byte-identical on the wire.

**Test hygiene:**
- Fixes pre-existing faucet test suite bleed: `readConfig()` was never mocked, so tests read the developer's real `~/.vara-wallet/config.json`. On any dev machine with a mainnet `wsEndpoint` configured, 6 tests threw `WRONG_NETWORK` before any assertion ran. CI passed only because the CI runner has no config file.

**Docs:**
- Added SS58 `--args` example to README.md.

## Test Coverage

```
CODE PATHS                                           USER FLOWS (CLI unit-level)
[+] src/utils/hex-bytes.ts                           [+] call / encode --args
  ├── tryActorIdToHex()                                ├── [★★★ TESTED] SS58 → hex payload
  │   ├── [★★★ TESTED] non-string passthrough          ├── [★★★ TESTED] canonical hex byte-identical
  │   ├── [★★★ TESTED] canonical hex passthrough       └── [★★  TESTED] garbage → INVALID_ADDRESS
  │   ├── [★★★ TESTED] SS58 → hex
  │   └── [★★★ TESTED] decode fail → CliError
  ├── v1 ActorId branch
  │   ├── [★★★ TESTED] positional actor_id arg
  │   ├── [★★  TESTED] args-level SS58↔hex parity
  │   └── [★★★ TESTED] struct-nested actor_id
  └── v2 ActorId branch
      ├── [★★★ TESTED] 'ActorId' TypeDecl direct
      └── [★★★ TESTED] struct-nested ActorId

[+] src/__tests__/faucet.test.ts (test-infra fix)
  └── [★★★ TESTED] readConfig mock — verified by 8/8 faucet tests passing

COVERAGE: 11/11 paths (100%)   QUALITY: ★★★:10 ★★:1 ★:0   GAPS: 0
```

Tests: 349 → 360 (+11 new). Full suite: 360/360 passing.

## Pre-Landing Review

No issues found. Eng Review CLEAR (plan-stage audit via /plan-eng-review: 0 unresolved, 0 critical gaps).

Adversarial subagent pass surfaced 6 informational observations, all evaluated as non-blockers:
- SS58 prefix ambiguity (#1) — consistent with existing codebase behavior for `balance`/`transfer`/`voucher` sites; not a #31 concern.
- Checksum strictness (#2) — verified `addressToHex` uses default strict `decodeAddress` at `src/utils/address.ts:8`.
- Named-type alias to `actor_id` (#4) — handled correctly via existing walker recursion; rare IDL pattern noted for follow-up.

## Plan Completion

13/13 plan items DONE. 1 CHANGED item: faucet test fix, user-approved during ship triage and committed separately.

## Verification

- `npx tsc --noEmit` — clean.
- `npm test` — 360/360 pass.
- Manual smoke (optional, against live RPC): `vara-wallet call <pid> Vft/BalanceOf --args '["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]'` — succeeds where it previously errored.

## Test plan

- [x] All Jest tests pass (360 tests, 29 suites)
- [x] Type check clean
- [x] Backward compat verified (canonical hex byte-identical)
- [x] New SS58 path unit-tested against equivalent hex payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)