### PR TITLE
feat: suggest cross-service match in method-not-found hint (closes #33)

### DIFF
--- a/src/__tests__/sails-suggest.test.ts
+++ b/src/__tests__/sails-suggest.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Cross-service "Did you mean?" hints for missing service / method names.
+ *
+ * Issue #33. Helpers live in src/services/sails.ts:
+ *   - suggestMethod(sails, service, method)
+ *   - suggestService(sails, service)
+ *
+ * Two suggestion sources, one capped suggestion:
+ *   1. Exact case-insensitive hit in another service (the common
+ *      `Vft/Name` → `VftMetadata/Name` case for VFT IDLs).
+ *   2. A single Levenshtein-≤2 fuzzy match. Ties at the minimum
+ *      distance produce no suggestion (zero-false-positive bar).
+ */
+import { SailsIdlParser } from 'sails-js-parser';
+import { Sails } from 'sails-js';
+import { VFT_STANDARD_IDL } from '../idl/bundled-idls';
+import { suggestMethod, suggestService } from '../services/sails';
+
+// Tie fixture: two services share the method name `Foo` so a typo
+// equidistant from both produces no suggestion. Also includes a service
+// pair (`Apxa`, `Apya`) for the service-tie case — both distance 1 from
+// a typo like `Apza`.
+const TIE_IDL = `constructor {
+  New : ();
+};
+
+service Apxa {
+  Foo : () -> bool;
+  query Bar : () -> u8;
+};
+
+service Beta {
+  Foo : () -> bool;
+};
+
+service Apya {
+  query Anything : () -> u8;
+};
+`;
+
+describe('suggestMethod / suggestService', () => {
+  let parser: SailsIdlParser;
+  let vft: Sails;
+  let tie: Sails;
+
+  beforeAll(async () => {
+    parser = await SailsIdlParser.new();
+    vft = new Sails(parser);
+    vft.parseIdl(VFT_STANDARD_IDL);
+    tie = new Sails(parser);
+    tie.parseIdl(TIE_IDL);
+  });
+
+  describe('suggestMethod — cross-service exact hit', () => {
+    it('Vft/Name → VftMetadata/Name (Name lives only in VftMetadata)', () => {
+      // Sanity: `Name` is NOT in Vft on the standard IDL.
+      expect(vft.services['Vft'].queries['Name']).toBeUndefined();
+      expect(vft.services['VftMetadata'].queries['Name']).toBeDefined();
+      expect(suggestMethod(vft, 'Vft', 'Name')).toBe('VftMetadata/Name');
+    });
+
+    it('Vft/Symbol → VftMetadata/Symbol', () => {
+      expect(suggestMethod(vft, 'Vft', 'Symbol')).toBe('VftMetadata/Symbol');
+    });
+
+    it('case-insensitive: Vft/name still suggests VftMetadata/Name', () => {
+      expect(suggestMethod(vft, 'Vft', 'name')).toBe('VftMetadata/Name');
+    });
+  });
+
+  describe('suggestMethod — fuzzy Levenshtein ≤2', () => {
+    it('Vft/TotalSuplpy → Vft/TotalSupply (transposition, distance 2)', () => {
+      expect(suggestMethod(vft, 'Vft', 'TotalSuplpy')).toBe('Vft/TotalSupply');
+    });
+
+    it('Vft/Aprove → Vft/Approve (single char insert)', () => {
+      expect(suggestMethod(vft, 'Vft', 'Aprove')).toBe('Vft/Approve');
+    });
+
+    it('Vft/TotallyFake → no suggestion (distance > 2)', () => {
+      expect(suggestMethod(vft, 'Vft', 'TotallyFake')).toBeNull();
+    });
+
+    it('Vft/CompletelyUnrelated → no suggestion', () => {
+      expect(suggestMethod(vft, 'Vft', 'CompletelyUnrelated')).toBeNull();
+    });
+  });
+
+  describe('suggestMethod — tie at minimum distance produces no suggestion', () => {
+    it('Apxa/Fox → no suggestion (Apxa/Foo and Beta/Foo both distance 1)', () => {
+      // `Fox` is distance 1 from both `Apxa/Foo` and `Beta/Foo`.
+      expect(suggestMethod(tie, 'Apxa', 'Fox')).toBeNull();
+    });
+  });
+
+  describe('suggestService', () => {
+    it('Vftt → Vft (single char insert, distance 1)', () => {
+      expect(suggestService(vft, 'Vftt')).toBe('Vft');
+    });
+
+    it('case-insensitive: vft → Vft', () => {
+      expect(suggestService(vft, 'vft')).toBe('Vft');
+    });
+
+    it('VftMetdata → VftMetadata (transposition, distance 2)', () => {
+      expect(suggestService(vft, 'VftMetdata')).toBe('VftMetadata');
+    });
+
+    it('CompletelyMadeUp → no suggestion', () => {
+      expect(suggestService(vft, 'CompletelyMadeUp')).toBeNull();
+    });
+
+    it('Apza → no suggestion when Apxa and Apya are both distance 1', () => {
+      // `Apza` is distance 1 from both `Apxa` (subst z→x) and `Apya`
+      // (subst z→y). Tie → null, no arbitrary pick.
+      expect(suggestService(tie, 'Apza')).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/sails-suggest.test.ts
+++ b/src/__tests__/sails-suggest.test.ts
@@ -38,6 +38,30 @@ service Apya {
 };
 `;
 
+// Dedup fixture: a synthetic Sails-shaped object where one service has
+// the same method name (`Ping`) declared in both `functions` and
+// `queries`. Per-service deduping must collapse this to a single
+// candidate, otherwise the `length === 1` check spuriously fails and the
+// hint is suppressed. See PR #45 review (gemini-code-assist).
+//
+// We construct this directly rather than via the IDL parser because the
+// parser may or may not allow same-name function/query pairs depending
+// on grammar version, but the Sails runtime data model exposes them as
+// independent `Record<string, …>` maps either way — which is what the
+// suggestion code consumes.
+function makeDupSails() {
+  const fn = { args: [], returnTypeDef: null, docs: undefined };
+  const services = {
+    Main: { functions: { DoStuff: fn }, queries: {}, events: {} },
+    Other: {
+      functions: { Ping: fn },
+      queries: { Ping: fn },
+      events: {},
+    },
+  };
+  return { services } as unknown as Parameters<typeof suggestMethod>[0];
+}
+
 describe('suggestMethod / suggestService', () => {
   let parser: SailsIdlParser;
   let vft: Sails;
@@ -90,6 +114,22 @@ describe('suggestMethod / suggestService', () => {
     it('Apxa/Fox → no suggestion (Apxa/Foo and Beta/Foo both distance 1)', () => {
       // `Fox` is distance 1 from both `Apxa/Foo` and `Beta/Foo`.
       expect(suggestMethod(tie, 'Apxa', 'Fox')).toBeNull();
+    });
+  });
+
+  describe('suggestMethod — per-service dedup of function/query collisions', () => {
+    // Regression for PR #45 review: when a method name exists in both
+    // `functions` and `queries` of the same service, the suggestion code
+    // must count it once. Otherwise the spurious duplicate trips the
+    // `length === 1` tie-rejection and silently drops a valid hint.
+    const dup = makeDupSails();
+
+    it('exact case-insensitive: Main/ping → Other/Ping (not suppressed by dup)', () => {
+      expect(suggestMethod(dup, 'Main', 'ping')).toBe('Other/Ping');
+    });
+
+    it('fuzzy: Main/Pong → Other/Ping (not suppressed by dup)', () => {
+      expect(suggestMethod(dup, 'Main', 'Pong')).toBe('Other/Ping');
     });
   });
 

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
-import { loadSailsAuto, describeSailsProgram, type LoadedSails } from '../services/sails';
+import { loadSailsAuto, describeSailsProgram, suggestMethod, suggestService, type LoadedSails } from '../services/sails';
 import { resolveBlockNumber } from '../services/tx-executor';
 import { validateVoucher } from '../services/voucher-validator';
 import { output, verbose, CliError, resolveAmount, minimalToVara, addressToHex, coerceArgsAuto, decodeSailsResult } from '../utils';
@@ -48,8 +48,10 @@ export function registerCallCommand(program: Command): void {
       const service = sails.services[serviceName];
       if (!service) {
         const available = Object.keys(sails.services).join(', ');
+        const hint = suggestService(sails, serviceName);
+        const prefix = hint ? `Did you mean: ${hint}/${methodName}? ` : '';
         throw new CliError(
-          `Service "${serviceName}" not found. Available services: ${available}`,
+          `${prefix}Service "${serviceName}" not found. Available services: ${available}`,
           'SERVICE_NOT_FOUND',
         );
       }
@@ -77,8 +79,10 @@ export function registerCallCommand(program: Command): void {
           ...Object.keys(serviceDesc.functions || {}).map((m) => `${serviceName}/${m} (function)`),
           ...Object.keys(serviceDesc.queries || {}).map((m) => `${serviceName}/${m} (query)`),
         ];
+        const hint = suggestMethod(sails, serviceName, methodName);
+        const prefix = hint ? `Did you mean: ${hint}? ` : '';
         throw new CliError(
-          `Method "${methodName}" not found in service "${serviceName}". Available: ${allMethods.join(', ')}`,
+          `${prefix}Method "${methodName}" not found in service "${serviceName}". Available: ${allMethods.join(', ')}`,
           'METHOD_NOT_FOUND',
         );
       }

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { ProgramMetadata } from '@gear-js/api';
 import * as fs from 'fs';
 import { getApi } from '../services/api';
-import { loadSailsAuto, parseIdlFileAuto, isSailsV2, type LoadedSails } from '../services/sails';
+import { loadSailsAuto, parseIdlFileAuto, isSailsV2, suggestMethod, suggestService, type LoadedSails } from '../services/sails';
 import { output, verbose, CliError, tryHexToText, coerceArgsAuto } from '../utils';
 
 export function registerEncodeCommand(program: Command): void {
@@ -47,12 +47,16 @@ export function registerEncodeCommand(program: Command): void {
         const [serviceName, methodName] = parts;
         const service = sails.services[serviceName];
         if (!service) {
-          throw new CliError(`Service "${serviceName}" not found`, 'SERVICE_NOT_FOUND');
+          const hint = suggestService(sails, serviceName);
+          const prefix = hint ? `Did you mean: ${hint}/${methodName}? ` : '';
+          throw new CliError(`${prefix}Service "${serviceName}" not found`, 'SERVICE_NOT_FOUND');
         }
 
         const func = service.functions[methodName] || service.queries[methodName];
         if (!func) {
-          throw new CliError(`Method "${methodName}" not found in "${serviceName}"`, 'METHOD_NOT_FOUND');
+          const hint = suggestMethod(sails, serviceName, methodName);
+          const prefix = hint ? `Did you mean: ${hint}? ` : '';
+          throw new CliError(`${prefix}Method "${methodName}" not found in "${serviceName}"`, 'METHOD_NOT_FOUND');
         }
 
         const rawArgs = Array.isArray(parsedValue) ? parsedValue : [parsedValue];
@@ -124,12 +128,16 @@ export function registerEncodeCommand(program: Command): void {
         const [serviceName, methodName] = parts;
         const service = sails.services[serviceName];
         if (!service) {
-          throw new CliError(`Service "${serviceName}" not found`, 'SERVICE_NOT_FOUND');
+          const hint = suggestService(sails, serviceName);
+          const prefix = hint ? `Did you mean: ${hint}/${methodName}? ` : '';
+          throw new CliError(`${prefix}Service "${serviceName}" not found`, 'SERVICE_NOT_FOUND');
         }
 
         const func = service.functions[methodName] || service.queries[methodName];
         if (!func) {
-          throw new CliError(`Method "${methodName}" not found in "${serviceName}"`, 'METHOD_NOT_FOUND');
+          const hint = suggestMethod(sails, serviceName, methodName);
+          const prefix = hint ? `Did you mean: ${hint}? ` : '';
+          throw new CliError(`${prefix}Method "${methodName}" not found in "${serviceName}"`, 'METHOD_NOT_FOUND');
         }
 
         let decoded: unknown;

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -612,6 +612,151 @@ function renderEventType(sails: LoadedSails, event: EventLike): string {
   return describeType(sails, event.typeDef);
 }
 
+// ────────────────────────────────────────────────────────────────────
+// Cross-service match hints (issue #33)
+//
+// When `call <pid> Service/Method` 404s on either name, we surface a
+// "Did you mean: …?" hint. Two sources:
+//   1. Exact case-insensitive match in a different service (very common
+//      for VFT IDLs where `Vft/Name` is actually `VftMetadata/Name`).
+//   2. Single Levenshtein-≤2 fuzzy match within any service.
+//
+// Zero-false-positive bar: ties at the minimum distance → no suggestion.
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * Levenshtein edit distance with an early-exit cap. Returns `cap + 1`
+ * once the running minimum row value exceeds `cap`, so callers can
+ * cheaply reject "too far" candidates without paying the full O(n*m).
+ */
+function levenshtein(a: string, b: string, cap: number): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > cap) return cap + 1;
+  // Standard 1D-rolling-row DP.
+  const prev = new Array(b.length + 1);
+  const curr = new Array(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    let rowMin = curr[0];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(
+        curr[j - 1] + 1,       // insert
+        prev[j] + 1,           // delete
+        prev[j - 1] + cost,    // substitute
+      );
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > cap) return cap + 1;
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+  return prev[b.length];
+}
+
+/** All method names (functions + queries) for a given service. */
+function methodNamesIn(sails: LoadedSails, serviceName: string): string[] {
+  const svc = (sails.services as Record<string, ServiceLike>)[serviceName];
+  if (!svc) return [];
+  return [...Object.keys(svc.functions), ...Object.keys(svc.queries)];
+}
+
+/**
+ * Find a single best suggestion across all (Service, Method) pairs for
+ * a missing `serviceName/methodName`. Returns `"Service/Method"` or null.
+ *
+ * Preference order:
+ *   1. Exact case-insensitive match for `methodName` in any service
+ *      (including the same service, in case method-name casing was off).
+ *      If exactly one such match exists → suggest it.
+ *   2. Otherwise, Levenshtein-≤2 fuzzy match across all (svc, method)
+ *      pairs. Suggest only when there is exactly one candidate at the
+ *      minimum distance — ties produce no suggestion.
+ */
+export function suggestMethod(
+  sails: LoadedSails,
+  serviceName: string,
+  methodName: string,
+): string | null {
+  const allServices = sails.services as Record<string, ServiceLike>;
+  const lowerMethod = methodName.toLowerCase();
+
+  // 1. Exact case-insensitive match anywhere.
+  const exactHits: string[] = [];
+  for (const [svcName, svc] of Object.entries(allServices)) {
+    for (const m of [...Object.keys(svc.functions), ...Object.keys(svc.queries)]) {
+      if (m.toLowerCase() === lowerMethod && !(svcName === serviceName && m === methodName)) {
+        exactHits.push(`${svcName}/${m}`);
+      }
+    }
+  }
+  if (exactHits.length === 1) return exactHits[0];
+  // Multiple exact matches across services → ambiguous, no hint.
+  if (exactHits.length > 1) return null;
+
+  // 2. Fuzzy match within all services.
+  const cap = 2;
+  let bestDist = cap + 1;
+  let bestMatches: string[] = [];
+  for (const [svcName, svc] of Object.entries(allServices)) {
+    for (const m of [...Object.keys(svc.functions), ...Object.keys(svc.queries)]) {
+      // Skip identity (shouldn't happen — caller already checked the
+      // method is missing — but defensive).
+      if (svcName === serviceName && m === methodName) continue;
+      const d = levenshtein(methodName, m, cap);
+      if (d > cap) continue;
+      if (d < bestDist) {
+        bestDist = d;
+        bestMatches = [`${svcName}/${m}`];
+      } else if (d === bestDist) {
+        bestMatches.push(`${svcName}/${m}`);
+      }
+    }
+  }
+  if (bestMatches.length === 1) return bestMatches[0];
+  return null;
+}
+
+/**
+ * Find a single best service-name suggestion for a missing service.
+ * Returns the suggested service name or null.
+ *
+ * Same rules as `suggestMethod`:
+ *   1. Exact case-insensitive hit → suggest it.
+ *   2. Levenshtein-≤2 with exactly one minimum-distance candidate.
+ */
+export function suggestService(sails: LoadedSails, serviceName: string): string | null {
+  const services = Object.keys(sails.services as Record<string, ServiceLike>);
+  const lower = serviceName.toLowerCase();
+
+  // 1. Case-insensitive exact match.
+  const exact = services.filter((s) => s.toLowerCase() === lower);
+  if (exact.length === 1) return exact[0];
+  if (exact.length > 1) return null;
+
+  // 2. Fuzzy match.
+  const cap = 2;
+  let bestDist = cap + 1;
+  let bestMatches: string[] = [];
+  for (const s of services) {
+    if (s === serviceName) continue;
+    const d = levenshtein(serviceName, s, cap);
+    if (d > cap) continue;
+    if (d < bestDist) {
+      bestDist = d;
+      bestMatches = [s];
+    } else if (d === bestDist) {
+      bestMatches.push(s);
+    }
+  }
+  if (bestMatches.length === 1) return bestMatches[0];
+  return null;
+}
+
+// Internal export only used by the test suite — keeps the helper testable
+// without inflating the public API surface.
+export const _internal = { levenshtein, methodNamesIn };
+
 /**
  * Build a structured description of all services in a Sails program.
  * Shape is identical across v1 and v2 for consumers like the discover command.

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -654,13 +654,6 @@ function levenshtein(a: string, b: string, cap: number): number {
   return prev[b.length];
 }
 
-/** All method names (functions + queries) for a given service. */
-function methodNamesIn(sails: LoadedSails, serviceName: string): string[] {
-  const svc = (sails.services as Record<string, ServiceLike>)[serviceName];
-  if (!svc) return [];
-  return [...Object.keys(svc.functions), ...Object.keys(svc.queries)];
-}
-
 /**
  * Find a single best suggestion across all (Service, Method) pairs for
  * a missing `serviceName/methodName`. Returns `"Service/Method"` or null.
@@ -752,10 +745,6 @@ export function suggestService(sails: LoadedSails, serviceName: string): string 
   if (bestMatches.length === 1) return bestMatches[0];
   return null;
 }
-
-// Internal export only used by the test suite — keeps the helper testable
-// without inflating the public API surface.
-export const _internal = { levenshtein, methodNamesIn };
 
 /**
  * Build a structured description of all services in a Sails program.

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -675,9 +675,12 @@ export function suggestMethod(
   const lowerMethod = methodName.toLowerCase();
 
   // 1. Exact case-insensitive match anywhere.
+  // Dedupe per service: a name appearing in both functions and queries
+  // must count as a single candidate so the `length === 1` check holds.
   const exactHits: string[] = [];
   for (const [svcName, svc] of Object.entries(allServices)) {
-    for (const m of [...Object.keys(svc.functions), ...Object.keys(svc.queries)]) {
+    const methodNames = new Set([...Object.keys(svc.functions), ...Object.keys(svc.queries)]);
+    for (const m of methodNames) {
       if (m.toLowerCase() === lowerMethod && !(svcName === serviceName && m === methodName)) {
         exactHits.push(`${svcName}/${m}`);
       }
@@ -692,7 +695,8 @@ export function suggestMethod(
   let bestDist = cap + 1;
   let bestMatches: string[] = [];
   for (const [svcName, svc] of Object.entries(allServices)) {
-    for (const m of [...Object.keys(svc.functions), ...Object.keys(svc.queries)]) {
+    const methodNames = new Set([...Object.keys(svc.functions), ...Object.keys(svc.queries)]);
+    for (const m of methodNames) {
       // Skip identity (shouldn't happen — caller already checked the
       // method is missing — but defensive).
       if (svcName === serviceName && m === methodName) continue;


### PR DESCRIPTION
## Summary

Adds "Did you mean: ...?" hints to `SERVICE_NOT_FOUND` and `METHOD_NOT_FOUND` errors in `vara-wallet call` and `vara-wallet encode/decode`. Closes #33.

Two suggestion sources, capped at one suggestion to avoid noise:

1. **Exact case-insensitive match in another service** — the common VFT case where `Vft/Name` should suggest `VftMetadata/Name`.
2. **Levenshtein-≤2 fuzzy match** — typos like `Vft/TotalSuplpy` → `Vft/TotalSupply`. Suggestions only fire when there is exactly one candidate at the minimum distance. Ties produce no suggestion (zero-false-positive bar).

Error codes are unchanged. The hint is prepended to the existing error text:

```
Did you mean: VftMetadata/Name? Method "Name" not found in service "Vft". Available: ...
```

## Implementation

- `src/services/sails.ts` — adds `suggestMethod` and `suggestService` helpers, plus a small inline Levenshtein with an early-exit cap. No new dependencies.
- `src/commands/call.ts` — wires hints into the two error throws (SERVICE_NOT_FOUND at the service lookup, METHOD_NOT_FOUND at the method check).
- `src/commands/encode.ts` — same wire-up for both the `encode` and `decode` subcommands.

## Test Coverage

13 new Jest tests in `src/__tests__/sails-suggest.test.ts` covering:

- Cross-service exact hit (`Vft/Name` → `VftMetadata/Name`, plus `Symbol`)
- Case-insensitive fold (`Vft/name` → `VftMetadata/Name`)
- Fuzzy single-typo (`Vft/Aprove` → `Vft/Approve`)
- Fuzzy double-edit (`Vft/TotalSuplpy` → `Vft/TotalSupply`)
- Distance-too-far cases (no suggestion)
- Method ties (two services with identical-distance candidates → no suggestion)
- Service typos (`Vftt` → `Vft`, case-insensitive `vft` → `Vft`, `VftMetdata` → `VftMetadata`)
- Service ties using a custom `Apxa`/`Apya` fixture (no arbitrary pick)

Test count: 397 → 410 (+13). Full suite green. Typecheck clean.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx jest` — 410/410 green
- [x] `npx jest src/__tests__/sails-suggest.test.ts` — 13/13 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)