### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.1] - 2026-04-25
+
+### Fixed
+- `--json` mode no longer leaks `@polkadot` RPC-CORE disconnect warnings to stderr during shutdown. Previously `vara-wallet node info --json`, `balance --json`, etc. could emit `RPC-CORE: ...disconnected from wss://...` lines that broke downstream JSON parsers. The earlier `console.warn` patch in `src/services/api.ts` didn't fire because esbuild's module bundling put the logger's `console.error` call in a different scope, and the matcher was checking the wrong argument index. Replaced with a `process.stderr.write` interceptor matching the logger's timestamped `RPC-CORE:` prefix — bundle-scope-independent. `--verbose` output unaffected. (#34)
+- TypeScript build of the same patch: `(chunk, ...rest)` signature didn't match the `process.stderr.write` overloads, so `ts-jest` failed to compile 7 test suites (esbuild bundling silently passed, masking the issue in `npm run build`). Reworked the wrapper to a single rest-parameter form that satisfies both overloads.
+
 ## [0.14.0] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ Gas is auto-calculated if `--gas-limit` is omitted. Destination can be any actor
 ### `program`
 
 ```bash
-vara-wallet program upload <wasm> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>]
-vara-wallet program deploy <codeId> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>]
+vara-wallet program upload <wasm> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
+vara-wallet program deploy <codeId> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
 vara-wallet program info <programId>
 vara-wallet program list [--count <n>] [--all]
 ```
 
-Use `--idl` to auto-encode the constructor payload from a Sails IDL file. The constructor is auto-selected if the IDL has only one; use `--init <name>` when multiple constructors exist. `--args` passes constructor arguments as a JSON array. `--payload` and `--idl` are mutually exclusive.
+Use `--idl` to auto-encode the constructor payload from a Sails IDL file. The constructor is auto-selected if the IDL has only one; use `--init <name>` when multiple constructors exist. `--args` passes constructor arguments as a JSON array, or use `--args-file <path>` to read JSON from a file (or `-` for stdin). `--payload` and `--idl` are mutually exclusive. `--dry-run` encodes the constructor payload and exits without signing or submitting; the response reports the resolved constructor name, encoded hex, and `willSubmit: false`.
 
 ```bash
 # Deploy with IDL-based constructor encoding (auto-selects "New" constructor)
@@ -203,13 +203,17 @@ vara-wallet code list [--count <n>]
 
 ### `call` (Sails)
 
-High-level method invocation on Sails programs. Auto-detects queries vs functions. Use `--estimate` to calculate gas cost without sending the transaction (requires an account).
+High-level method invocation on Sails programs. Auto-detects queries vs functions. Use `--estimate` to calculate gas cost without sending the transaction (requires an account). Use `--dry-run` to encode the SCALE payload and exit without signing or submitting (works without a wallet — useful for previewing payloads on read-only machines).
 
 ```bash
-vara-wallet call <programId> <Service/Method> [--args <json>] [--value <v>] [--units vara|raw] [--gas-limit <n>] [--idl <path>] [--voucher <id>] [--estimate]
+vara-wallet call <programId> <Service/Method> [--args <json> | --args-file <path>] [--value <v>] [--units vara|raw] [--gas-limit <n>] [--idl <path>] [--voucher <id>] [--estimate | --dry-run]
 ```
 
 For v2 programs (sails ≥ 1.0.0-beta.1) the IDL is auto-resolved from the program's on-chain WASM — `--idl` is only needed for v1 programs or when overriding with a local file. Resolved IDLs are cached under `~/.vara-wallet/idl-cache/` so subsequent calls skip the fetch.
+
+`--args-file <path>` reads the JSON args from a file instead of the `--args` string; use `-` for stdin (`echo '[...]' | vara-wallet call ... --args-file -`). Eliminates shell-escape failures with nested JSON containing hex actor IDs or 64-byte `vec u8` signatures. Mutually exclusive with `--args` (`INVALID_ARGS_SOURCE`). `--estimate` and `--dry-run` are mutually exclusive (`CONFLICTING_OPTIONS`).
+
+The JSON response includes an `events: [...]` field with any decoded Sails events emitted by the call, phase-correlated to the submitting extrinsic (cross-transaction events from the same block are excluded). Nested numeric leaves (`U256`, `u128`) inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user types are recursively decoded to decimal strings to match the declared IDL return type.
 
 ### `discover` (Sails)
 
@@ -309,7 +313,7 @@ Subscribe to on-chain events with NDJSON streaming and optional SQLite persisten
 
 ```bash
 vara-wallet subscribe blocks [--finalized]
-vara-wallet subscribe messages <programId> [--type <eventName>] [--from-block <n>]
+vara-wallet subscribe messages <programId> [--event <type>] [--type <eventName>] [--from-block <n>] [--idl <path>] [--pallet-event] [--no-decode]
 vara-wallet subscribe mailbox <address>
 vara-wallet subscribe balance <address>
 vara-wallet subscribe transfers [--from <addr>] [--to <addr>]
@@ -320,6 +324,8 @@ vara-wallet subscribe program <programId>
 - `--count <n>` — exit after N events (useful for scripting)
 - `--timeout <seconds>` — exit after N seconds
 - `--no-persist` — stream only, skip SQLite persistence
+
+`subscribe messages` shares the IDL-aware filtering and decoding behavior described under `watch` above (`--event Service/Event`, `--pallet-event`, `--no-decode`).
 
 ### `inbox`
 
@@ -344,15 +350,21 @@ vara-wallet events prune [--older-than <duration>]
 Stream program events as NDJSON. For persistent event capture with SQLite storage, see `subscribe` above.
 
 ```bash
-vara-wallet watch <programId> [--event <type>]
+vara-wallet watch <programId> [--event <type>] [--idl <path>] [--pallet-event] [--no-decode]
 ```
+
+`--event` accepts both Gear pallet event names (`UserMessageSent`, `MessageQueued`, ...) and Sails events as `Service/Event` or bare `Event` (when unambiguous across services). Pallet vocabulary resolves to the legacy pallet path first so existing scripts keep working; ambiguous bare Sails names fail fast with `AMBIGUOUS_EVENT` listing the alternatives.
+
+When an IDL is loaded (explicit `--idl` or auto-resolved from the on-chain WASM), each emitted `UserMessageSent` is augmented with a decoded `sails: { service, event, data }` block alongside the existing raw fields (`payload`, `source`, `destination`, ...) — additive, so consumers parsing raw NDJSON keep working. Use `--pallet-event` to force pallet-event resolution even with an IDL loaded; `--no-decode` disables the opportunistic IDL auto-load entirely.
 
 ### `encode` / `decode`
 
 ```bash
-vara-wallet encode <type> <value> [--metadata <path>] [--idl <path>] [--program <id>] [--method <Service/Method>]
+vara-wallet encode <type> [value] [--args-file <path>] [--metadata <path>] [--idl <path>] [--program <id>] [--method <Service/Method>]
 vara-wallet decode <type> <hex> [--metadata <path>] [--idl <path>] [--program <id>] [--method <Service/Method>]
 ```
+
+For `encode`, the JSON value can be passed positionally or via `--args-file <path>` (use `-` for stdin). Positional and `--args-file` are mutually exclusive (`INVALID_ARGS_SOURCE`). Stdin via `--args-file -` rejects fast with `STDIN_IS_TTY` when no pipe is attached.
 
 ### `config`
 
@@ -425,7 +437,10 @@ The `--hex` flag treats input as 0x-prefixed hex bytes (strict validation: even-
 | `WRONG_NETWORK` | Command not available on this network (e.g., faucet on mainnet) |
 | `INVALID_NETWORK` | Unknown `--network` value |
 | `INVALID_CONFIG_KEY` | Unknown config key passed to `config set/get` |
-| `CONFLICTING_OPTIONS` | Mutually exclusive options used together (e.g., `--network` + `--ws`) |
+| `CONFLICTING_OPTIONS` | Mutually exclusive options used together (e.g., `--network` + `--ws`, `--estimate` + `--dry-run`) |
+| `INVALID_ARGS_SOURCE` | `--args` and `--args-file` (or positional value + `--args-file` on `encode`) used together |
+| `STDIN_IS_TTY` | `--args-file -` used with no pipe attached |
+| `AMBIGUOUS_EVENT` | Bare Sails event name resolves to multiple services — qualify as `Service/Event` |
 | `FAUCET_ERROR` | Faucet request failed |
 | `PROGRAM_ERROR` | Sails program execution failed (panic/error) |
 | `FAUCET_LIMIT` | Faucet daily/hourly limit reached |

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Subscribe to on-chain events with NDJSON streaming and optional SQLite persisten
 
 ```bash
 vara-wallet subscribe blocks [--finalized]
-vara-wallet subscribe messages <programId> [--event <type>] [--type <eventName>] [--from-block <n>] [--idl <path>] [--pallet-event] [--no-decode]
+vara-wallet subscribe messages <programId> [--type <Service/Event | EventName>] [--from-block <n>] [--idl <path>] [--pallet-event] [--no-decode]
 vara-wallet subscribe mailbox <address>
 vara-wallet subscribe balance <address>
 vara-wallet subscribe transfers [--from <addr>] [--to <addr>]
@@ -325,7 +325,7 @@ vara-wallet subscribe program <programId>
 - `--timeout <seconds>` — exit after N seconds
 - `--no-persist` — stream only, skip SQLite persistence
 
-`subscribe messages` shares the IDL-aware filtering and decoding behavior described under `watch` above (`--event Service/Event`, `--pallet-event`, `--no-decode`).
+`subscribe messages` shares the IDL-aware filtering and decoding behavior described under `watch` above. The filter flag is named `--type` here (vs `--event` on `watch`), but accepts the same values: Gear pallet event names, qualified `Service/Event`, or bare Sails event names. `--pallet-event` and `--no-decode` work the same way.
 
 ### `inbox`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -81,10 +81,11 @@ export async function getApi(wsEndpoint?: string): Promise<GearApi> {
 // regardless of how esbuild bundles module scopes.
 const origStderrWrite = process.stderr.write.bind(process.stderr);
 const rpcCoreRe = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\s+RPC-CORE:/;
-process.stderr.write = ((chunk: Uint8Array | string, ...rest: unknown[]) => {
-  const s = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+process.stderr.write = ((...args: unknown[]) => {
+  const chunk = args[0];
+  const s = typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString();
   if (rpcCoreRe.test(s)) return true;
-  return origStderrWrite(chunk as any, ...rest);
+  return (origStderrWrite as (...a: unknown[]) => boolean)(...args);
 }) as typeof process.stderr.write;
 
 export function disconnectApi(): void {


### PR DESCRIPTION
## Summary

- Patch release covering #34 (`--json` stderr leak from `@polkadot` RPC-CORE disconnect noise during shutdown).
- Includes a follow-up TS-typing fix on the same wrapper. The original `e7cfc4c` patch typechecked under `esbuild` (transpile-only) but broke `ts-jest` — 7 test suites failed to compile, which would have blocked `release.yml`'s `npm test` step on tag push. Reworked the wrapper signature to satisfy both `process.stderr.write` overloads.
- `package.json` 0.14.0 → 0.14.1, `CHANGELOG.md` entry added.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 525/525 pass
- [ ] After merge: tag `v0.14.1` on `main` to trigger npm publish + GitHub Release