### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.0] - 2026-04-25
+
+This release unifies the CLI surface that 0.11.x – 0.14.x grew organically. npm registry is on 0.10.0 when this ships, so the breaking changes below affect git-tracking users only — there are no published-version users using the renamed flags / fields. Take the cleanup now while it's free.
+
+### Fixed
+- **IDL auto-resolve from on-chain WASM** worked nowhere. `option.unwrap().toU8a()` in `tryExtractFromChain` (`src/services/sails.ts:355`) returned the bytes with a SCALE compact-length prefix, so the WASM-magic check downstream failed on every program with a confusing `IDL_PARSE_ERROR`. Fixed with `.toU8a(true)`. After this, v1 programs cleanly fall through to `IDL_NOT_FOUND` (and the `--idl` / `idl import` paths take over), and v2 programs get a real shot at the cache. Verified end-to-end against polybaskets contracts. New regression test: `src/__tests__/sails-extract-from-chain.test.ts` (5 tests, mocks the codec to assert `isBare=true` is used).
+- **`call --dry-run` reported the wrong `encodedPayload`**. `txBuilder.payload` returns `this._tx.args[0].toHex()` in sails-js's `TransactionBuilder`, which is the destination program ID (the first arg of `api.message.send`), not the SCALE-encoded message. Field name lied about its contents. Fixed by using `func.encodePayload(...args)` — the canonical SCALE encoder on the function reference itself, mirroring the pattern queries already used. Also surfaces `destination: <hex>` as a separate field so callers see both pieces unambiguously.
+- **`vft balance` and `vft allowance` crashed with `BigInt(null)`** when `findVftService` resolved to `VftExtension` (declared as `opt u256`) and the account had no balance / allowance row. Routed both through the existing `decodeSailsResult` walker (`src/utils/decode-sails-result.ts`, landed in #40); null surfaces as `'0'` in both `balance` and `balanceRaw` (matching on-chain semantics where a missing row is indistinguishable from zero). Closes the P2 item from `TODOS.md`.
+
+### Added
+- **`vara-wallet idl list`** — prints every cached IDL entry as `[{ codeId, version, source, importedAt, idlSizeBytes }, ...]`. Empty cache returns `[]`. Corrupted entries surface as `{ codeId, error: 'corrupted', ... }` rows so a single bad file never crashes the listing.
+- **`vara-wallet idl remove <code-id>`** — removes one cache entry. Idempotent: removing a non-existent entry returns `{ removed: false, codeId }` and exit 0, not an error. Reuses the strict 32-byte hex validator from `idl import`.
+- **`vara-wallet idl clear [--yes]`** — terraform-style: bare invocation prints a `wouldRemove` preview without unlinking; `--yes` commits. Snapshot-then-unlink under the hood: enumeration happens once, `ENOENT` during unlink is swallowed (race tolerance for parallel writers — cache is a recoverable resource so locking is over-engineering). `EACCES` surfaces as a clean `PERMISSION_DENIED` error code.
+- **New helper `enumerateCacheEntries()` in `src/services/idl-cache.ts`** — single source of truth for the iteration shape, reused by both `idl list` and `idl clear` preview. Forward-compatible reads (optional chaining on every meta field) so a future writer adding fields, or a pre-this-PR entry missing some, never crashes.
+- **`call --dry-run --estimate` now compose**. Both are read-only previews; the legacy mutex (`CONFLICTING_OPTIONS`) was overly restrictive. With both set the output merges `encodedPayload`, `destination`, and `estimateGas: { gasLimit, minLimit }` (account required, since estimate does need one). Pure `--estimate` keeps its lean shape unchanged so existing scripts parsing it stay working.
+- **`pallet:` prefix on `--event`** — explicit way to force the pallet vocabulary even with an IDL loaded. Replaces the old `--pallet-event` flag with single-flag mental model. Example: `watch $PID --event pallet:UserMessageSent`. Bare names that match the legacy Gear vocab still resolve to the pallet path (back-compat unchanged).
+- **Smoke test (`scripts/smoke.mjs`) extended** with 7 new bundled-CLI checks covering `idl list/import/remove/clear` happy paths. Catches bundling regressions (esbuild tree-shaking, export renames) that unit tests run against source can't see.
+
+### Changed (breaking on the unreleased 0.11+ surface; no published-version users affected)
+- **`--units` vocabulary unified to `human | raw` everywhere**. Before: native commands took `vara | raw` (default `vara`); VFT and DEX took `raw | token` (default `raw`). Two parallel idioms with inverse defaults and inverse polarity. Now: every command accepts `--units human | raw`. `human` means "interpret with the appropriate decimals for this command" — VARA's 12 for native, the token's declared decimals for VFT, LP decimals for `dex add-liquidity`/`remove-liquidity`. Per-command defaults stay (less in-context surprise: native still defaults to `human`, VFT/DEX still default to `raw`); only the vocabulary changes. **The literals `vara` and `token` are intentionally rejected by the validator** with `INVALID_UNITS` — catches stale scripts at the first `--units` pass instead of giving silent wrong-decimals math downstream. Centralized in `resolveAmount(amount, units?: string)` (was `(amount, unitsRaw: boolean)`).
+- **`subscribe messages` flag `--type` renamed to `--event`** — same accepted values (Gear pallet name, Sails `Service/Event`, bare Sails event), unified with `watch` so the flag name doesn't depend on which subscribe sub-surface you happen to be in. One-line search/replace for any committed agent script.
+- **NDJSON `sails:` field renamed to `decoded: { kind: 'sails', service, event, data }`** on `watch` and `subscribe messages` output. The `kind` discriminator future-proofs the surface so a second decoder type (e.g. EVM events) can sit alongside without renaming the top-level field again. Scripts parsing `.sails.event` should read `.decoded.event` and check `.decoded.kind === 'sails'`.
+
+### Removed (breaking on the unreleased 0.11+ surface)
+- **`--pallet-event` flag dropped** on `watch` and `subscribe messages`. Use `--event pallet:<EventName>` instead. The previous flag only mattered when a Sails event name collided with a pallet event name; the new prefix works the same way explicitly.
+
+### Migration from 0.14.x (git users only — npm jumps from 0.10.0 → 0.15.0 in one go, no migration needed)
+1. **`subscribe messages --type X` → `subscribe messages --event X`**. Same accepted values.
+2. **`--pallet-event` → `--event pallet:<Name>`**. The `--pallet-event` flag stops working.
+3. **NDJSON `.sails.*` → `.decoded.*`**, plus check `.decoded.kind === 'sails'` for forward-compat with future decoder types.
+4. **`--units vara` (native commands) → `--units human`** (or omit; it's the default).
+5. **`--units token` (VFT/DEX) → `--units human`**.
+6. **`call --dry-run` JSON output**: the `encodedPayload` field now actually contains the SCALE-encoded call (was incorrectly the program ID); a separate `destination` field carries the program ID. Scripts that took `encodedPayload` and tried to use it as a program ID need to read `destination` instead.
+
 ## [0.14.1] - 2026-04-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.1] - 2026-04-25
+
+### Fixed
+- `--json` mode no longer leaks `@polkadot` RPC-CORE disconnect warnings to stderr during shutdown. Previously `vara-wallet node info --json`, `balance --json`, etc. could emit `RPC-CORE: ...disconnected from wss://...` lines that broke downstream JSON parsers. The earlier `console.warn` patch in `src/services/api.ts` didn't fire because esbuild's module bundling put the logger's `console.error` call in a different scope, and the matcher was checking the wrong argument index. Replaced with a `process.stderr.write` interceptor matching the logger's timestamped `RPC-CORE:` prefix — bundle-scope-independent. `--verbose` output unaffected. (#34)
+- TypeScript build of the same patch: `(chunk, ...rest)` signature didn't match the `process.stderr.write` overloads, so `ts-jest` failed to compile 7 test suites (esbuild bundling silently passed, masking the issue in `npm run build`). Reworked the wrapper to a single rest-parameter form that satisfies both overloads.
+
 ## [0.14.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,99 +4,57 @@ All notable changes to this project will be documented in this file.
 
 ## [0.15.0] - 2026-04-25
 
-This release unifies the CLI surface that 0.11.x – 0.14.x grew organically. npm registry is on 0.10.0 when this ships, so the breaking changes below affect git-tracking users only — there are no published-version users using the renamed flags / fields. Take the cleanup now while it's free.
+First publish since 0.10.0. This release collapses the work that landed in git as 0.11 / 0.12 / 0.13 / 0.14 / 0.14.1 (none reached npm) into a single coherent surface, plus the UX cleanup that surfaced when documenting them. Upgrading from 0.10.0: install fresh, no migration needed.
+
+### Added
+
+**IDL surface**
+- `idl import <path.idl> (--code-id <hex> | --program <hex|ss58>)` — seed the local IDL cache for v1 programs or out-of-band IDLs.
+- `idl list` — print every cached IDL entry as `[{ codeId, version, source, importedAt, idlSizeBytes }]`. Corrupted entries surface as `{ codeId, error: 'corrupted', ... }` rows so a single bad file never crashes the listing.
+- `idl remove <code-id>` — remove one entry. Idempotent: missing entries return `{ removed: false }` and exit 0.
+- `idl clear [--yes]` — terraform-style: bare invocation prints a `wouldRemove` preview without unlinking; `--yes` commits. `EACCES` surfaces as `PERMISSION_DENIED`.
+- Auto-resolve IDL from on-chain WASM for v2 programs (sails ≥ 1.0.0-beta.1): `call` and `discover` work without `--idl`. Extracted from the `sails:idl` custom section of the program's WASM via `gearProgram.originalCodeStorage(codeId)`. Cached at `~/.vara-wallet/idl-cache/<codeId>.cache.json`; subsequent calls skip the fetch. Cache entries are validator-gated for `vft`/`dex` — a poisoned import gets evicted on first validator miss.
+
+**Call surface**
+- `call --dry-run` — encode the SCALE payload and exit without signing or submitting. Output: `{ kind, service, method, args, encodedPayload, destination, value, gasLimit, voucherId, willSubmit: false }`. Works without a wallet.
+- `call --estimate --dry-run` compose: same dry-run shape with `estimateGas: { gasLimit, minLimit }` appended (account required since estimate needs one).
+- `--args-file <path>` on `call`, `encode`, `program upload`, `program deploy` — read JSON args from a file (`-` for stdin). Eliminates shell-escape failures with nested JSON, hex actor IDs, or 64-byte `vec u8` signatures. Mutually exclusive with `--args` (`INVALID_ARGS_SOURCE`); stdin without a pipe attached fails fast with `STDIN_IS_TTY`.
+- `--dry-run` on `program upload` and `program deploy` — encode the constructor payload + report resolved constructor name without uploading.
+- SS58 addresses (`5Grw...`) accepted in `--args` for any `ActorId`-typed positional or struct-nested argument. Canonical hex input remains byte-identical on the wire.
+- `events: [...]` field on `call` JSON response with phase-correlated decoded Sails events.
+- Cross-service hint on `METHOD_NOT_FOUND` ("Did you mean `OtherService/Method`?").
+- `PROGRAM_ERROR` carries a structured `reason` subcode for both function calls and queries.
+
+**Subscribe / watch**
+- IDL-aware event decoding: when an IDL is loaded, `UserMessageSent` events get a `decoded: { kind: 'sails', service, event, data }` block alongside the raw fields. Additive — consumers parsing raw NDJSON keep working. The `kind` discriminator future-proofs the surface for additional decoder types.
+- `--event` filter on both `watch` and `subscribe messages` accepts: Gear pallet event names, qualified `Service/Event`, bare Sails event names (when unambiguous across services), or `pallet:<Name>` to force pallet vocabulary even with an IDL loaded. Ambiguous bare Sails names hard-fail with `AMBIGUOUS_EVENT` listing the alternatives.
+- `--no-decode` to disable the opportunistic IDL auto-load entirely.
+- New `src/services/sails-events.ts` module exposing `decodeSailsEvent`, `listEventNames`, `resolveEventName`, `collectDecodedEvents`. Walks v2 `service.extends` recursively.
+
+**Wallet / chain**
+- `wallet keys <name>` — export raw key material (`address`, `publicKey`, `secretKeyPkcs8`, `type`) for Polkadot tooling.
+- `transfer --all` — drain the entire account via Substrate's native `transferAll` extrinsic (no client-side fee/ED math).
 
 ### Fixed
-- **IDL auto-resolve from on-chain WASM** worked nowhere. `option.unwrap().toU8a()` in `tryExtractFromChain` (`src/services/sails.ts:355`) returned the bytes with a SCALE compact-length prefix, so the WASM-magic check downstream failed on every program with a confusing `IDL_PARSE_ERROR`. Fixed with `.toU8a(true)`. After this, v1 programs cleanly fall through to `IDL_NOT_FOUND` (and the `--idl` / `idl import` paths take over), and v2 programs get a real shot at the cache. Verified end-to-end against polybaskets contracts. New regression test: `src/__tests__/sails-extract-from-chain.test.ts` (5 tests, mocks the codec to assert `isBare=true` is used).
-- **`call --dry-run` reported the wrong `encodedPayload`**. `txBuilder.payload` returns `this._tx.args[0].toHex()` in sails-js's `TransactionBuilder`, which is the destination program ID (the first arg of `api.message.send`), not the SCALE-encoded message. Field name lied about its contents. Fixed by using `func.encodePayload(...args)` — the canonical SCALE encoder on the function reference itself, mirroring the pattern queries already used. Also surfaces `destination: <hex>` as a separate field so callers see both pieces unambiguously.
-- **`vft balance` and `vft allowance` crashed with `BigInt(null)`** when `findVftService` resolved to `VftExtension` (declared as `opt u256`) and the account had no balance / allowance row. Routed both through the existing `decodeSailsResult` walker (`src/utils/decode-sails-result.ts`, landed in #40); null surfaces as `'0'` in both `balance` and `balanceRaw` (matching on-chain semantics where a missing row is indistinguishable from zero). Closes the P2 item from `TODOS.md`.
+- IDL auto-resolve from on-chain WASM was broken on every program: `option.unwrap().toU8a()` returned bytes with a SCALE compact-length prefix, so the WASM-magic check failed with a confusing `IDL_PARSE_ERROR`. Fixed with `.toU8a(true)`. Verified end-to-end against polybaskets contracts.
+- `call --dry-run` `encodedPayload` reported the destination program ID instead of the actual SCALE-encoded message (sails-js's `txBuilder.payload` is `args[0].toHex()`, not the encoded call). Fixed by using `func.encodePayload(...args)`. The destination program ID is now surfaced separately as `destination`.
+- `vft balance` and `vft allowance` crashed with `BigInt(null)` when `findVftService` resolved to `VftExtension.BalanceOf` (declared `opt u256`) for accounts with no balance row. Routed through `decodeSailsResult`; null surfaces as `'0'`.
+- Nested `U256` / `u128` / `u64` inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user-defined types now decode to decimal strings recursively (was: leaked as raw `0x...` hex). Applies to `call`, `vft`, and `dex` responses.
+- Sails program errors surface readable messages with `PROGRAM_ERROR` instead of `[object Object]`.
+- `--json` mode no longer leaks `@polkadot` RPC-CORE disconnect warnings to stderr during shutdown. Filter intercepts at `process.stderr.write` (bundle-scope-independent).
+- `formatError()` fallback properly serializes non-Error objects via `JSON.stringify`.
 
-### Added
-- **`vara-wallet idl list`** — prints every cached IDL entry as `[{ codeId, version, source, importedAt, idlSizeBytes }, ...]`. Empty cache returns `[]`. Corrupted entries surface as `{ codeId, error: 'corrupted', ... }` rows so a single bad file never crashes the listing.
-- **`vara-wallet idl remove <code-id>`** — removes one cache entry. Idempotent: removing a non-existent entry returns `{ removed: false, codeId }` and exit 0, not an error. Reuses the strict 32-byte hex validator from `idl import`.
-- **`vara-wallet idl clear [--yes]`** — terraform-style: bare invocation prints a `wouldRemove` preview without unlinking; `--yes` commits. Snapshot-then-unlink under the hood: enumeration happens once, `ENOENT` during unlink is swallowed (race tolerance for parallel writers — cache is a recoverable resource so locking is over-engineering). `EACCES` surfaces as a clean `PERMISSION_DENIED` error code.
-- **New helper `enumerateCacheEntries()` in `src/services/idl-cache.ts`** — single source of truth for the iteration shape, reused by both `idl list` and `idl clear` preview. Forward-compatible reads (optional chaining on every meta field) so a future writer adding fields, or a pre-this-PR entry missing some, never crashes.
-- **`call --dry-run --estimate` now compose**. Both are read-only previews; the legacy mutex (`CONFLICTING_OPTIONS`) was overly restrictive. With both set the output merges `encodedPayload`, `destination`, and `estimateGas: { gasLimit, minLimit }` (account required, since estimate does need one). Pure `--estimate` keeps its lean shape unchanged so existing scripts parsing it stay working.
-- **`pallet:` prefix on `--event`** — explicit way to force the pallet vocabulary even with an IDL loaded. Replaces the old `--pallet-event` flag with single-flag mental model. Example: `watch $PID --event pallet:UserMessageSent`. Bare names that match the legacy Gear vocab still resolve to the pallet path (back-compat unchanged).
-- **Smoke test (`scripts/smoke.mjs`) extended** with 7 new bundled-CLI checks covering `idl list/import/remove/clear` happy paths. Catches bundling regressions (esbuild tree-shaking, export renames) that unit tests run against source can't see.
+### Changed (breaking against 0.10.0 only where noted)
 
-### Changed (breaking on the unreleased 0.11+ surface; no published-version users affected)
-- **`--units` vocabulary unified to `human | raw` everywhere**. Before: native commands took `vara | raw` (default `vara`); VFT and DEX took `raw | token` (default `raw`). Two parallel idioms with inverse defaults and inverse polarity. Now: every command accepts `--units human | raw`. `human` means "interpret with the appropriate decimals for this command" — VARA's 12 for native, the token's declared decimals for VFT, LP decimals for `dex add-liquidity`/`remove-liquidity`. Per-command defaults stay (less in-context surprise: native still defaults to `human`, VFT/DEX still default to `raw`); only the vocabulary changes. **The literals `vara` and `token` are intentionally rejected by the validator** with `INVALID_UNITS` — catches stale scripts at the first `--units` pass instead of giving silent wrong-decimals math downstream. Centralized in `resolveAmount(amount, units?: string)` (was `(amount, unitsRaw: boolean)`).
-- **`subscribe messages` flag `--type` renamed to `--event`** — same accepted values (Gear pallet name, Sails `Service/Event`, bare Sails event), unified with `watch` so the flag name doesn't depend on which subscribe sub-surface you happen to be in. One-line search/replace for any committed agent script.
-- **NDJSON `sails:` field renamed to `decoded: { kind: 'sails', service, event, data }`** on `watch` and `subscribe messages` output. The `kind` discriminator future-proofs the surface so a second decoder type (e.g. EVM events) can sit alongside without renaming the top-level field again. Scripts parsing `.sails.event` should read `.decoded.event` and check `.decoded.kind === 'sails'`.
-
-### Removed (breaking on the unreleased 0.11+ surface)
-- **`--pallet-event` flag dropped** on `watch` and `subscribe messages`. Use `--event pallet:<EventName>` instead. The previous flag only mattered when a Sails event name collided with a pallet event name; the new prefix works the same way explicitly.
-
-### Migration from 0.14.x (git users only — npm jumps from 0.10.0 → 0.15.0 in one go, no migration needed)
-1. **`subscribe messages --type X` → `subscribe messages --event X`**. Same accepted values.
-2. **`--pallet-event` → `--event pallet:<Name>`**. The `--pallet-event` flag stops working.
-3. **NDJSON `.sails.*` → `.decoded.*`**, plus check `.decoded.kind === 'sails'` for forward-compat with future decoder types.
-4. **`--units vara` (native commands) → `--units human`** (or omit; it's the default).
-5. **`--units token` (VFT/DEX) → `--units human`**.
-6. **`call --dry-run` JSON output**: the `encodedPayload` field now actually contains the SCALE-encoded call (was incorrectly the program ID); a separate `destination` field carries the program ID. Scripts that took `encodedPayload` and tried to use it as a program ID need to read `destination` instead.
-
-## [0.14.1] - 2026-04-25
-
-### Fixed
-- `--json` mode no longer leaks `@polkadot` RPC-CORE disconnect warnings to stderr during shutdown. Previously `vara-wallet node info --json`, `balance --json`, etc. could emit `RPC-CORE: ...disconnected from wss://...` lines that broke downstream JSON parsers. The earlier `console.warn` patch in `src/services/api.ts` didn't fire because esbuild's module bundling put the logger's `console.error` call in a different scope, and the matcher was checking the wrong argument index. Replaced with a `process.stderr.write` interceptor matching the logger's timestamped `RPC-CORE:` prefix — bundle-scope-independent. `--verbose` output unaffected. (#34)
-- TypeScript build of the same patch: `(chunk, ...rest)` signature didn't match the `process.stderr.write` overloads, so `ts-jest` failed to compile 7 test suites (esbuild bundling silently passed, masking the issue in `npm run build`). Reworked the wrapper to a single rest-parameter form that satisfies both overloads.
-
-## [0.14.0] - 2026-04-24
-
-### Added
-- IDL-aware Sails event decoding in `watch` and `subscribe messages` (closes #36). Loading an IDL (explicitly via `--idl <path>` or auto-resolved from chain WASM) augments each emitted `UserMessageSent` with a `sails: {service, event, data}` block. Existing raw fields (`payload`, `source`, `destination`, etc.) are untouched, so consumers that already parse the raw NDJSON keep working.
-- `--event <Service/Event>` and bare-name Sails event filters on both `watch` and `subscribe messages`. Gear pallet vocabulary (`UserMessageSent`, `MessageQueued`, etc.) still resolves to the legacy pallet path first so existing scripts keep working. Ambiguous bare Sails names hard-fail with `AMBIGUOUS_EVENT` and list the alternatives.
-- `--pallet-event` flag on `watch` / `subscribe messages` to force Gear pallet event resolution even when an IDL is loaded, and `--no-decode` to disable the opportunistic IDL auto-load entirely.
-- Decoded Sails events are appended to the `call` JSON response under a new `events: [...]` key (closes #37). The event scan is phase-correlated to the submitting extrinsic, so cross-transaction events that share the block are excluded. Additive — existing response fields (`txHash`, `blockHash`, `messageId`, `result`, ...) are unchanged.
-- New `src/services/sails-events.ts` module exposing `decodeSailsEvent`, `listEventNames`, `resolveEventName`, and `collectDecodedEvents`. Recursively walks v2 `service.extends`, so events declared in an inherited service are discoverable in filter resolution and decoding.
-- Decoded event payloads flow through the shared `decodeEventData` walker (alias of `decodeSailsResult` from #32), so nested `Option<U256>`, `Vec<U256>`, and user-defined types normalize to the same JSON shape as `call` replies.
-- `--args-file <path>` on `call`, `encode`, `program upload`, and `program deploy` reads the JSON args from a file instead of the `--args` string. Use `-` for stdin (`echo '[...]' | vara-wallet call ... --args-file -`). Eliminates shell-escape failures when nested JSON contains hex actor IDs or 64-byte `vec u8` signatures (the failure mode that surfaced as `{"error":"[object Object]","code":"UNKNOWN_ERROR"}` during 2026-04-23 live testing). Closes [#20](https://github.com/gear-foundation/vara-wallet/issues/20).
-- `--dry-run` on `call`, `program upload`, and `program deploy`: encode the SCALE payload and exit without signing or submitting. Output includes the encoded hex, resolved constructor name (for upload/deploy), and `willSubmit: false`. Works without a wallet configured — agents can preview payloads on read-only machines.
-
-### Changed
-- `--args` and `--args-file` are mutually exclusive (`code: INVALID_ARGS_SOURCE`). `--estimate` and `--dry-run` are mutually exclusive on `call` (`code: CONFLICTING_OPTIONS`). Malformed-JSON errors from `--args-file` never echo the file path or content (file may contain test seeds); error reports parse position only.
-- Stdin (`--args-file -`) rejects fast with `STDIN_IS_TTY` when no pipe is attached, instead of hanging waiting for EOF — common AI-agent footgun.
-
-## [0.13.0] - 2026-04-24
-
-### Added
-- Auto-resolve IDL from on-chain WASM for v2 programs (sails ≥ 1.0.0-beta.1): `vara-wallet call` and `vara-wallet discover` now work on any such program without `--idl`. IDL is extracted from the `sails:idl` custom section of the program's original WASM via `gearProgram.originalCodeStorage(codeId)`.
-- Local IDL cache at `~/.vara-wallet/idl-cache/<codeId>.cache.json`. First call against a program fetches the WASM and populates the cache; subsequent calls are free.
-- `vara-wallet idl import <path.idl> (--code-id <hex> | --program <hex|ss58>)` command for seeding the cache with out-of-band IDLs (v1 programs, or any case where the on-chain WASM doesn't carry the section).
-- IDL cache entries are validator-gated on read for `vft`/`dex` commands: if a cached IDL fails the caller's validator (e.g. a bad `idl import` against a VFT program), the entry is evicted and the bundled fallback is tried. Preserves the pre-cache safety contract.
-- Strict validation on `--code-id` input (32-byte hex, with or without `0x` prefix) — rejects path-traversal attempts and malformed hex before they reach the cache layer.
-
-### Removed / Breaking
-- **`metaStorageUrl` config key and `VARA_META_STORAGE` env var are gone.** `vara-wallet config set metaStorageUrl <url>` now errors with `INVALID_CONFIG_KEY`. Empirically the meta-storage endpoint returned 0/13 usable IDLs during 2026-04-23 testing; the new WASM-custom-section path replaces it for v2, and `idl import` replaces it for v1. Stale entries in existing `~/.vara-wallet/config.json` files are silently ignored (no migration required).
+- **CLI is bundled to a single `dist/app.js`** with esbuild. Runtime dependencies shrink from ~120 transitive packages to 2 (`better-sqlite3`, `smoldot`). Fixes the `npm install -g vara-wallet` hangs reported in 0.10. Global install is now ~2 MB gzipped.
+- **Node.js 20 or newer required** (`engines: { node: ">=20" }`). Breaking for any user still on Node 18 or older.
+- **`--units` vocabulary unified to `human | raw`** across every command (was: `vara | raw` for native, `raw | token` for VFT/DEX). `human` interprets with the appropriate decimals — VARA's 12 for native, the token's declared decimals for VFT, LP decimals for `dex add-liquidity`/`remove-liquidity`. Per-command defaults preserved (native still defaults to `human`, VFT/DEX still default to `raw`); only the literal name changes. **The legacy literals `vara` and `token` are rejected with `INVALID_UNITS`** — agents copying old `--units vara` invocations get a clear validator error, not silent wrong-decimals math.
+- **`metaStorageUrl` config key and `VARA_META_STORAGE` env var are removed.** `config set metaStorageUrl <url>` errors with `INVALID_CONFIG_KEY`. Empirically the endpoint returned near-zero usable IDLs; the new WASM-custom-section auto-resolve replaces it for v2, `idl import` replaces it for v1. Stale entries in existing config files are silently ignored.
 
 ### Internal
-- Extracted `writeUserFile` / `writeUserFileAtomic` helpers to `src/utils/secure-file.ts`; `config.ts`, `wallet-store.ts`, and the new `idl-cache.ts` share the "mode 0700 parent + mode 0600 file" idiom.
-
-## [0.12.0] - 2026-04-23
-
-### Added
-- `call`, `encode`, and `program deploy` now accept SS58 addresses (`5Grw...`) in `--args` for any `ActorId`-typed positional or struct-nested argument. Previously only 32-byte hex was accepted, forcing users to manually decode addresses copied from Subscan before passing them to Sails methods like `Vft/BalanceOf`. Canonical hex input remains byte-identical on the wire. Closes [#31](https://github.com/gear-foundation/vara-wallet/issues/31).
-
-### Fixed
-- `call --json` now recursively decodes nested `U256` / `u128` / `u64` into decimal strings when they appear inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user-defined types. Previously only top-level primitives decoded correctly; nested numeric leaves leaked as raw `0x...` hex. Same fix applied to `vft` and `dex` transaction responses (#32).
-- `VftExtension/BalanceOf` now returns `{"result": "186726170"}` (or `null`) instead of a 32-byte hex blob.
-- `VftExtension/Allowances` now returns fully-decoded nested arrays — every inner `U256` is a decimal string, tuples stay as arrays, `ActorId` entries stay hex.
-- Faucet test suite no longer reads the developer's real `~/.vara-wallet/config.json`. The mainnet guard at `faucet.ts:49` was triggering on any dev machine with a mainnet `wsEndpoint` configured, failing 6 tests locally even though CI stayed green.
-
-### Changed
-- **Breaking (for anyone parsing raw hex from `--json` output):** the shape of `result` now matches the declared IDL return type at every level. Callers that expected `"0x..."` for nested `U256` must read the decimal string instead. Top-level primitives (`Vft/TotalSupply`, `VftMetadata/Symbol`) are unchanged.
-
-## [0.11.0] - 2026-04-22
-
-### Added
-- `wallet keys <name>` command: export raw key material (`address`, `publicKey`, `secretKeyPkcs8`, `type`) for use with Polkadot tooling
-- `transfer --all` flag: drain the entire account via Substrate's native `transferAll` extrinsic (no client-side fee/ED math)
-
-### Changed
-- **CLI is now bundled with esbuild into a single `dist/app.js`.** Runtime dependencies shrink from ~120 transitive packages to 2 (`better-sqlite3`, `smoldot`). Fixes reports of `npm install -g vara-wallet` hanging for minutes on slow networks, where npm's retry policy turned stalled tarball fetches into multi-minute retry storms. Global install is now ~2 MB gzipped and a few seconds on any network.
-- **Node.js 20 or newer is now required** (`engines: { node: ">=20" }`). Matches the existing CI matrix.
-- Build script: `npm run build` now invokes `node scripts/build.mjs` instead of `tsc`.
+- Build script: `npm run build` invokes `node scripts/build.mjs` (was: `tsc`).
+- Extracted `writeUserFile` / `writeUserFileAtomic` helpers to `src/utils/secure-file.ts`; `config.ts`, `wallet-store.ts`, and `idl-cache.ts` share the "mode 0700 parent + mode 0600 file" idiom.
+- New regression tests for the on-chain IDL extraction (`sails-extract-from-chain.test.ts`), dry-run encoding contract (`dry-run.test.ts` extended), VFT null-safety (`vft-balance-null-safety.test.ts`), and IDL cache list/remove/clear (`idl-list-remove-clear.test.ts`). 525 → 563 tests.
 
 ## [0.10.0] - 2026-04-09
 

--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ Gas is auto-calculated if `--gas-limit` is omitted. Destination can be any actor
 ### `program`
 
 ```bash
-vara-wallet program upload <wasm> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>]
-vara-wallet program deploy <codeId> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>]
+vara-wallet program upload <wasm> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
+vara-wallet program deploy <codeId> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
 vara-wallet program info <programId>
 vara-wallet program list [--count <n>] [--all]
 ```
 
-Use `--idl` to auto-encode the constructor payload from a Sails IDL file. The constructor is auto-selected if the IDL has only one; use `--init <name>` when multiple constructors exist. `--args` passes constructor arguments as a JSON array. `--payload` and `--idl` are mutually exclusive.
+Use `--idl` to auto-encode the constructor payload from a Sails IDL file. The constructor is auto-selected if the IDL has only one; use `--init <name>` when multiple constructors exist. `--args` passes constructor arguments as a JSON array, or use `--args-file <path>` to read JSON from a file (or `-` for stdin). `--payload` and `--idl` are mutually exclusive. `--dry-run` encodes the constructor payload and exits without signing or submitting; the response reports the resolved constructor name, encoded hex, and `willSubmit: false`.
 
 ```bash
 # Deploy with IDL-based constructor encoding (auto-selects "New" constructor)
@@ -203,13 +203,17 @@ vara-wallet code list [--count <n>]
 
 ### `call` (Sails)
 
-High-level method invocation on Sails programs. Auto-detects queries vs functions. Use `--estimate` to calculate gas cost without sending the transaction (requires an account).
+High-level method invocation on Sails programs. Auto-detects queries vs functions. Use `--estimate` to calculate gas cost without sending the transaction (requires an account). Use `--dry-run` to encode the SCALE payload and exit without signing or submitting (works without a wallet — useful for previewing payloads on read-only machines).
 
 ```bash
-vara-wallet call <programId> <Service/Method> [--args <json>] [--value <v>] [--units vara|raw] [--gas-limit <n>] [--idl <path>] [--voucher <id>] [--estimate]
+vara-wallet call <programId> <Service/Method> [--args <json> | --args-file <path>] [--value <v>] [--units vara|raw] [--gas-limit <n>] [--idl <path>] [--voucher <id>] [--estimate | --dry-run]
 ```
 
 For v2 programs (sails ≥ 1.0.0-beta.1) the IDL is auto-resolved from the program's on-chain WASM — `--idl` is only needed for v1 programs or when overriding with a local file. Resolved IDLs are cached under `~/.vara-wallet/idl-cache/` so subsequent calls skip the fetch.
+
+`--args-file <path>` reads the JSON args from a file instead of the `--args` string; use `-` for stdin (`echo '[...]' | vara-wallet call ... --args-file -`). Eliminates shell-escape failures with nested JSON containing hex actor IDs or 64-byte `vec u8` signatures. Mutually exclusive with `--args` (`INVALID_ARGS_SOURCE`). `--estimate` and `--dry-run` are mutually exclusive (`CONFLICTING_OPTIONS`).
+
+The JSON response includes an `events: [...]` field with any decoded Sails events emitted by the call, phase-correlated to the submitting extrinsic (cross-transaction events from the same block are excluded). Nested numeric leaves (`U256`, `u128`) inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user types are recursively decoded to decimal strings to match the declared IDL return type.
 
 ### `discover` (Sails)
 
@@ -309,7 +313,7 @@ Subscribe to on-chain events with NDJSON streaming and optional SQLite persisten
 
 ```bash
 vara-wallet subscribe blocks [--finalized]
-vara-wallet subscribe messages <programId> [--type <eventName>] [--from-block <n>]
+vara-wallet subscribe messages <programId> [--event <type>] [--type <eventName>] [--from-block <n>] [--idl <path>] [--pallet-event] [--no-decode]
 vara-wallet subscribe mailbox <address>
 vara-wallet subscribe balance <address>
 vara-wallet subscribe transfers [--from <addr>] [--to <addr>]
@@ -320,6 +324,8 @@ vara-wallet subscribe program <programId>
 - `--count <n>` — exit after N events (useful for scripting)
 - `--timeout <seconds>` — exit after N seconds
 - `--no-persist` — stream only, skip SQLite persistence
+
+`subscribe messages` shares the IDL-aware filtering and decoding behavior described under `watch` above (`--event Service/Event`, `--pallet-event`, `--no-decode`).
 
 ### `inbox`
 
@@ -344,15 +350,21 @@ vara-wallet events prune [--older-than <duration>]
 Stream program events as NDJSON. For persistent event capture with SQLite storage, see `subscribe` above.
 
 ```bash
-vara-wallet watch <programId> [--event <type>]
+vara-wallet watch <programId> [--event <type>] [--idl <path>] [--pallet-event] [--no-decode]
 ```
+
+`--event` accepts both Gear pallet event names (`UserMessageSent`, `MessageQueued`, ...) and Sails events as `Service/Event` or bare `Event` (when unambiguous across services). Pallet vocabulary resolves to the legacy pallet path first so existing scripts keep working; ambiguous bare Sails names fail fast with `AMBIGUOUS_EVENT` listing the alternatives.
+
+When an IDL is loaded (explicit `--idl` or auto-resolved from the on-chain WASM), each emitted `UserMessageSent` is augmented with a decoded `sails: { service, event, data }` block alongside the existing raw fields (`payload`, `source`, `destination`, ...) — additive, so consumers parsing raw NDJSON keep working. Use `--pallet-event` to force pallet-event resolution even with an IDL loaded; `--no-decode` disables the opportunistic IDL auto-load entirely.
 
 ### `encode` / `decode`
 
 ```bash
-vara-wallet encode <type> <value> [--metadata <path>] [--idl <path>] [--program <id>] [--method <Service/Method>]
+vara-wallet encode <type> [value] [--args-file <path>] [--metadata <path>] [--idl <path>] [--program <id>] [--method <Service/Method>]
 vara-wallet decode <type> <hex> [--metadata <path>] [--idl <path>] [--program <id>] [--method <Service/Method>]
 ```
+
+For `encode`, the JSON value can be passed positionally or via `--args-file <path>` (use `-` for stdin). Positional and `--args-file` are mutually exclusive (`INVALID_ARGS_SOURCE`). Stdin via `--args-file -` rejects fast with `STDIN_IS_TTY` when no pipe is attached.
 
 ### `config`
 
@@ -425,7 +437,10 @@ The `--hex` flag treats input as 0x-prefixed hex bytes (strict validation: even-
 | `WRONG_NETWORK` | Command not available on this network (e.g., faucet on mainnet) |
 | `INVALID_NETWORK` | Unknown `--network` value |
 | `INVALID_CONFIG_KEY` | Unknown config key passed to `config set/get` |
-| `CONFLICTING_OPTIONS` | Mutually exclusive options used together (e.g., `--network` + `--ws`) |
+| `CONFLICTING_OPTIONS` | Mutually exclusive options used together (e.g., `--network` + `--ws`, `--estimate` + `--dry-run`) |
+| `INVALID_ARGS_SOURCE` | `--args` and `--args-file` (or positional value + `--args-file` on `encode`) used together |
+| `STDIN_IS_TTY` | `--args-file -` used with no pipe attached |
+| `AMBIGUOUS_EVENT` | Bare Sails event name resolves to multiple services — qualify as `Service/Event` |
 | `FAUCET_ERROR` | Faucet request failed |
 | `PROGRAM_ERROR` | Sails program execution failed (panic/error) |
 | `FAUCET_LIMIT` | Faucet daily/hourly limit reached |

--- a/README.md
+++ b/README.md
@@ -203,17 +203,19 @@ vara-wallet code list [--count <n>]
 
 ### `call` (Sails)
 
-High-level method invocation on Sails programs. Auto-detects queries vs functions. Use `--estimate` to calculate gas cost without sending the transaction (requires an account). Use `--dry-run` to encode the SCALE payload and exit without signing or submitting (works without a wallet — useful for previewing payloads on read-only machines).
+High-level method invocation on Sails programs. Auto-detects queries vs functions. `--estimate` computes gas cost (account required). `--dry-run` encodes the SCALE payload without signing / submitting (no account needed, useful for previewing on read-only machines). The two compose: passing both encodes AND estimates in one call.
 
 ```bash
-vara-wallet call <programId> <Service/Method> [--args <json> | --args-file <path>] [--value <v>] [--units vara|raw] [--gas-limit <n>] [--idl <path>] [--voucher <id>] [--estimate | --dry-run]
+vara-wallet call <programId> <Service/Method> [--args <json> | --args-file <path>] [--value <v>] [--units human|raw] [--gas-limit <n>] [--idl <path>] [--voucher <id>] [--estimate] [--dry-run]
 ```
 
-For v2 programs (sails ≥ 1.0.0-beta.1) the IDL is auto-resolved from the program's on-chain WASM — `--idl` is only needed for v1 programs or when overriding with a local file. Resolved IDLs are cached under `~/.vara-wallet/idl-cache/` so subsequent calls skip the fetch.
+For v2 programs (sails ≥ 1.0.0-beta.1) the IDL is auto-resolved from the program's on-chain WASM — `--idl` is only needed for v1 programs (use `idl import`) or when overriding with a local file. Resolved IDLs are cached under `~/.vara-wallet/idl-cache/` so subsequent calls skip the fetch. Inspect or evict the cache with `vara-wallet idl list/remove/clear`.
 
-`--args-file <path>` reads the JSON args from a file instead of the `--args` string; use `-` for stdin (`echo '[...]' | vara-wallet call ... --args-file -`). Eliminates shell-escape failures with nested JSON containing hex actor IDs or 64-byte `vec u8` signatures. Mutually exclusive with `--args` (`INVALID_ARGS_SOURCE`). `--estimate` and `--dry-run` are mutually exclusive (`CONFLICTING_OPTIONS`).
+`--args-file <path>` reads the JSON args from a file instead of the `--args` string; use `-` for stdin (`echo '[...]' | vara-wallet call ... --args-file -`). Eliminates shell-escape failures with nested JSON containing hex actor IDs or 64-byte `vec u8` signatures. Mutually exclusive with `--args` (`INVALID_ARGS_SOURCE`).
 
-The JSON response includes an `events: [...]` field with any decoded Sails events emitted by the call, phase-correlated to the submitting extrinsic (cross-transaction events from the same block are excluded). Nested numeric leaves (`U256`, `u128`) inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user types are recursively decoded to decimal strings to match the declared IDL return type.
+`--dry-run` output includes `encodedPayload` (the actual SCALE-encoded call bytes — round-trippable via `decode`), `destination` (the program ID the message is bound for), and `willSubmit: false`. With `--estimate` also set, `estimateGas: { gasLimit, minLimit }` is appended.
+
+The JSON response from a real submission includes an `events: [...]` field with any decoded Sails events emitted by the call, phase-correlated to the submitting extrinsic (cross-transaction events from the same block are excluded). Nested numeric leaves (`U256`, `u128`) inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user types are recursively decoded to decimal strings to match the declared IDL return type.
 
 ### `discover` (Sails)
 
@@ -227,15 +229,19 @@ Same auto-resolution as `call`.
 
 ### `idl` (Sails IDL cache)
 
-Seed the local IDL cache with an out-of-band IDL. Needed for v1 programs (no embedded IDL in WASM) and for one-off imports. Once imported, `call`/`discover`/`vft`/`dex` find the IDL automatically for that program's `codeId`.
+Manage the local IDL cache at `~/.vara-wallet/idl-cache/`. The cache is populated automatically when v2 programs auto-resolve their IDL from on-chain WASM, or manually via `idl import` for v1 programs (no embedded IDL section).
 
 ```bash
-# Import an IDL for a specific program (resolves codeId via RPC)
-vara-wallet idl import ./my-program.idl --program <programId>
-
-# Import for a known codeId — fully offline
-vara-wallet idl import ./my-program.idl --code-id 0x<hex>
+vara-wallet idl import <path.idl> (--code-id <hex> | --program <hex|ss58>)
+vara-wallet idl list
+vara-wallet idl remove <code-id>
+vara-wallet idl clear [--yes]
 ```
+
+- **`idl import`** seeds the cache with an out-of-band IDL. `--code-id` is fully offline; `--program` resolves `codeId` via RPC. Once imported, `call`/`discover`/`vft`/`dex` find the IDL automatically for that program's `codeId`.
+- **`idl list`** prints `[{ codeId, version, source, importedAt, idlSizeBytes }, ...]`. Empty cache returns `[]`. Corrupted entries surface as `{ codeId, error: 'corrupted', ... }` rows so a single bad file never crashes the listing.
+- **`idl remove <code-id>`** removes one entry. Idempotent: removing a non-existent entry returns `{ removed: false, codeId }` and exit 0.
+- **`idl clear`** (terraform-style) — bare invocation prints a `wouldRemove` preview without unlinking; `--yes` commits and prints `{ removed: N, path }`. Snapshot-then-unlink: ENOENT for entries removed by parallel writers between enumeration and unlink is swallowed.
 
 ### `vft` (Fungible Tokens)
 
@@ -245,14 +251,14 @@ Works out of the box with standard VFT programs — no `--idl` needed (bundled I
 vara-wallet vft info <tokenProgram> [--idl <path>]
 vara-wallet vft balance <tokenProgram> [account] [--idl <path>]
 vara-wallet vft allowance <tokenProgram> <owner> <spender> [--idl <path>]
-vara-wallet vft transfer <tokenProgram> <to> <amount> [--idl <path>] [--units raw|token] [--voucher <id>]
-vara-wallet vft approve <tokenProgram> <spender> <amount> [--idl <path>] [--units raw|token] [--voucher <id>]
-vara-wallet vft transfer-from <tokenProgram> <from> <to> <amount> [--idl <path>] [--units raw|token] [--voucher <id>]
-vara-wallet vft mint <tokenProgram> <to> <amount> [--idl <path>] [--units raw|token] [--voucher <id>]
-vara-wallet vft burn <tokenProgram> <from> <amount> [--idl <path>] [--units raw|token] [--voucher <id>]
+vara-wallet vft transfer <tokenProgram> <to> <amount> [--idl <path>] [--units human|raw] [--voucher <id>]
+vara-wallet vft approve <tokenProgram> <spender> <amount> [--idl <path>] [--units human|raw] [--voucher <id>]
+vara-wallet vft transfer-from <tokenProgram> <from> <to> <amount> [--idl <path>] [--units human|raw] [--voucher <id>]
+vara-wallet vft mint <tokenProgram> <to> <amount> [--idl <path>] [--units human|raw] [--voucher <id>]
+vara-wallet vft burn <tokenProgram> <from> <amount> [--idl <path>] [--units human|raw] [--voucher <id>]
 ```
 
-Use `--units token` to pass human-readable amounts (e.g., `1.5` → auto-converts using on-chain decimals). Default is `raw` (minimal units).
+`--units human` passes amounts using the token's declared decimals (e.g., `1.5` auto-converts via the on-chain `Decimals` query). Default is `raw` (minimal units, passthrough as bigint). The legacy `token` literal was renamed to `human` in 0.15.0 for cross-command consistency. `vft balance` and `vft allowance` safely return `'0'` when the underlying query is `opt u256` and the account has no row (was a `BigInt(null)` crash in 0.14.x).
 
 ### `dex` (DEX Trading)
 
@@ -263,18 +269,18 @@ Rivr DEX testnet factory: `0xaec14c514124fffa6c4b832ba7c12fa19e7fa663774c549c114
 ```bash
 vara-wallet dex pairs [--factory <addr>] [--limit <n>]
 vara-wallet dex pool <token0> <token1> [--factory <addr>]
-vara-wallet dex quote <tokenIn> <tokenOut> <amount> [--reverse] [--units raw|token]
+vara-wallet dex quote <tokenIn> <tokenOut> <amount> [--reverse] [--units human|raw]
 vara-wallet dex swap <tokenIn> <tokenOut> <amount> [--slippage <bps>] [--deadline <s>] [--exact-out] [--skip-approve] [--voucher <id>]
 vara-wallet dex add-liquidity <token0> <token1> <amount0> <amount1> [--slippage <bps>] [--deadline <s>] [--skip-approve] [--voucher <id>]
 vara-wallet dex remove-liquidity <token0> <token1> <liquidity> [--slippage <bps>] [--deadline <s>] [--skip-approve] [--voucher <id>]
 ```
 
-Slippage is in basis points (100 = 1%, default). Swaps auto-approve input tokens unless `--skip-approve` is set. Use `--units token` to pass human-readable amounts.
+Slippage is in basis points (100 = 1%, default). Swaps auto-approve input tokens unless `--skip-approve` is set. Use `--units human` to pass amounts in the token's declared decimals (e.g. `1.5`); default is `raw` (minimal units).
 
 ### `voucher`
 
 ```bash
-vara-wallet voucher issue <spender> <value> [--units vara|raw] [--duration <blocks>] [--programs <ids>]
+vara-wallet voucher issue <spender> <value> [--units human|raw] [--duration <blocks>] [--programs <ids>]
 vara-wallet voucher list <account> [--program <id>]
 vara-wallet voucher revoke <spender> <voucherId>
 ```
@@ -313,7 +319,7 @@ Subscribe to on-chain events with NDJSON streaming and optional SQLite persisten
 
 ```bash
 vara-wallet subscribe blocks [--finalized]
-vara-wallet subscribe messages <programId> [--type <Service/Event | EventName>] [--from-block <n>] [--idl <path>] [--pallet-event] [--no-decode]
+vara-wallet subscribe messages <programId> [--event <Service/Event | EventName | pallet:Name>] [--from-block <n>] [--idl <path>] [--no-decode]
 vara-wallet subscribe mailbox <address>
 vara-wallet subscribe balance <address>
 vara-wallet subscribe transfers [--from <addr>] [--to <addr>]
@@ -325,7 +331,7 @@ vara-wallet subscribe program <programId>
 - `--timeout <seconds>` — exit after N seconds
 - `--no-persist` — stream only, skip SQLite persistence
 
-`subscribe messages` shares the IDL-aware filtering and decoding behavior described under `watch` above. The filter flag is named `--type` here (vs `--event` on `watch`), but accepts the same values: Gear pallet event names, qualified `Service/Event`, or bare Sails event names. `--pallet-event` and `--no-decode` work the same way.
+`subscribe messages` and `watch` share the IDL-aware filtering / decoding behavior. Both use `--event` (renamed from `--type` in 0.15.0 for consistency).
 
 ### `inbox`
 
@@ -350,12 +356,16 @@ vara-wallet events prune [--older-than <duration>]
 Stream program events as NDJSON. For persistent event capture with SQLite storage, see `subscribe` above.
 
 ```bash
-vara-wallet watch <programId> [--event <type>] [--idl <path>] [--pallet-event] [--no-decode]
+vara-wallet watch <programId> [--event <type>] [--idl <path>] [--no-decode]
 ```
 
-`--event` accepts both Gear pallet event names (`UserMessageSent`, `MessageQueued`, ...) and Sails events as `Service/Event` or bare `Event` (when unambiguous across services). Pallet vocabulary resolves to the legacy pallet path first so existing scripts keep working; ambiguous bare Sails names fail fast with `AMBIGUOUS_EVENT` listing the alternatives.
+`--event` accepts:
+- **Gear pallet event names** (`UserMessageSent`, `MessageQueued`, ...) — bare names that match the legacy pallet vocab always resolve to the pallet path, so existing scripts keep working.
+- **Qualified Sails events** as `Service/Event` — always unambiguous.
+- **Bare Sails event names** — succeed when exactly one service declares the event. Multiple-service collisions hard-fail with `AMBIGUOUS_EVENT` listing the alternatives.
+- **`pallet:<Name>` prefix** — explicitly forces pallet vocabulary even when an IDL is loaded. Replaces the old `--pallet-event` flag (removed in 0.15.0). Example: `--event pallet:UserMessageSent`.
 
-When an IDL is loaded (explicit `--idl` or auto-resolved from the on-chain WASM), each emitted `UserMessageSent` is augmented with a decoded `sails: { service, event, data }` block alongside the existing raw fields (`payload`, `source`, `destination`, ...) — additive, so consumers parsing raw NDJSON keep working. Use `--pallet-event` to force pallet-event resolution even with an IDL loaded; `--no-decode` disables the opportunistic IDL auto-load entirely.
+When an IDL is loaded (explicit `--idl` or auto-resolved from the on-chain WASM), each emitted `UserMessageSent` is augmented with a `decoded: { kind: 'sails', service, event, data }` block alongside the existing raw fields (`payload`, `source`, `destination`, ...) — additive, so consumers parsing raw NDJSON keep working. The `kind` discriminator future-proofs the surface for additional decoder types. (Renamed from `sails: {...}` in 0.15.0.) `--no-decode` disables the opportunistic IDL auto-load entirely.
 
 ### `encode` / `decode`
 
@@ -437,9 +447,12 @@ The `--hex` flag treats input as 0x-prefixed hex bytes (strict validation: even-
 | `WRONG_NETWORK` | Command not available on this network (e.g., faucet on mainnet) |
 | `INVALID_NETWORK` | Unknown `--network` value |
 | `INVALID_CONFIG_KEY` | Unknown config key passed to `config set/get` |
-| `CONFLICTING_OPTIONS` | Mutually exclusive options used together (e.g., `--network` + `--ws`, `--estimate` + `--dry-run`) |
+| `CONFLICTING_OPTIONS` | Mutually exclusive options used together (e.g., `--network` + `--ws`). Note: `--estimate` + `--dry-run` *compose* on `call` since 0.15.0 (no longer conflicting) |
 | `INVALID_ARGS_SOURCE` | `--args` and `--args-file` (or positional value + `--args-file` on `encode`) used together |
 | `STDIN_IS_TTY` | `--args-file -` used with no pipe attached |
+| `INVALID_UNITS` | `--units` value isn't `human` or `raw` (rejects legacy `vara` / `token` literals from pre-0.15) |
+| `PERMISSION_DENIED` | OS-level permission error (e.g. `idl clear --yes` on a read-only cache dir) |
+| `INVALID_CODE_ID` | `--code-id` argument isn't a 32-byte hex string |
 | `AMBIGUOUS_EVENT` | Bare Sails event name resolves to multiple services — qualify as `Service/Event` |
 | `FAUCET_ERROR` | Faucet request failed |
 | `PROGRAM_ERROR` | Sails program execution failed (panic/error) |

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Subscribe to on-chain events with NDJSON streaming and optional SQLite persisten
 
 ```bash
 vara-wallet subscribe blocks [--finalized]
-vara-wallet subscribe messages <programId> [--event <type>] [--type <eventName>] [--from-block <n>] [--idl <path>] [--pallet-event] [--no-decode]
+vara-wallet subscribe messages <programId> [--type <Service/Event | EventName>] [--from-block <n>] [--idl <path>] [--pallet-event] [--no-decode]
 vara-wallet subscribe mailbox <address>
 vara-wallet subscribe balance <address>
 vara-wallet subscribe transfers [--from <addr>] [--to <addr>]
@@ -325,7 +325,7 @@ vara-wallet subscribe program <programId>
 - `--timeout <seconds>` — exit after N seconds
 - `--no-persist` — stream only, skip SQLite persistence
 
-`subscribe messages` shares the IDL-aware filtering and decoding behavior described under `watch` above (`--event Service/Event`, `--pallet-event`, `--no-decode`).
+`subscribe messages` shares the IDL-aware filtering and decoding behavior described under `watch` above. The filter flag is named `--type` here (vs `--event` on `watch`), but accepts the same values: Gear pallet event names, qualified `Service/Event`, or bare Sails event names. `--pallet-event` and `--no-decode` work the same way.
 
 ### `inbox`
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ vara-wallet node info
 
 ```bash
 vara-wallet balance [address]
-vara-wallet transfer <to> <amount> [--units vara|raw]
+vara-wallet transfer <to> <amount> [--units human|raw]
 vara-wallet transfer <to> --all
 ```
 
@@ -164,9 +164,9 @@ vara-wallet transfer <to> --all
 ### `message`
 
 ```bash
-vara-wallet message send <destination> [--payload <hex>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--metadata <path>] [--voucher <id>]
-vara-wallet message reply <messageId> [--payload <hex>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--metadata <path>] [--voucher <id>]
-vara-wallet message calculate-reply <programId> [--payload <hex>] [--value <v>] [--units vara|raw] [--origin <addr>] [--at <blockHash>]
+vara-wallet message send <destination> [--payload <hex>] [--gas-limit <n>] [--value <v>] [--units human|raw] [--metadata <path>] [--voucher <id>]
+vara-wallet message reply <messageId> [--payload <hex>] [--gas-limit <n>] [--value <v>] [--units human|raw] [--metadata <path>] [--voucher <id>]
+vara-wallet message calculate-reply <programId> [--payload <hex>] [--value <v>] [--units human|raw] [--origin <addr>] [--at <blockHash>]
 ```
 
 Gas is auto-calculated if `--gas-limit` is omitted. Destination can be any actor (program, user, wallet). Use `--value` to transfer VARA tokens alongside a message. Use `--voucher <id>` to pay for the message using a voucher instead of the sender's balance.
@@ -174,8 +174,8 @@ Gas is auto-calculated if `--gas-limit` is omitted. Destination can be any actor
 ### `program`
 
 ```bash
-vara-wallet program upload <wasm> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
-vara-wallet program deploy <codeId> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units vara|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
+vara-wallet program upload <wasm> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units human|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
+vara-wallet program deploy <codeId> [--payload <hex>] [--idl <path>] [--init <name>] [--args <json> | --args-file <path>] [--gas-limit <n>] [--value <v>] [--units human|raw] [--salt <hex>] [--metadata <path>] [--dry-run]
 vara-wallet program info <programId>
 vara-wallet program list [--count <n>] [--all]
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -55,6 +55,31 @@ function runDiscover(idlPath, label) {
   );
 }
 
+/**
+ * Run the bundled CLI with a freshly-isolated VARA_WALLET_DIR so the IDL
+ * cache subcommands (idl import/list/remove/clear) operate on an empty
+ * sandbox per invocation. Returns parsed --json output or exits non-zero.
+ */
+function runCli(args, label, walletDir) {
+  const result = spawnSync(process.execPath, [BUNDLE, ...args, '--json'], {
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, VARA_WALLET_DIR: walletDir },
+  });
+  if (result.status !== 0) {
+    console.error(`smoke[${label}] FAILED — exit ${result.status}`);
+    if (result.stderr) console.error('stderr:', result.stderr.slice(0, 2000));
+    if (result.stdout) console.error('stdout:', result.stdout.slice(0, 2000));
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    console.error(`smoke[${label}] FAILED — non-JSON output: ${result.stdout.slice(0, 500)}`);
+    process.exit(1);
+  }
+}
+
 const tmp = mkdtempSync(join(tmpdir(), 'vara-wallet-smoke-'));
 try {
   // v1: extract the first bundled VFT IDL and write it to a temp file.
@@ -78,6 +103,74 @@ try {
     process.exit(1);
   }
   runDiscover(v2Path, 'v2');
+
+  // idl list / import / remove / clear — happy path against the bundled
+  // CLI. Catches bundling regressions (esbuild tree-shaking idl-cache
+  // exports, export renames) that unit tests run against source can't see.
+  // Each call uses a private VARA_WALLET_DIR under tmp/ so the user's
+  // real cache is untouched.
+  const walletDir = join(tmp, 'wallet-home');
+  const FAKE_CODE_ID = '0x' + 'ab'.repeat(32);
+
+  const listEmpty = runCli(['idl', 'list'], 'idl-list-empty', walletDir);
+  if (!Array.isArray(listEmpty) || listEmpty.length !== 0) {
+    console.error(`smoke[idl-list-empty] FAILED — expected [], got ${JSON.stringify(listEmpty)}`);
+    process.exit(1);
+  }
+  console.log('smoke[idl-list-empty] OK — empty cache returns []');
+
+  const imported = runCli(
+    ['idl', 'import', v2Path, '--code-id', FAKE_CODE_ID],
+    'idl-import',
+    walletDir,
+  );
+  if (imported?.source !== 'import' || !imported?.codeId) {
+    console.error(`smoke[idl-import] FAILED — unexpected shape: ${JSON.stringify(imported)}`);
+    process.exit(1);
+  }
+  console.log('smoke[idl-import] OK — imported v2 fixture');
+
+  const listOne = runCli(['idl', 'list'], 'idl-list-one', walletDir);
+  if (!Array.isArray(listOne) || listOne.length !== 1 || listOne[0].source !== 'import') {
+    console.error(`smoke[idl-list-one] FAILED — expected 1 import entry, got ${JSON.stringify(listOne)}`);
+    process.exit(1);
+  }
+  console.log('smoke[idl-list-one] OK — 1 entry visible after import');
+
+  const removed = runCli(
+    ['idl', 'remove', FAKE_CODE_ID],
+    'idl-remove',
+    walletDir,
+  );
+  if (removed?.removed !== true) {
+    console.error(`smoke[idl-remove] FAILED — expected { removed: true }, got ${JSON.stringify(removed)}`);
+    process.exit(1);
+  }
+  console.log('smoke[idl-remove] OK — entry removed');
+
+  // Re-import to test clear --yes against a populated cache.
+  runCli(['idl', 'import', v2Path, '--code-id', FAKE_CODE_ID], 'idl-reimport', walletDir);
+
+  const preview = runCli(['idl', 'clear'], 'idl-clear-preview', walletDir);
+  if (!Array.isArray(preview?.wouldRemove) || preview.wouldRemove.length !== 1) {
+    console.error(`smoke[idl-clear-preview] FAILED — expected 1 entry in wouldRemove, got ${JSON.stringify(preview)}`);
+    process.exit(1);
+  }
+  console.log('smoke[idl-clear-preview] OK — preview shows 1 entry');
+
+  const cleared = runCli(['idl', 'clear', '--yes'], 'idl-clear-commit', walletDir);
+  if (cleared?.removed !== 1) {
+    console.error(`smoke[idl-clear-commit] FAILED — expected { removed: 1 }, got ${JSON.stringify(cleared)}`);
+    process.exit(1);
+  }
+  console.log('smoke[idl-clear-commit] OK — entry cleared');
+
+  const listFinal = runCli(['idl', 'list'], 'idl-list-final', walletDir);
+  if (!Array.isArray(listFinal) || listFinal.length !== 0) {
+    console.error(`smoke[idl-list-final] FAILED — expected [] after clear, got ${JSON.stringify(listFinal)}`);
+    process.exit(1);
+  }
+  console.log('smoke[idl-list-final] OK — cache empty after clear');
 
   console.log('smoke: all checks passed');
 } finally {

--- a/src/__tests__/dry-run.test.ts
+++ b/src/__tests__/dry-run.test.ts
@@ -7,6 +7,7 @@ describe('buildFunctionDryRun', () => {
       method: 'Increment',
       args: [1, 2, 3],
       encodedPayload: '0xdeadbeef',
+      destination: '0x' + '11'.repeat(32),
     });
     expect(out).toEqual({
       kind: 'function',
@@ -14,6 +15,7 @@ describe('buildFunctionDryRun', () => {
       method: 'Increment',
       args: [1, 2, 3],
       encodedPayload: '0xdeadbeef',
+      destination: '0x' + '11'.repeat(32),
       value: '0',
       gasLimit: null,
       voucherId: null,
@@ -27,6 +29,7 @@ describe('buildFunctionDryRun', () => {
       method: 'M',
       args: [],
       encodedPayload: '0x00',
+      destination: '0xbeef',
       value: '1000000000000',
       gasLimit: '5000000',
       voucherId: '0xfeed',
@@ -35,6 +38,33 @@ describe('buildFunctionDryRun', () => {
     expect(out.gasLimit).toBe('5000000');
     expect(out.voucherId).toBe('0xfeed');
     expect(out.willSubmit).toBe(false);
+    expect(out.destination).toBe('0xbeef');
+  });
+
+  it('includes estimateGas when supplied (composition with --estimate)', () => {
+    const out = buildFunctionDryRun({
+      service: 'S',
+      method: 'M',
+      args: [],
+      encodedPayload: '0x00',
+      destination: '0xbeef',
+      estimateGas: { gasLimit: '5000000000', minLimit: '4500000000' },
+    });
+    expect(out.estimateGas).toEqual({ gasLimit: '5000000000', minLimit: '4500000000' });
+    // Estimate is purely additive: dry-run shape preserved.
+    expect(out.kind).toBe('function');
+    expect(out.willSubmit).toBe(false);
+  });
+
+  it('omits estimateGas when not supplied (plain --dry-run path)', () => {
+    const out = buildFunctionDryRun({
+      service: 'S',
+      method: 'M',
+      args: [],
+      encodedPayload: '0x00',
+      destination: '0xbeef',
+    });
+    expect(out).not.toHaveProperty('estimateGas');
   });
 
   it('emits keys in deterministic order (kind first, willSubmit last)', () => {
@@ -43,10 +73,27 @@ describe('buildFunctionDryRun', () => {
       method: 'M',
       args: [],
       encodedPayload: '0x00',
+      destination: '0xbeef',
     });
     const keys = Object.keys(out);
     expect(keys[0]).toBe('kind');
     expect(keys[keys.length - 1]).toBe('willSubmit');
+  });
+
+  it('emits keys in deterministic order with estimateGas (still kind first, willSubmit last)', () => {
+    const out = buildFunctionDryRun({
+      service: 'S',
+      method: 'M',
+      args: [],
+      encodedPayload: '0x00',
+      destination: '0xbeef',
+      estimateGas: { gasLimit: '1', minLimit: '1' },
+    });
+    const keys = Object.keys(out);
+    expect(keys[0]).toBe('kind');
+    expect(keys[keys.length - 1]).toBe('willSubmit');
+    // estimateGas slots in just before willSubmit.
+    expect(keys[keys.length - 2]).toBe('estimateGas');
   });
 });
 
@@ -83,6 +130,7 @@ describe('dry-run does not invoke network methods', () => {
     const signAndSend = jest.fn();
     const fakeBuilder = {
       payload: '0xfeedface',
+      programId: '0xbeef',
       signAndSend,
     };
     // The helper does not touch the builder — the action layer does.
@@ -91,7 +139,8 @@ describe('dry-run does not invoke network methods', () => {
       service: 'S',
       method: 'M',
       args: [],
-      encodedPayload: fakeBuilder.payload,
+      encodedPayload: '0xc0ffee',
+      destination: fakeBuilder.programId,
     });
     expect(signAndSend).not.toHaveBeenCalled();
   });

--- a/src/__tests__/dry-run.test.ts
+++ b/src/__tests__/dry-run.test.ts
@@ -1,4 +1,4 @@
-import { buildFunctionDryRun, buildQueryDryRun } from '../commands/call';
+import { buildFunctionDryRun, buildQueryDryRun, _resolveDryRunPayloadForTests } from '../commands/call';
 
 describe('buildFunctionDryRun', () => {
   it('returns the documented dry-run shape with required fields', () => {
@@ -113,6 +113,66 @@ describe('buildQueryDryRun', () => {
       encodedPayload: '0xabcd',
       willSubmit: false,
     });
+  });
+});
+
+/**
+ * B2 regression contract: encodedPayload MUST come from func.encodePayload(),
+ * NOT from txBuilder.payload (sails-js's destination-program-id getter).
+ *
+ * The pre-0.15 bug returned `txBuilder.payload` which is `args[0].toHex()`
+ * inside sails-js's TransactionBuilder — i.e. the destination program ID,
+ * not the SCALE-encoded call. A revert would have all dry-run helper
+ * tests still pass because the helper takes encodedPayload as a literal
+ * arg. This test plants different values for `.payload` (the bug shape)
+ * and `.encodePayload(...)` (the fix), and asserts the helper picks the
+ * right one.
+ */
+describe('B2 regression: _resolveDryRunPayloadForTests', () => {
+  it('picks encodedPayload from func.encodePayload(...args), not txBuilder.payload', () => {
+    const SCALE_BYTES = '0xCALLED_ENCODE_PAYLOAD';
+    const PROG_ID = '0x' + 'aa'.repeat(32);
+    const BUGGY_PAYLOAD = PROG_ID; // what txBuilder.payload would return
+
+    const encodePayload = jest.fn().mockReturnValue(SCALE_BYTES);
+    const txBuilder = { payload: BUGGY_PAYLOAD, programId: PROG_ID };
+    // Function-shaped object with .encodePayload — mirrors sails-js func reference.
+    // Cast through `any` because we mock a thin slice of the sails-js surface.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const func = Object.assign(jest.fn().mockReturnValue(txBuilder), { encodePayload }) as any;
+
+    const result = _resolveDryRunPayloadForTests(func, txBuilder, [42, 'foo', { nested: true }]);
+
+    expect(result.encodedPayload).toBe(SCALE_BYTES);
+    expect(result.encodedPayload).not.toBe(BUGGY_PAYLOAD); // the bug shape
+    expect(result.encodedPayload).not.toBe(PROG_ID); // the bug-equivalent
+    expect(result.destination).toBe(PROG_ID);
+    expect(encodePayload).toHaveBeenCalledWith(42, 'foo', { nested: true });
+  });
+
+  it('forwards args verbatim to encodePayload (no transformation)', () => {
+    const encodePayload = jest.fn().mockReturnValue('0x00');
+    const txBuilder = { programId: '0xbeef' };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const func = Object.assign(jest.fn().mockReturnValue(txBuilder), { encodePayload }) as any;
+
+    _resolveDryRunPayloadForTests(func, txBuilder, []);
+    expect(encodePayload).toHaveBeenCalledWith();
+
+    encodePayload.mockClear();
+    _resolveDryRunPayloadForTests(func, txBuilder, [1n, 2n, 'three']);
+    expect(encodePayload).toHaveBeenCalledWith(1n, 2n, 'three');
+  });
+
+  it('reads destination from txBuilder.programId, separate from the encoded bytes', () => {
+    const encodePayload = jest.fn().mockReturnValue('0x' + 'cafe'.repeat(8));
+    const txBuilder = { programId: '0x' + 'dead'.repeat(16) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const func = Object.assign(jest.fn().mockReturnValue(txBuilder), { encodePayload }) as any;
+
+    const result = _resolveDryRunPayloadForTests(func, txBuilder, []);
+    expect(result.destination).toBe(txBuilder.programId);
+    expect(result.encodedPayload).not.toBe(result.destination);
   });
 });
 

--- a/src/__tests__/idl-list-remove-clear.test.ts
+++ b/src/__tests__/idl-list-remove-clear.test.ts
@@ -1,0 +1,170 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Redirect VARA_WALLET_DIR before importing modules under test.
+const testDir = path.join(os.tmpdir(), `vara-idl-listrm-test-${Date.now()}-${process.pid}`);
+process.env.VARA_WALLET_DIR = testDir;
+
+import {
+  writeCachedIdl,
+  evictCachedIdl,
+  enumerateCacheEntries,
+  getIdlCacheDir,
+  getIdlEntryPath,
+  IdlCacheMeta,
+} from '../services/idl-cache';
+
+const codeIdA = '0x' + 'aa'.repeat(32);
+const codeIdB = '0x' + 'bb'.repeat(32);
+const codeIdC = '0x' + 'cc'.repeat(32);
+
+const meta = (source: 'chain' | 'import'): IdlCacheMeta => ({
+  version: 'v2',
+  source,
+  importedAt: '2026-04-25T00:00:00.000Z',
+});
+
+afterAll(() => {
+  fs.rmSync(testDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Clean slate between tests so each test owns its fixture state.
+  const dir = getIdlCacheDir();
+  if (fs.existsSync(dir)) {
+    for (const name of fs.readdirSync(dir)) {
+      if (name.endsWith('.cache.json')) fs.unlinkSync(path.join(dir, name));
+    }
+  }
+});
+
+describe('enumerateCacheEntries', () => {
+  it('returns [] when the cache dir does not exist (fresh install)', () => {
+    // Use a directory we know doesn't exist; can't blow away getIdlCacheDir
+    // because writeCachedIdl will recreate it, so we just verify the
+    // post-create empty case.
+    const dir = getIdlCacheDir();
+    if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+    expect(enumerateCacheEntries()).toEqual([]);
+  });
+
+  it('returns [] when the cache dir exists but contains no .cache.json files', () => {
+    const dir = getIdlCacheDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'unrelated.txt'), 'noise', { mode: 0o600 });
+    expect(enumerateCacheEntries()).toEqual([]);
+  });
+
+  it('lists every cached entry with full metadata', () => {
+    writeCachedIdl(codeIdA, 'service A {}', meta('chain'));
+    writeCachedIdl(codeIdB, 'service B { query Foo : () -> u32; }', meta('import'));
+
+    const entries = enumerateCacheEntries().sort((x, y) => x.codeId.localeCompare(y.codeId));
+    expect(entries).toHaveLength(2);
+    expect(entries[0].codeId).toBe('aa'.repeat(32));
+    expect(entries[0].source).toBe('chain');
+    expect(entries[0].version).toBe('v2');
+    expect(entries[0].idlSizeBytes).toBe(Buffer.byteLength('service A {}', 'utf-8'));
+    expect(entries[1].codeId).toBe('bb'.repeat(32));
+    expect(entries[1].source).toBe('import');
+  });
+
+  it('surfaces a corrupted entry as { error: "corrupted" } without crashing the listing', () => {
+    writeCachedIdl(codeIdA, 'service A {}', meta('chain'));
+    const corruptedFile = path.join(getIdlCacheDir(), `${'cc'.repeat(32)}.cache.json`);
+    fs.writeFileSync(corruptedFile, '{ this is not json', { mode: 0o600 });
+
+    const entries = enumerateCacheEntries().sort((x, y) => x.codeId.localeCompare(y.codeId));
+    expect(entries).toHaveLength(2);
+    const corrupted = entries.find((e) => e.error === 'corrupted');
+    expect(corrupted).toBeDefined();
+    expect(corrupted?.codeId).toBe('cc'.repeat(32));
+    // The healthy entry is still present.
+    const healthy = entries.find((e) => e.error === undefined);
+    expect(healthy?.codeId).toBe('aa'.repeat(32));
+  });
+
+  it('forward-compat: missing meta fields do not crash the listing', () => {
+    writeCachedIdl(codeIdA, 'service A {}', meta('chain'));
+    // Manually rewrite the file with a partial meta shape (simulates a
+    // future writer adding fields, or a pre-this-PR entry missing some).
+    const file = getIdlEntryPath(codeIdA);
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ idl: 'service A {}', meta: {} }),
+      { mode: 0o600 },
+    );
+    const entries = enumerateCacheEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].version).toBe('unknown');
+    expect(entries[0].source).toBe('unknown');
+    expect(entries[0].importedAt).toBeNull();
+    // Still computes idlSizeBytes from the present idl string.
+    expect(entries[0].idlSizeBytes).toBe(Buffer.byteLength('service A {}', 'utf-8'));
+  });
+});
+
+describe('idl remove (via evictCachedIdl)', () => {
+  it('removes an existing entry', () => {
+    writeCachedIdl(codeIdA, 'service A {}', meta('chain'));
+    expect(fs.existsSync(getIdlEntryPath(codeIdA))).toBe(true);
+    evictCachedIdl(codeIdA);
+    expect(fs.existsSync(getIdlEntryPath(codeIdA))).toBe(false);
+  });
+
+  it('is idempotent: removing a non-existent entry does not throw', () => {
+    expect(fs.existsSync(getIdlEntryPath(codeIdC))).toBe(false);
+    expect(() => evictCachedIdl(codeIdC)).not.toThrow();
+  });
+});
+
+describe('idl clear semantics (snapshot-then-unlink)', () => {
+  it('regression: snapshot-then-unlink swallows ENOENT for entries removed mid-clear', () => {
+    // Setup three entries, then directly invoke the snapshot+unlink loop
+    // simulating a parallel process unlinking codeIdB between enumeration
+    // and the unlink call. This proves the loop is race-tolerant.
+    writeCachedIdl(codeIdA, 'service A {}', meta('chain'));
+    writeCachedIdl(codeIdB, 'service B {}', meta('chain'));
+    writeCachedIdl(codeIdC, 'service C {}', meta('chain'));
+
+    const dir = getIdlCacheDir();
+    const entries = enumerateCacheEntries(); // snapshot
+
+    // Simulate the parallel-process race: B disappears before our unlink.
+    fs.unlinkSync(getIdlEntryPath(codeIdB));
+
+    // Now the loop the command runs (mirrors src/commands/idl.ts):
+    let removed = 0;
+    let threw = false;
+    for (const entry of entries) {
+      const file = path.join(dir, `${entry.codeId}.cache.json`);
+      try {
+        fs.unlinkSync(file);
+        removed++;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') continue;
+        threw = true;
+      }
+    }
+    expect(threw).toBe(false);
+    // Only the two surviving entries got removed; B was already gone.
+    expect(removed).toBe(2);
+    expect(enumerateCacheEntries()).toEqual([]);
+  });
+
+  it('preview shape (without --yes): wouldRemove lists every entry and includes hint', () => {
+    writeCachedIdl(codeIdA, 'service A {}', meta('chain'));
+    writeCachedIdl(codeIdB, 'service B {}', meta('import'));
+
+    const entries = enumerateCacheEntries();
+    const wouldRemove = entries.map((e) => ({ codeId: e.codeId, source: e.source }));
+    expect(wouldRemove).toHaveLength(2);
+    expect(wouldRemove).toContainEqual({ codeId: 'aa'.repeat(32), source: 'chain' });
+    expect(wouldRemove).toContainEqual({ codeId: 'bb'.repeat(32), source: 'import' });
+    // Files survive — preview did not unlink.
+    expect(fs.existsSync(getIdlEntryPath(codeIdA))).toBe(true);
+    expect(fs.existsSync(getIdlEntryPath(codeIdB))).toBe(true);
+  });
+});

--- a/src/__tests__/sails-extract-from-chain.test.ts
+++ b/src/__tests__/sails-extract-from-chain.test.ts
@@ -1,0 +1,158 @@
+import { _tryExtractFromChainForTests } from '../services/sails';
+import type { GearApi } from '@gear-js/api';
+
+// Build a minimal valid WASM blob: '\0asm' magic + version 1 + optional
+// custom sections. Mirrors the helper in wasm-section.test.ts; duplicated
+// here because that helper isn't exported and re-using via cross-test
+// imports complicates module resolution.
+const WASM_HEADER = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+
+function uleb128(n: number): number[] {
+  const bytes: number[] = [];
+  do {
+    let byte = n & 0x7f;
+    n >>>= 7;
+    if (n !== 0) byte |= 0x80;
+    bytes.push(byte);
+  } while (n !== 0);
+  return bytes;
+}
+
+function buildWasm(customSections: Array<{ name: string; payload: Uint8Array }>): Uint8Array {
+  const chunks: number[] = [...WASM_HEADER];
+  for (const { name, payload } of customSections) {
+    const nameBytes = new TextEncoder().encode(name);
+    const nameLen = uleb128(nameBytes.length);
+    const sectionBodyLen = nameLen.length + nameBytes.length + payload.length;
+    chunks.push(0x00); // custom section id
+    chunks.push(...uleb128(sectionBodyLen));
+    chunks.push(...nameLen);
+    chunks.push(...nameBytes);
+    chunks.push(...payload);
+  }
+  return new Uint8Array(chunks);
+}
+
+/**
+ * Stub Bytes codec. The real @polkadot/types-codec Bytes prepends the SCALE
+ * compact-length when toU8a() is called bare; toU8a(true) returns the raw
+ * inner bytes. We mimic that exactly: tracking which call shape is used is
+ * the entire point of the test (B1 regression: the prefix must NOT leak
+ * into extractSailsIdl).
+ */
+function makeBytesCodec(inner: Uint8Array): {
+  toU8a: (isBare?: boolean) => Uint8Array;
+  callShapes: Array<boolean | undefined>;
+} {
+  const callShapes: Array<boolean | undefined> = [];
+  return {
+    toU8a(isBare?: boolean) {
+      callShapes.push(isBare);
+      if (isBare === true) return inner;
+      // Bare false / undefined: simulate the leaked compact-length prefix.
+      // Real polkadot prepends a SCALE compact uint of inner.length.
+      // We just prepend an arbitrary 4-byte garbage prefix to make the
+      // WASM-magic check fail downstream — the exact bytes don't matter,
+      // only that they are NOT the WASM magic.
+      const garbage = new Uint8Array([0x4a, 0x43, 0x04, 0x00]);
+      const out = new Uint8Array(garbage.length + inner.length);
+      out.set(garbage, 0);
+      out.set(inner, garbage.length);
+      return out;
+    },
+    callShapes,
+  };
+}
+
+function makeNoneOption(): { isSome: false } {
+  return { isSome: false };
+}
+
+function makeSomeOption(bytes: { toU8a: (isBare?: boolean) => Uint8Array }) {
+  return {
+    isSome: true as const,
+    unwrap() {
+      return bytes;
+    },
+  };
+}
+
+function makeApi(opts: {
+  storage?: () => Promise<unknown>;
+  throwOnQuery?: Error;
+}): GearApi {
+  const originalCodeStorage = opts.throwOnQuery
+    ? () => Promise.reject(opts.throwOnQuery)
+    : opts.storage ?? (() => Promise.resolve(makeNoneOption()));
+  return {
+    query: {
+      gearProgram: {
+        originalCodeStorage,
+      },
+    },
+  } as unknown as GearApi;
+}
+
+const FAKE_CODE_ID = '0x' + '11'.repeat(32);
+
+describe('tryExtractFromChain (B1 regression)', () => {
+  const encoder = new TextEncoder();
+
+  it('returns the IDL string when WASM has a sails:idl section', async () => {
+    const idl = 'service Counter { query Value : () -> u32; };';
+    const wasm = buildWasm([{ name: 'sails:idl', payload: encoder.encode(idl) }]);
+    const codec = makeBytesCodec(wasm);
+    const api = makeApi({ storage: async () => makeSomeOption(codec) });
+
+    const result = await _tryExtractFromChainForTests(api, FAKE_CODE_ID);
+    expect(result).toBe(idl);
+    // The fix: the function MUST call toU8a(true) to strip the SCALE prefix.
+    // If this asserts toU8a was called bare (undefined or false), the magic
+    // check would have failed and the test would not have reached this line —
+    // but we assert it explicitly to make the regression intent visible.
+    expect(codec.callShapes).toEqual([true]);
+  });
+
+  it('returns null when WASM has no sails:idl section (clean fallthrough, no IDL_PARSE_ERROR)', async () => {
+    const wasm = buildWasm([
+      { name: 'name', payload: encoder.encode('noise') },
+      { name: 'producers', payload: encoder.encode('also noise') },
+    ]);
+    const codec = makeBytesCodec(wasm);
+    const api = makeApi({ storage: async () => makeSomeOption(codec) });
+
+    const result = await _tryExtractFromChainForTests(api, FAKE_CODE_ID);
+    expect(result).toBeNull();
+    expect(codec.callShapes).toEqual([true]);
+  });
+
+  it('returns null when originalCodeStorage returns None (no entry)', async () => {
+    const api = makeApi({ storage: async () => makeNoneOption() });
+
+    const result = await _tryExtractFromChainForTests(api, FAKE_CODE_ID);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when originalCodeStorage RPC throws (network/auth/etc.)', async () => {
+    const api = makeApi({ throwOnQuery: new Error('connection reset') });
+
+    const result = await _tryExtractFromChainForTests(api, FAKE_CODE_ID);
+    expect(result).toBeNull();
+  });
+
+  it('regression: bytes passed to extractSailsIdl start with WASM magic 00 61 73 6d', async () => {
+    // Negative-control: if the implementation regresses to toU8a() (bare),
+    // the bytes seen by extractSailsIdl will start with the garbage prefix
+    // and the WASM-magic check will throw IDL_PARSE_ERROR. This test asserts
+    // the happy-path returns successfully — i.e., the bytes that reached
+    // extractSailsIdl had a valid WASM magic. The toU8a call-shape assertion
+    // in the first test is the direct check; this test is the end-to-end
+    // assertion that the contract holds.
+    const idl = '!@sails: 1.0.0-beta.1\nservice Foo@0x00 {}';
+    const wasm = buildWasm([{ name: 'sails:idl', payload: encoder.encode(idl) }]);
+    const codec = makeBytesCodec(wasm);
+    const api = makeApi({ storage: async () => makeSomeOption(codec) });
+
+    await expect(_tryExtractFromChainForTests(api, FAKE_CODE_ID)).resolves.toBe(idl);
+  });
+});

--- a/src/__tests__/subscribe-filter-resolution.test.ts
+++ b/src/__tests__/subscribe-filter-resolution.test.ts
@@ -1,12 +1,17 @@
 /**
- * `resolveSubscribeFilter` is the gating point for `--type` / `--event`
- * across watch and subscribe. Resolution order MUST be Gear-first so
- * legacy CLI vocabulary keeps working without surprise (Codex finding #5).
+ * `resolveSubscribeFilter` is the gating point for the `--event` flag
+ * across watch and subscribe messages. Resolution order MUST be:
+ *   1. `pallet:` prefix → strip and resolve as pallet event (replaces
+ *      the old --pallet-event flag).
+ *   2. Bare Gear vocab name → pallet (back-compat).
+ *   3. Sails IDL match if loaded.
+ *   4. Fallback to pallet validation (clean error).
  *
  * Cases covered:
  *   - Bare Gear name resolves to pallet path even when an IDL is loaded.
  *   - Bare name unknown to Gear vocab but resolvable in IDL → sails path.
- *   - --pallet-event escape hatch forces pallet path.
+ *   - `pallet:Name` prefix forces pallet path even when an IDL is loaded.
+ *   - `pallet:` prefix with invalid name → clean validation error.
  *   - Ambiguous bare Sails name → AMBIGUOUS_EVENT (hard fail, not warn).
  */
 import * as path from 'path';
@@ -20,17 +25,59 @@ const AMBIGUOUS_FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-ambiguous.
 describe('resolveSubscribeFilter', () => {
   it('Gear-first precedence — bare name in Gear vocab resolves to pallet path even with IDL loaded', async () => {
     const sails = await parseIdlFileV2(EVENTS_FIXTURE);
-    const out = resolveSubscribeFilter('UserMessageSent', sails, false);
+    const out = resolveSubscribeFilter('UserMessageSent', sails);
     expect(out).toEqual({ kind: 'pallet', event: 'UserMessageSent' });
+  });
+
+  it('pallet: prefix forces pallet vocab even when an IDL is loaded', async () => {
+    const sails = await parseIdlFileV2(EVENTS_FIXTURE);
+    const out = resolveSubscribeFilter('pallet:UserMessageSent', sails);
+    expect(out).toEqual({ kind: 'pallet', event: 'UserMessageSent' });
+  });
+
+  it('pallet: prefix with no IDL loaded works the same as a bare pallet name', () => {
+    const out = resolveSubscribeFilter('pallet:MessageQueued', null);
+    expect(out).toEqual({ kind: 'pallet', event: 'MessageQueued' });
+  });
+
+  it('pallet: prefix with an invalid pallet name surfaces validation error (not silent)', () => {
+    let caught: unknown;
+    try {
+      resolveSubscribeFilter('pallet:NonexistentEvent', null);
+    } catch (err) { caught = err; }
+    // validateEventName throws CliError with a code; we just assert the throw.
+    expect(caught).toBeInstanceOf(CliError);
   });
 
   it('AMBIGUOUS_EVENT thrown (hard fail) when bare Sails name matches multiple services', async () => {
     const sails = await parseIdlFileV2(AMBIGUOUS_FIXTURE);
     let caught: unknown;
     try {
-      resolveSubscribeFilter('Posted', sails, false);
+      resolveSubscribeFilter('Posted', sails);
     } catch (err) { caught = err; }
     expect(caught).toBeInstanceOf(CliError);
     expect((caught as CliError).code).toBe('AMBIGUOUS_EVENT');
+  });
+
+  it('AMBIGUOUS_EVENT bypassed when pallet: prefix is used (forces pallet path, never touches IDL)', async () => {
+    const sails = await parseIdlFileV2(AMBIGUOUS_FIXTURE);
+    // `Posted` is ambiguous in the Sails IDL but isn't a pallet event, so
+    // pallet:Posted should fail at validateEventName, NOT at AMBIGUOUS_EVENT.
+    let caught: unknown;
+    try {
+      resolveSubscribeFilter('pallet:Posted', sails);
+    } catch (err) { caught = err; }
+    expect(caught).toBeInstanceOf(CliError);
+    expect((caught as CliError).code).not.toBe('AMBIGUOUS_EVENT');
+  });
+
+  it('Service/Event qualified name resolves to sails path (unambiguous)', async () => {
+    const sails = await parseIdlFileV2(AMBIGUOUS_FIXTURE);
+    const out = resolveSubscribeFilter('Forum/Posted', sails);
+    expect(out.kind).toBe('sails');
+    if (out.kind === 'sails') {
+      expect(out.service).toBe('Forum');
+      expect(out.event).toBe('Posted');
+    }
   });
 });

--- a/src/__tests__/units.test.ts
+++ b/src/__tests__/units.test.ts
@@ -40,11 +40,40 @@ describe('minimalToVara', () => {
 });
 
 describe('resolveAmount', () => {
-  it('converts VARA by default', () => {
+  it('converts VARA by default (units omitted)', () => {
     expect(resolveAmount('2')).toBe(2_000_000_000_000n);
   });
 
-  it('passes through raw units', () => {
-    expect(resolveAmount('12345', true)).toBe(12345n);
+  it('converts VARA when units = "human"', () => {
+    expect(resolveAmount('2', 'human')).toBe(2_000_000_000_000n);
+  });
+
+  it('passes through raw units when units = "raw"', () => {
+    expect(resolveAmount('12345', 'raw')).toBe(12345n);
+  });
+
+  it('rejects invalid --units values with INVALID_UNITS', () => {
+    let caught: unknown;
+    try {
+      resolveAmount('1', 'potato');
+    } catch (err) { caught = err; }
+    expect(caught).toBeDefined();
+    expect((caught as { code?: string }).code).toBe('INVALID_UNITS');
+  });
+
+  it('rejects the legacy "vara" literal (renamed to human in 0.15)', () => {
+    let caught: unknown;
+    try {
+      resolveAmount('1', 'vara');
+    } catch (err) { caught = err; }
+    expect((caught as { code?: string }).code).toBe('INVALID_UNITS');
+  });
+
+  it('rejects the legacy "token" literal (renamed to human in 0.15)', () => {
+    let caught: unknown;
+    try {
+      resolveAmount('1', 'token');
+    } catch (err) { caught = err; }
+    expect((caught as { code?: string }).code).toBe('INVALID_UNITS');
   });
 });

--- a/src/__tests__/vft-balance-null-safety.test.ts
+++ b/src/__tests__/vft-balance-null-safety.test.ts
@@ -16,51 +16,51 @@ import { _formatVftAmountForTests } from '../commands/vft';
 describe('_formatVftAmountForTests (U8 null-safety)', () => {
   describe('null path (Option::None / no balance row)', () => {
     it('returns rawStr "0" when decoded is null and no decimals', () => {
-      const out = _formatVftAmountForTests(null, null, 'balance');
+      const out = _formatVftAmountForTests(null, null);
       expect(out.rawStr).toBe('0');
       expect(out.humanStr).toBe('0');
       expect(out.decimals).toBeNull();
     });
 
     it('returns rawStr "0" + humanStr "0" (decimals applied to zero) when decimals present', () => {
-      const out = _formatVftAmountForTests(null, 6, 'balance');
+      const out = _formatVftAmountForTests(null, 6);
       expect(out.rawStr).toBe('0');
       expect(out.humanStr).toBe('0'); // minimalToVara(0n, 6) === '0'
       expect(out.decimals).toBe(6);
     });
 
-    it('null path applies identically for allowance kind', () => {
-      const balance = _formatVftAmountForTests(null, 18, 'balance');
-      const allowance = _formatVftAmountForTests(null, 18, 'allowance');
-      expect(balance.rawStr).toBe(allowance.rawStr);
-      expect(balance.humanStr).toBe(allowance.humanStr);
+    it('null path is shape-symmetric (balance and allowance share the helper)', () => {
+      // The same helper drives both balance and allowance; null → '0' regardless.
+      const a = _formatVftAmountForTests(null, 18);
+      const b = _formatVftAmountForTests(null, 18);
+      expect(a).toEqual(b);
     });
   });
 
   describe('non-null path (Option::Some / explicit zero)', () => {
     it('passes through bigint values as decimal strings', () => {
-      const out = _formatVftAmountForTests(123_456_789n, null, 'balance');
+      const out = _formatVftAmountForTests(123_456_789n, null);
       expect(out.rawStr).toBe('123456789');
       expect(out.humanStr).toBe('123456789');
     });
 
     it('passes through string-numeric values from decodeSailsResult', () => {
       // decodeSailsResult normalizes U256 to decimal strings (#32 fix).
-      const out = _formatVftAmountForTests('1000000000000000000', null, 'balance');
+      const out = _formatVftAmountForTests('1000000000000000000', null);
       expect(out.rawStr).toBe('1000000000000000000');
     });
 
     it('converts to human form when decimals present', () => {
       // 1.5 token at 6 decimals = 1500000 minimal units.
-      const out = _formatVftAmountForTests(1_500_000n, 6, 'balance');
+      const out = _formatVftAmountForTests(1_500_000n, 6);
       expect(out.rawStr).toBe('1500000');
       expect(out.humanStr).toBe('1.5');
       expect(out.decimals).toBe(6);
     });
 
     it('explicit zero (decoded = 0n) is distinct from null path in raw form', () => {
-      const explicitZero = _formatVftAmountForTests(0n, null, 'balance');
-      const nullValue = _formatVftAmountForTests(null, null, 'balance');
+      const explicitZero = _formatVftAmountForTests(0n, null);
+      const nullValue = _formatVftAmountForTests(null, null);
       // Both surface as '0' — matches on-chain semantics where missing
       // row and explicit zero are indistinguishable for transfer-spend.
       expect(explicitZero.rawStr).toBe('0');
@@ -70,14 +70,14 @@ describe('_formatVftAmountForTests (U8 null-safety)', () => {
 
   describe('regression: drops to BigInt(null) would throw', () => {
     it('does NOT throw on null input (pre-0.15 bug shape)', () => {
-      expect(() => _formatVftAmountForTests(null, null, 'balance')).not.toThrow();
-      expect(() => _formatVftAmountForTests(null, 12, 'allowance')).not.toThrow();
+      expect(() => _formatVftAmountForTests(null, null)).not.toThrow();
+      expect(() => _formatVftAmountForTests(null, 12)).not.toThrow();
     });
 
     it('rawStr never becomes the literal "null" string', () => {
       // `String(null)` would yield "null"; the helper must short-circuit
       // before reaching that path.
-      const out = _formatVftAmountForTests(null, null, 'balance');
+      const out = _formatVftAmountForTests(null, null);
       expect(out.rawStr).not.toBe('null');
     });
   });

--- a/src/__tests__/vft-balance-null-safety.test.ts
+++ b/src/__tests__/vft-balance-null-safety.test.ts
@@ -1,0 +1,84 @@
+/**
+ * U8 regression contract: `vft balance` and `vft allowance` must
+ * translate Option::None (decoded === null) to the string '0' before
+ * any BigInt coercion. Pre-0.15 the code was `BigInt(result)` directly,
+ * which crashed with "Cannot convert null to a BigInt" when
+ * `findVftService` resolved to `VftExtension.BalanceOf` (declared
+ * `opt u256`) for an account with no balance row.
+ *
+ * Fix routes the result through `decodeSailsResult` (null-aware) and
+ * then `_formatVftAmountForTests` (the unit-test seam) translates null
+ * → '0'. A regression that drops the null check would break THIS test,
+ * not just real-world VftExtension queries.
+ */
+import { _formatVftAmountForTests } from '../commands/vft';
+
+describe('_formatVftAmountForTests (U8 null-safety)', () => {
+  describe('null path (Option::None / no balance row)', () => {
+    it('returns rawStr "0" when decoded is null and no decimals', () => {
+      const out = _formatVftAmountForTests(null, null, 'balance');
+      expect(out.rawStr).toBe('0');
+      expect(out.humanStr).toBe('0');
+      expect(out.decimals).toBeNull();
+    });
+
+    it('returns rawStr "0" + humanStr "0" (decimals applied to zero) when decimals present', () => {
+      const out = _formatVftAmountForTests(null, 6, 'balance');
+      expect(out.rawStr).toBe('0');
+      expect(out.humanStr).toBe('0'); // minimalToVara(0n, 6) === '0'
+      expect(out.decimals).toBe(6);
+    });
+
+    it('null path applies identically for allowance kind', () => {
+      const balance = _formatVftAmountForTests(null, 18, 'balance');
+      const allowance = _formatVftAmountForTests(null, 18, 'allowance');
+      expect(balance.rawStr).toBe(allowance.rawStr);
+      expect(balance.humanStr).toBe(allowance.humanStr);
+    });
+  });
+
+  describe('non-null path (Option::Some / explicit zero)', () => {
+    it('passes through bigint values as decimal strings', () => {
+      const out = _formatVftAmountForTests(123_456_789n, null, 'balance');
+      expect(out.rawStr).toBe('123456789');
+      expect(out.humanStr).toBe('123456789');
+    });
+
+    it('passes through string-numeric values from decodeSailsResult', () => {
+      // decodeSailsResult normalizes U256 to decimal strings (#32 fix).
+      const out = _formatVftAmountForTests('1000000000000000000', null, 'balance');
+      expect(out.rawStr).toBe('1000000000000000000');
+    });
+
+    it('converts to human form when decimals present', () => {
+      // 1.5 token at 6 decimals = 1500000 minimal units.
+      const out = _formatVftAmountForTests(1_500_000n, 6, 'balance');
+      expect(out.rawStr).toBe('1500000');
+      expect(out.humanStr).toBe('1.5');
+      expect(out.decimals).toBe(6);
+    });
+
+    it('explicit zero (decoded = 0n) is distinct from null path in raw form', () => {
+      const explicitZero = _formatVftAmountForTests(0n, null, 'balance');
+      const nullValue = _formatVftAmountForTests(null, null, 'balance');
+      // Both surface as '0' — matches on-chain semantics where missing
+      // row and explicit zero are indistinguishable for transfer-spend.
+      expect(explicitZero.rawStr).toBe('0');
+      expect(nullValue.rawStr).toBe('0');
+    });
+  });
+
+  describe('regression: drops to BigInt(null) would throw', () => {
+    it('does NOT throw on null input (pre-0.15 bug shape)', () => {
+      expect(() => _formatVftAmountForTests(null, null, 'balance')).not.toThrow();
+      expect(() => _formatVftAmountForTests(null, 12, 'allowance')).not.toThrow();
+    });
+
+    it('rawStr never becomes the literal "null" string', () => {
+      // `String(null)` would yield "null"; the helper must short-circuit
+      // before reaching that path.
+      const out = _formatVftAmountForTests(null, null, 'balance');
+      expect(out.rawStr).not.toBe('null');
+    });
+  });
+});

--- a/src/__tests__/watch-decoded.test.ts
+++ b/src/__tests__/watch-decoded.test.ts
@@ -87,19 +87,22 @@ describe('formatUserMessageSentMaybeDecoded', () => {
     expect(out.payload).toMatch(/^0x/);
     expect(out.value).toBe('0');
     expect(out.details).toBeNull();
-    // Sails block appended.
-    expect(out.sails).toEqual({ service: 'Walker', event: 'StepCount', data: 42 });
+    // Decoded block appended (0.15 shape: decoded.kind === 'sails').
+    expect(out.decoded).toEqual({ kind: 'sails', service: 'Walker', event: 'StepCount', data: 42 });
+    // Old top-level sails: field is gone (renamed for forward-compat).
+    expect(out.sails).toBeUndefined();
   });
 
-  it('omits sails: block when no IDL is loaded (raw passthrough)', () => {
+  it('omits decoded block when no IDL is loaded (raw passthrough)', () => {
     const event = buildStepCountUms(sails, 42, PROGRAM_ID);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const out = formatUserMessageSentMaybeDecoded(event as any, null, PROGRAM_ID);
+    expect(out.decoded).toBeUndefined();
     expect(out.sails).toBeUndefined();
     expect(out.payload).toMatch(/^0x/);
   });
 
-  it('omits sails: block when source !== programId (Codex finding #2 — pre-filter)', () => {
+  it('omits decoded block when source !== programId (pre-filter — events[E].is() only checks destination + payload prefix)', () => {
     // Same valid Sails payload, but the message's source is OTHER_PROGRAM.
     // sails-js's events[E].is() would still return true (it only checks
     // destination + payload prefix), so we must skip decode at the
@@ -107,6 +110,7 @@ describe('formatUserMessageSentMaybeDecoded', () => {
     const event = buildStepCountUms(sails, 42, OTHER_PROGRAM);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const out = formatUserMessageSentMaybeDecoded(event as any, sails, PROGRAM_ID);
+    expect(out.decoded).toBeUndefined();
     expect(out.sails).toBeUndefined();
     expect(out.source).toBe(OTHER_PROGRAM);
   });

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -34,7 +34,7 @@ export function registerBalanceCommand(program: Command): void {
     .description('Transfer VARA tokens')
     .argument('<to>', 'destination address (hex or SS58)')
     .argument('[amount]', 'amount to transfer (in VARA by default)')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--all', 'transfer entire balance (account will be reaped)')
     .action(async (to: string, amount: string | undefined, options: { units?: string; all?: boolean }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
@@ -71,8 +71,7 @@ export function registerBalanceCommand(program: Command): void {
           amountRaw: balanceRaw.toString(),
         });
       } else {
-        const isRaw = options.units === 'raw';
-        const amountMinimal = resolveAmount(amount!, isRaw);
+        const amountMinimal = resolveAmount(amount!, options.units);
 
         if (amountMinimal <= 0n) {
           throw new CliError('Amount must be positive', 'INVALID_AMOUNT');

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -35,14 +35,10 @@ export function registerCallCommand(program: Command): void {
     }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
 
-      // Mutual exclusion: --estimate and --dry-run are both "preview" modes;
-      // picking one is unambiguous. Surface explicitly.
-      if (options.estimate && options.dryRun) {
-        throw new CliError(
-          'Cannot use --estimate and --dry-run together; pick one.',
-          'CONFLICTING_OPTIONS',
-        );
-      }
+      // --estimate and --dry-run COMPOSE on functions: when both are set,
+      // we encode the payload AND compute gas estimate (requires account).
+      // The legacy mutex was overly restrictive; previewing both is the
+      // common case for "what will this cost AND what payload am I sending".
 
       const api = await getApi(opts.ws);
 
@@ -118,31 +114,49 @@ export function registerCallCommand(program: Command): void {
  * Build the dry-run output object for a function call.
  * Pure helper so it can be unit-tested without wiring the full Commander
  * action. Key order is fixed for deterministic agent-friendly output.
+ *
+ * `destination` is the program ID the message is bound for. Surfaced
+ * separately from `encodedPayload` (the SCALE-encoded call) so callers
+ * can identify both pieces from a single dry-run reply.
+ *
+ * `estimateGas`, when present, is the result of composing --dry-run with
+ * --estimate (requires an account). Absent on plain --dry-run.
  */
 export function buildFunctionDryRun(input: {
   service: string;
   method: string;
   args: unknown[];
   encodedPayload: string;
+  destination: string;
   value?: string;
   gasLimit?: string;
   voucherId?: string;
+  estimateGas?: { gasLimit: string | null; minLimit: string | null };
 }): Record<string, unknown> {
-  return {
+  const out: Record<string, unknown> = {
     kind: 'function',
     service: input.service,
     method: input.method,
     args: input.args,
     encodedPayload: input.encodedPayload,
+    destination: input.destination,
     value: input.value ?? '0',
     gasLimit: input.gasLimit ?? null,
     voucherId: input.voucherId ?? null,
-    willSubmit: false,
   };
+  if (input.estimateGas) {
+    out.estimateGas = input.estimateGas;
+  }
+  out.willSubmit = false;
+  return out;
 }
 
 /**
  * Build the dry-run output object for a query call.
+ *
+ * Queries do not have a `destination` field today because the on-chain
+ * query path does not surface one separately from the program ID supplied
+ * by the caller. Add if a use case emerges.
  */
 export function buildQueryDryRun(input: {
   service: string;
@@ -221,17 +235,28 @@ async function executeFunction(
   const func = sails.services[serviceName].functions[methodName];
   args = coerceArgsAuto(args, func.args, sails, serviceName);
 
-  // Dry-run: encode payload and exit. No account, no gas calc, no submit.
-  // This must run BEFORE any account / value resolution so agents on
-  // machines with no wallet configured can still preview a payload.
-  if (options.dryRun) {
-    const txBuilder = func(...args);
-    const encodedPayload = txBuilder.payload;
+  // Dry-run + estimate composition. Both are read-only previews:
+  //   --dry-run      : encode payload, no account needed.
+  //   --estimate     : compute gas, account required.
+  //   both together  : encode payload AND compute gas, account required.
+  //   neither        : real submission (further down).
+  //
+  // encodePayload(...args) is the canonical SCALE-encoder on the function
+  // reference itself (mirrors the executeQuery path at this file's earlier
+  // query.encodePayload call). txBuilder.programId surfaces the destination
+  // explicitly. Both are resolved up front so the dry-run path needs no
+  // account, while the dry-run+estimate path falls through to gas calc.
+  const txBuilder = func(...args);
+  const encodedPayload = func.encodePayload(...args);
+  const destination = txBuilder.programId;
+
+  if (options.dryRun && !options.estimate) {
     output(buildFunctionDryRun({
       service: serviceName,
       method: methodName,
       args,
       encodedPayload,
+      destination,
       value: options.value !== '0' ? options.value : undefined,
       gasLimit: options.gasLimit,
       voucherId: options.voucher,
@@ -248,8 +273,6 @@ async function executeFunction(
     await validateVoucher(api, accountHex, options.voucher, programId);
   }
 
-  const txBuilder = func(...args);
-
   txBuilder.withAccount(account);
 
   if (value > 0n) {
@@ -265,12 +288,33 @@ async function executeFunction(
   }
 
   if (options.estimate) {
-    output({
-      estimate: true,
-      gasLimit: (txBuilder.gasInfo as any)?.limit?.toString() ?? txBuilder.gasInfo?.min_limit?.toString() ?? null,
-      minLimit: txBuilder.gasInfo?.min_limit?.toString() ?? null,
-      value: value.toString(),
-    });
+    const gasLimitStr = (txBuilder.gasInfo as any)?.limit?.toString() ?? txBuilder.gasInfo?.min_limit?.toString() ?? null;
+    const minLimitStr = txBuilder.gasInfo?.min_limit?.toString() ?? null;
+
+    if (options.dryRun) {
+      // Composition: dry-run shape with estimateGas appended.
+      output(buildFunctionDryRun({
+        service: serviceName,
+        method: methodName,
+        args,
+        encodedPayload,
+        destination,
+        value: options.value !== '0' ? options.value : undefined,
+        gasLimit: options.gasLimit,
+        voucherId: options.voucher,
+        estimateGas: { gasLimit: gasLimitStr, minLimit: minLimitStr },
+      }));
+    } else {
+      // Pure --estimate (no --dry-run): preserve the legacy lean shape so
+      // existing scripts parsing { estimate: true, gasLimit, minLimit, value }
+      // keep working unchanged.
+      output({
+        estimate: true,
+        gasLimit: gasLimitStr,
+        minLimit: minLimitStr,
+        value: value.toString(),
+      });
+    }
     return;
   }
 

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -111,6 +111,37 @@ export function registerCallCommand(program: Command): void {
 }
 
 /**
+ * Resolve the dry-run payload + destination for a function call.
+ *
+ * `encodedPayload` MUST come from `func.encodePayload(...args)` — the
+ * canonical SCALE encoder. `txBuilder.payload` (sails-js's
+ * `this._tx.args[0].toHex()`) is the message destination program ID,
+ * not the encoded call. Surfacing both pieces from one helper makes the
+ * contract testable: a regression that swapped `encodedPayload` to
+ * `txBuilder.payload` would visibly disagree with `destination` in
+ * tests, where the production code did silently the wrong thing.
+ *
+ * Takes `txBuilder` as a separate arg (instead of building one
+ * internally) so the action handler doesn't double-build txBuilder
+ * when it also needs gas-calc / signAndSend on the same instance.
+ *
+ * Exported with the `_…ForTests` suffix to match the convention used by
+ * `_tryExtractFromChainForTests` and `_resolveIdlForTests` in
+ * `src/services/sails.ts` — public surface is reserved for the action
+ * handler, this is purely a regression-test seam.
+ */
+export function _resolveDryRunPayloadForTests(
+  func: { encodePayload: (...args: unknown[]) => string },
+  txBuilder: { programId: string },
+  args: unknown[],
+): { encodedPayload: string; destination: string } {
+  return {
+    encodedPayload: func.encodePayload(...args),
+    destination: txBuilder.programId,
+  };
+}
+
+/**
  * Build the dry-run output object for a function call.
  * Pure helper so it can be unit-tested without wiring the full Commander
  * action. Key order is fixed for deterministic agent-friendly output.
@@ -241,14 +272,12 @@ async function executeFunction(
   //   both together  : encode payload AND compute gas, account required.
   //   neither        : real submission (further down).
   //
-  // encodePayload(...args) is the canonical SCALE-encoder on the function
-  // reference itself (mirrors the executeQuery path at this file's earlier
-  // query.encodePayload call). txBuilder.programId surfaces the destination
-  // explicitly. Both are resolved up front so the dry-run path needs no
-  // account, while the dry-run+estimate path falls through to gas calc.
+  // _resolveDryRunPayloadForTests is the canonical encoder seam (also
+  // exported as a regression hook). The dry-run+estimate path falls
+  // through to gas calc, which mutates txBuilder via
+  // withAccount/withValue/calculateGas — same instance, no rebuild.
   const txBuilder = func(...args);
-  const encodedPayload = func.encodePayload(...args);
-  const destination = txBuilder.programId;
+  const { encodedPayload, destination } = _resolveDryRunPayloadForTests(func, txBuilder, args);
 
   if (options.dryRun && !options.estimate) {
     output(buildFunctionDryRun({

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -16,7 +16,7 @@ export function registerCallCommand(program: Command): void {
     .option('--args <json>', 'method arguments as JSON array (default: [])')
     .option('--args-file <path>', 'read --args JSON from file (use - for stdin)')
     .option('--value <value>', 'value to send (in VARA, functions only)', '0')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--gas-limit <gas>', 'gas limit override (functions only)')
     .option('--idl <path>', 'path to local IDL file')
     .option('--voucher <id>', 'voucher ID to pay for the message')
@@ -265,8 +265,7 @@ async function executeFunction(
   }
 
   const account = await resolveAccount(opts);
-  const isRaw = options.units === 'raw';
-  const value = resolveAmount(options.value, isRaw);
+  const value = resolveAmount(options.value, options.units);
 
   if (options.voucher) {
     const accountHex = addressToHex(account.address);

--- a/src/commands/dex.ts
+++ b/src/commands/dex.ts
@@ -268,18 +268,18 @@ async function resolveTokenAmount(
   amount: string,
   units?: string,
 ): Promise<bigint> {
-  if (units !== undefined && units !== 'raw' && units !== 'token') {
+  if (units !== undefined && units !== 'raw' && units !== 'human') {
     throw new CliError(
-      `Invalid --units value: "${units}". Must be "raw" or "token".`,
+      `Invalid --units value: "${units}". Must be "raw" or "human".`,
       'INVALID_UNITS',
     );
   }
 
-  if (units === 'token') {
+  if (units === 'human') {
     const decimals = await queryTokenDecimals(api, tokenAddress);
     if (decimals === null) {
       throw new CliError(
-        'Cannot use --units token: Decimals query is not available on this token program.',
+        'Cannot use --units human: Decimals query is not available on this token program.',
         'DECIMALS_UNAVAILABLE',
       );
     }
@@ -298,7 +298,7 @@ async function resolveTokenAmount(
     return BigInt(amount);
   } catch {
     throw new CliError(
-      `Invalid amount: "${amount}". Use a whole number for raw units, or --units token for decimal amounts.`,
+      `Invalid amount: "${amount}". Use a whole number for raw units, or --units human for decimal amounts.`,
       'INVALID_AMOUNT',
     );
   }
@@ -618,7 +618,7 @@ export function registerDexCommand(program: Command): void {
     .argument('<amount>', 'input amount (or output amount with --reverse)')
     .option('--factory <addr>', 'factory program address')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token')
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)')
     .option('--reverse', 'calculate required input for exact output')
     .action(async (tokenIn: string, tokenOut: string, amount: string, options: {
       factory?: string; idl?: string; units?: string; reverse?: boolean;
@@ -695,7 +695,7 @@ export function registerDexCommand(program: Command): void {
     .argument('<amount>', 'amount to swap')
     .option('--factory <addr>', 'factory program address')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token')
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)')
     .option('--slippage <bps>', `slippage tolerance in basis points (default: ${DEFAULT_SLIPPAGE_BPS})`)
     .option('--deadline <seconds>', `tx deadline in seconds (default: ${DEFAULT_DEADLINE_SECONDS})`)
     .option('--exact-out', 'treat amount as exact output (swap tokens for exact tokens)')
@@ -800,7 +800,7 @@ export function registerDexCommand(program: Command): void {
     .argument('<amount1>', 'desired amount of second token')
     .option('--factory <addr>', 'factory program address')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token')
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)')
     .option('--slippage <bps>', `slippage tolerance in basis points (default: ${DEFAULT_SLIPPAGE_BPS})`)
     .option('--deadline <seconds>', `tx deadline in seconds (default: ${DEFAULT_DEADLINE_SECONDS})`)
     .option('--skip-approve', 'skip automatic token approval')
@@ -897,7 +897,7 @@ export function registerDexCommand(program: Command): void {
     .argument('<liquidity>', 'LP token amount to burn')
     .option('--factory <addr>', 'factory program address')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token (uses LP decimals)')
+    .option('--units <type>', 'amount units: raw (default) or human (uses LP decimals)')
     .option('--slippage <bps>', `slippage tolerance in basis points (default: ${DEFAULT_SLIPPAGE_BPS})`)
     .option('--deadline <seconds>', `tx deadline in seconds (default: ${DEFAULT_DEADLINE_SECONDS})`)
     .option('--skip-approve', 'skip automatic token approval')

--- a/src/commands/dex.ts
+++ b/src/commands/dex.ts
@@ -8,7 +8,7 @@ import { loadSails } from '../services/sails';
 import { readConfig } from '../services/config';
 import { resolveBlockNumber } from '../services/tx-executor';
 import { validateVoucher } from '../services/voucher-validator';
-import { output, verbose, CliError, minimalToVara, toMinimalUnits, addressToHex, decodeSailsResult } from '../utils';
+import { output, verbose, CliError, minimalToVara, toMinimalUnits, addressToHex, decodeSailsResult, validateUnits } from '../utils';
 import { BUNDLED_DEX_FACTORY_IDLS, BUNDLED_DEX_PAIR_IDLS, BUNDLED_VFT_IDLS } from '../idl/bundled-idls';
 
 // ---------------------------------------------------------------------------
@@ -268,14 +268,9 @@ async function resolveTokenAmount(
   amount: string,
   units?: string,
 ): Promise<bigint> {
-  if (units !== undefined && units !== 'raw' && units !== 'human') {
-    throw new CliError(
-      `Invalid --units value: "${units}". Must be "raw" or "human".`,
-      'INVALID_UNITS',
-    );
-  }
+  const u = validateUnits(units);
 
-  if (units === 'human') {
+  if (u === 'human') {
     const decimals = await queryTokenDecimals(api, tokenAddress);
     if (decimals === null) {
       throw new CliError(

--- a/src/commands/idl.ts
+++ b/src/commands/idl.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 import * as fs from 'fs';
-import * as path from 'path';
 import { getApi } from '../services/api';
 import {
   writeCachedIdl,
@@ -153,7 +152,9 @@ export function registerIdlCommand(program: Command): void {
 
       let removed = 0;
       for (const entry of entries) {
-        const file = path.join(dir, `${entry.codeId}.cache.json`);
+        // Reuse getIdlEntryPath so the cache filename schema is single-sourced
+        // in idl-cache.ts (was: inline `${codeId}.cache.json` template).
+        const file = getIdlEntryPath(entry.codeId);
         try {
           fs.unlinkSync(file);
           removed++;

--- a/src/commands/idl.ts
+++ b/src/commands/idl.ts
@@ -1,9 +1,20 @@
 import { Command } from 'commander';
 import * as fs from 'fs';
+import * as path from 'path';
 import { getApi } from '../services/api';
-import { writeCachedIdl, getIdlEntryPath } from '../services/idl-cache';
+import {
+  writeCachedIdl,
+  getIdlEntryPath,
+  getIdlCacheDir,
+  enumerateCacheEntries,
+  evictCachedIdl,
+} from '../services/idl-cache';
 import { detectIdlVersion } from '../services/sails';
-import { output, verbose, CliError, addressToHex } from '../utils';
+import { output, verbose, CliError, addressToHex, errorMessage } from '../utils';
+
+/** Strict 32-byte hex (with or without 0x prefix). Reused across idl
+ *  import/remove so the codeId vocabulary is identical. */
+const CODE_ID_HEX_RE = /^(0x)?[0-9a-fA-F]{64}$/;
 
 /**
  * `vara-wallet idl import <path.idl> (--code-id <hex> | --program <hex|ss58>)`
@@ -89,5 +100,76 @@ export function registerIdlCommand(program: Command): void {
         source: 'import',
         path: getIdlEntryPath(codeId),
       });
+    });
+
+  // ───────────── idl list ─────────────
+  idl
+    .command('list')
+    .description('List cached IDL entries')
+    .action(() => {
+      output(enumerateCacheEntries());
+    });
+
+  // ───────────── idl remove <code-id> ─────────────
+  idl
+    .command('remove')
+    .description('Remove a single cached IDL entry (idempotent — non-existent entries return removed: false, exit 0)')
+    .argument('<code-id>', 'code ID (0x-prefixed or bare 32-byte hex)')
+    .action((codeId: string) => {
+      if (!CODE_ID_HEX_RE.test(codeId)) {
+        throw new CliError(
+          `Invalid <code-id>: expected 32-byte hex (0x-prefixed or bare), got "${codeId}"`,
+          'INVALID_CODE_ID',
+        );
+      }
+      const file = getIdlEntryPath(codeId);
+      const existed = fs.existsSync(file);
+      // evictCachedIdl already swallows ENOENT and verbose-logs other errors.
+      evictCachedIdl(codeId);
+      output({ codeId, removed: existed });
+    });
+
+  // ───────────── idl clear [--yes] ─────────────
+  // terraform-style: bare invocation previews; --yes commits.
+  idl
+    .command('clear')
+    .description('Remove all cached IDL entries (terraform-style: bare invocation previews; --yes commits)')
+    .option('--yes', 'actually remove the entries (without --yes, only previews what would be removed)')
+    .action((options: { yes?: boolean }) => {
+      const dir = getIdlCacheDir();
+      // Snapshot — single readdir at the top. New entries created by a
+      // parallel writer between snapshot and unlink will simply survive
+      // until the next clear (recoverable resource, no locking).
+      const entries = enumerateCacheEntries();
+
+      if (!options.yes) {
+        output({
+          wouldRemove: entries.map((e) => ({ codeId: e.codeId, source: e.source })),
+          path: dir,
+          hint: 'vara-wallet idl clear --yes to proceed',
+        });
+        return;
+      }
+
+      let removed = 0;
+      for (const entry of entries) {
+        const file = path.join(dir, `${entry.codeId}.cache.json`);
+        try {
+          fs.unlinkSync(file);
+          removed++;
+          verbose(`IDL cache entry removed: ${entry.codeId}`);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === 'ENOENT') continue; // race: removed between snapshot and unlink
+          if (code === 'EACCES') {
+            throw new CliError(
+              `Permission denied removing IDL cache entry ${entry.codeId}: ${errorMessage(err)}`,
+              'PERMISSION_DENIED',
+            );
+          }
+          throw err;
+        }
+      }
+      output({ removed, path: dir });
     });
 }

--- a/src/commands/idl.ts
+++ b/src/commands/idl.ts
@@ -71,7 +71,7 @@ export function registerIdlCommand(program: Command): void {
         // it hits the cache filename. Without this, `--code-id "../../etc/foo"`
         // would escape the cache directory (mode 0600 on the file, but outside
         // ~/.vara-wallet/idl-cache/ — still a path-traversal surface).
-        if (!/^(0x)?[0-9a-fA-F]{64}$/.test(options.codeId)) {
+        if (!CODE_ID_HEX_RE.test(options.codeId)) {
           throw new CliError(
             `Invalid --code-id: expected 32-byte hex string (0x-prefixed or bare), got "${options.codeId}"`,
             'INVALID_CODE_ID',

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -61,7 +61,7 @@ export function registerMessageCommand(program: Command): void {
     .option('--payload-ascii <text>', 'message payload as plain text (converted to hex)')
     .option('--gas-limit <gas>', 'gas limit (auto-calculated if not set)')
     .option('--value <value>', 'value to send with message (in VARA)', '0')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--metadata <path>', 'path to .meta.txt file for encoding')
     .option('--voucher <id>', 'voucher ID to pay for the message')
     .action(async (destination: string, options: {
@@ -76,8 +76,7 @@ export function registerMessageCommand(program: Command): void {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
-      const isRaw = options.units === 'raw';
-      const value = resolveAmount(options.value, isRaw);
+      const value = resolveAmount(options.value, options.units);
 
       let meta: ProgramMetadata | undefined;
       if (options.metadata) {
@@ -151,7 +150,7 @@ export function registerMessageCommand(program: Command): void {
     .option('--payload-ascii <text>', 'reply payload as plain text (converted to hex)')
     .option('--gas-limit <gas>', 'gas limit (auto-calculated if not set)')
     .option('--value <value>', 'value to send with reply (in VARA)', '0')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--metadata <path>', 'path to .meta.txt file for encoding')
     .option('--voucher <id>', 'voucher ID to pay for the message')
     .action(async (messageId: string, options: {
@@ -166,8 +165,7 @@ export function registerMessageCommand(program: Command): void {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
-      const isRaw = options.units === 'raw';
-      const value = resolveAmount(options.value, isRaw);
+      const value = resolveAmount(options.value, options.units);
 
       let meta: ProgramMetadata | undefined;
       if (options.metadata) {
@@ -232,7 +230,7 @@ export function registerMessageCommand(program: Command): void {
     .option('--payload <payload>', 'message payload (hex 0x... or JSON string)', '0x')
     .option('--payload-ascii <text>', 'message payload as plain text (converted to hex)')
     .option('--value <value>', 'value to simulate (in VARA)', '0')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--origin <address>', 'origin address for the calculation (hex or SS58)')
     .option('--at <blockHash>', 'block hash to query state at')
     .action(async (programId: string, options: {
@@ -245,8 +243,7 @@ export function registerMessageCommand(program: Command): void {
     }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
-      const isRaw = options.units === 'raw';
-      const value = resolveAmount(options.value, isRaw);
+      const value = resolveAmount(options.value, options.units);
 
       // Resolve origin - use provided address or account
       let origin: `0x${string}`;

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -112,7 +112,7 @@ export function registerProgramCommand(program: Command): void {
     .option('--args-file <path>', 'read constructor --args JSON from file (use - for stdin, requires --idl)')
     .option('--gas-limit <gas>', 'gas limit (auto-calculated if not set)')
     .option('--value <value>', 'value to send (in VARA)', '0')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--salt <salt>', 'salt for program address (hex)')
     .option('--metadata <path>', 'path to .meta.txt file')
     .option('--dry-run', 'encode the constructor payload and exit without uploading (no account required)')
@@ -157,8 +157,7 @@ export function registerProgramCommand(program: Command): void {
 
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
-      const isRaw = options.units === 'raw';
-      const value = resolveAmount(options.value, isRaw);
+      const value = resolveAmount(options.value, options.units);
 
       const code = fs.readFileSync(wasmPath);
 
@@ -219,7 +218,7 @@ export function registerProgramCommand(program: Command): void {
     .option('--args-file <path>', 'read constructor --args JSON from file (use - for stdin, requires --idl)')
     .option('--gas-limit <gas>', 'gas limit (auto-calculated if not set)')
     .option('--value <value>', 'value to send (in VARA)', '0')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--salt <salt>', 'salt for program address (hex)')
     .option('--metadata <path>', 'path to .meta.txt file')
     .option('--dry-run', 'encode the constructor payload and exit without creating (no account required)')
@@ -260,8 +259,7 @@ export function registerProgramCommand(program: Command): void {
 
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
-      const isRaw = options.units === 'raw';
-      const value = resolveAmount(options.value, isRaw);
+      const value = resolveAmount(options.value, options.units);
 
       let meta: ProgramMetadata | undefined;
       if (options.metadata) {

--- a/src/commands/subscribe/messages.ts
+++ b/src/commands/subscribe/messages.ts
@@ -23,16 +23,14 @@ export function registerMessagesCommand(parent: Command): void {
     .command('messages')
     .description('Subscribe to program messages and events')
     .argument('<programId>', 'program ID to watch (hex or SS58)')
-    .option('--type <eventType>', 'specific event type (Gear pallet event or Sails Service/Event)')
+    .option('--event <eventType>', 'event filter: Gear pallet name (UserMessageSent), Sails Service/Event, bare Sails event, or pallet:Name to force pallet vocab')
     .option('--from-block <number>', 'backfill from a specific block number')
     .option('--idl <path>', 'path to local IDL file (forces Sails-aware decode)')
-    .option('--pallet-event', 'force Gear pallet event resolution even when an IDL is loaded')
     .option('--no-decode', 'disable opportunistic IDL auto-load (raw output only)')
     .action(async (programId: string, options: {
-      type?: string;
+      event?: string;
       fromBlock?: string;
       idl?: string;
-      palletEvent?: boolean;
       decode?: boolean;
     }) => {
       const opts = parent.parent!.optsWithGlobals() as { ws?: string; count?: string; timeout?: string; persist?: boolean };
@@ -61,8 +59,8 @@ export function registerMessagesCommand(parent: Command): void {
         }
       }
 
-      if (options.type) {
-        const filter = resolveSubscribeFilter(options.type, sails, options.palletEvent === true);
+      if (options.event) {
+        const filter = resolveSubscribeFilter(options.event, sails);
         const fromBlock = options.fromBlock ? validateFromBlock(options.fromBlock) : undefined;
 
         if (filter.kind === 'pallet') {

--- a/src/commands/subscribe/messages.ts
+++ b/src/commands/subscribe/messages.ts
@@ -108,24 +108,31 @@ export function registerMessagesCommand(parent: Command): void {
             const unsub = await api.gearEvents.subscribeToUserMessageSentByActor(
               { from: programIdHex },
               safeCallback((event) => {
-                const decoded = formatUserMessageSentMaybeDecoded(event, sails, programIdHex);
-                const sailsBlock = (decoded as { sails?: { service: string; event: string } }).sails;
-                if (!sailsBlock || sailsBlock.service !== filter.service || sailsBlock.event !== filter.event) {
+                const formatted = formatUserMessageSentMaybeDecoded(event, sails, programIdHex);
+                const decodedBlock = (formatted as {
+                  decoded?: { kind: string; service: string; event: string };
+                }).decoded;
+                if (
+                  !decodedBlock ||
+                  decodedBlock.kind !== 'sails' ||
+                  decodedBlock.service !== filter.service ||
+                  decodedBlock.event !== filter.event
+                ) {
                   return;
                 }
                 const data = {
                   type: 'message' as const,
                   event: 'UserMessageSent',
-                  ...decoded,
+                  ...formatted,
                   timestamp: Date.now(),
                 };
 
                 emitAndPersist(data, persist, {
                   type: 'message',
-                  event_id: decoded.messageId as string,
+                  event_id: formatted.messageId as string,
                   data,
-                  source: decoded.source as string,
-                  destination: decoded.destination as string,
+                  source: formatted.source as string,
+                  destination: formatted.destination as string,
                   program_id: programIdHex,
                 });
 

--- a/src/commands/subscribe/messages.ts
+++ b/src/commands/subscribe/messages.ts
@@ -15,6 +15,7 @@ import {
   validateFromBlock,
   formatUserMessageSent,
   formatUserMessageSentMaybeDecoded,
+  matchesSailsFilter,
   resolveSubscribeFilter,
 } from './shared';
 
@@ -109,17 +110,7 @@ export function registerMessagesCommand(parent: Command): void {
               { from: programIdHex },
               safeCallback((event) => {
                 const formatted = formatUserMessageSentMaybeDecoded(event, sails, programIdHex);
-                const decodedBlock = (formatted as {
-                  decoded?: { kind: string; service: string; event: string };
-                }).decoded;
-                if (
-                  !decodedBlock ||
-                  decodedBlock.kind !== 'sails' ||
-                  decodedBlock.service !== filter.service ||
-                  decodedBlock.event !== filter.event
-                ) {
-                  return;
-                }
+                if (!matchesSailsFilter(formatted, filter)) return;
                 const data = {
                   type: 'message' as const,
                   event: 'UserMessageSent',

--- a/src/commands/subscribe/shared.ts
+++ b/src/commands/subscribe/shared.ts
@@ -259,6 +259,18 @@ export function formatUserMessageSent(event: UserMessageSent): Record<string, un
 }
 
 /**
+ * Typed shape of the decoded NDJSON augmentation block. The `kind`
+ * discriminator is a literal so consumers can switch on it; future
+ * decoder types (e.g. EVM events) sit alongside `'sails'`.
+ */
+export type DecodedBlock = {
+  kind: 'sails';
+  service: string;
+  event: string;
+  data: unknown;
+};
+
+/**
  * Decode a `UserMessageSent` against an optional Sails IDL and return the
  * existing raw shape, additively augmented with
  * `decoded: { kind: 'sails', service, event, data }` when a decode
@@ -285,7 +297,32 @@ export function formatUserMessageSentMaybeDecoded(
   if (sourceHex !== programIdHex) return raw;
   const decoded = decodeSailsEvent(sails, event);
   if (!decoded) return raw;
-  return { ...raw, decoded: { kind: 'sails', service: decoded.service, event: decoded.event, data: decoded.data } };
+  const decodedBlock: DecodedBlock = {
+    kind: 'sails',
+    service: decoded.service,
+    event: decoded.event,
+    data: decoded.data,
+  };
+  return { ...raw, decoded: decodedBlock };
+}
+
+/**
+ * Returns true when the formatted message has a Sails-decoded block
+ * matching the given filter. Used by both `watch` and
+ * `subscribe messages` to decide whether to emit a UserMessageSent
+ * event after the IDL-aware filter is set.
+ */
+export function matchesSailsFilter(
+  formatted: Record<string, unknown>,
+  filter: { service: string; event: string },
+): boolean {
+  const block = (formatted as { decoded?: DecodedBlock }).decoded;
+  return (
+    block !== undefined &&
+    block.kind === 'sails' &&
+    block.service === filter.service &&
+    block.event === filter.event
+  );
 }
 
 /**
@@ -315,14 +352,16 @@ export type ResolvedSubscribeFilter =
   | { kind: 'sails'; service: string; event: string }
   | { kind: 'pallet'; event: GearEventName };
 
+/** `pallet:Foo` → forces pallet vocab. Replaces the dropped `--pallet-event` flag. */
+export const PALLET_PREFIX = 'pallet:';
+
 export function resolveSubscribeFilter(
   name: string,
   sails: LoadedSails | null,
 ): ResolvedSubscribeFilter {
   // `pallet:` prefix forces pallet vocab regardless of IDL state.
-  // Replaces the old `--pallet-event` boolean flag with inline syntax.
-  if (name.startsWith('pallet:')) {
-    return { kind: 'pallet', event: validateEventName(name.slice('pallet:'.length)) };
+  if (name.startsWith(PALLET_PREFIX)) {
+    return { kind: 'pallet', event: validateEventName(name.slice(PALLET_PREFIX.length)) };
   }
   // Gear-first precedence — bare names that match the legacy pallet vocab
   // always resolve to the pallet path. Anything else would silently break

--- a/src/commands/subscribe/shared.ts
+++ b/src/commands/subscribe/shared.ts
@@ -260,15 +260,19 @@ export function formatUserMessageSent(event: UserMessageSent): Record<string, un
 
 /**
  * Decode a `UserMessageSent` against an optional Sails IDL and return the
- * existing raw shape, additively augmented with `sails: {service, event,
- * data}` when a decode succeeds. NEVER renames or removes existing fields
- * — backward-compat on the wire is the contract.
+ * existing raw shape, additively augmented with
+ * `decoded: { kind: 'sails', service, event, data }` when a decode
+ * succeeds. NEVER renames or removes existing raw fields.
+ *
+ * The `kind: 'sails'` discriminator future-proofs the surface so a second
+ * decoder type (e.g. EVM events) can sit alongside without renaming the
+ * top-level field again. Replaces the 0.14.x `sails: {...}` shape.
  *
  * `sails-js`'s own `events[E].is()` only checks destination + payload
  * prefix. So we MUST pre-filter by `message.source === programIdHex`
  * here; otherwise an unrelated program that happens to share the
  * service hash + event id would get its events spuriously decoded
- * against this IDL (Codex finding #2).
+ * against this IDL.
  */
 export function formatUserMessageSentMaybeDecoded(
   event: UserMessageSent,
@@ -281,7 +285,7 @@ export function formatUserMessageSentMaybeDecoded(
   if (sourceHex !== programIdHex) return raw;
   const decoded = decodeSailsEvent(sails, event);
   if (!decoded) return raw;
-  return { ...raw, sails: { service: decoded.service, event: decoded.event, data: decoded.data } };
+  return { ...raw, decoded: { kind: 'sails', service: decoded.service, event: decoded.event, data: decoded.data } };
 }
 
 /**

--- a/src/commands/subscribe/shared.ts
+++ b/src/commands/subscribe/shared.ts
@@ -285,20 +285,27 @@ export function formatUserMessageSentMaybeDecoded(
 }
 
 /**
- * Resolved filter for `--type` / `--event` flags on watch / subscribe.
+ * Resolved filter for the `--event` flag on watch / subscribe messages.
  *
- * `pallet` — match a `gearEvents` pallet event by name (back-compat).
+ * `pallet` — match a `gearEvents` pallet event by name.
  * `sails` — match a Sails IDL event by `(service, event)`.
  *
- * Resolution order: Gear vocab first, then Sails IDL. This preserves
- * back-compat for users who already type `--event UserMessageSent`
- * (it always resolves to the pallet event, never to a same-named
- * Sails event). Users who want a Sails event can pass `Service/Event`
- * (always unambiguous) or a bare name that exists only in the IDL.
+ * Resolution order:
+ *   1. `pallet:` prefix → strip and resolve as pallet event (forces pallet
+ *      vocab even when an IDL is loaded). Replaces the old `--pallet-event`
+ *      flag with a single-flag mental model.
+ *   2. Bare names that match the legacy Gear vocab → pallet path
+ *      (back-compat: existing scripts using `--event UserMessageSent`
+ *      keep working).
+ *   3. Sails IDL lookup if an IDL is loaded — bare names that match a
+ *      Sails event resolve to the sails path. `Service/Event` is always
+ *      unambiguous.
+ *   4. Falls back to pallet validation, which surfaces a clean error if
+ *      the name doesn't match anywhere.
  *
- * `forcePallet=true` skips the IDL lookup entirely. Used by the
- * `--pallet-event` escape-hatch flag for the rare case where a user
- * has loaded an IDL but wants the pallet path anyway.
+ * Ambiguous bare Sails names (same name in multiple services) hard-fail
+ * with `AMBIGUOUS_EVENT` listing the alternatives — `resolveEventName`
+ * throws that and we let it propagate.
  */
 export type ResolvedSubscribeFilter =
   | { kind: 'sails'; service: string; event: string }
@@ -307,17 +314,17 @@ export type ResolvedSubscribeFilter =
 export function resolveSubscribeFilter(
   name: string,
   sails: LoadedSails | null,
-  forcePallet: boolean,
 ): ResolvedSubscribeFilter {
+  // `pallet:` prefix forces pallet vocab regardless of IDL state.
+  // Replaces the old `--pallet-event` boolean flag with inline syntax.
+  if (name.startsWith('pallet:')) {
+    return { kind: 'pallet', event: validateEventName(name.slice('pallet:'.length)) };
+  }
   // Gear-first precedence — bare names that match the legacy pallet vocab
-  // always resolve to the pallet path. Codex finding #5: anything else
-  // would silently break existing scripts when an IDL happens to declare
-  // a same-named event.
+  // always resolve to the pallet path. Anything else would silently break
+  // existing scripts when an IDL happens to declare a same-named event.
   if (!name.includes('/') && (VALID_GEAR_EVENTS as readonly string[]).includes(name)) {
     return { kind: 'pallet', event: name as GearEventName };
-  }
-  if (forcePallet) {
-    return { kind: 'pallet', event: validateEventName(name) };
   }
   if (sails) {
     // resolveEventName throws AMBIGUOUS_EVENT on multi-service bare-name

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -78,6 +78,38 @@ async function queryDecimals(sails: Sails, serviceName: string): Promise<number 
 }
 
 /**
+ * Build the JSON output shape for `vft balance` / `vft allowance` from
+ * the decoded query result. Pulled out as a pure helper so the U8
+ * null-safety contract has a unit-test seam.
+ *
+ * Contract:
+ *   - `decoded === null` (Option::None from `opt u256` returns) → '0'.
+ *     Mirrors on-chain semantics where a missing balance / allowance
+ *     row is indistinguishable from zero from the spend perspective.
+ *   - `decimals === null` → emit raw + raw (no human form).
+ *   - Otherwise → convert with `minimalToVara(BigInt(raw), decimals)`.
+ *
+ * `kind` controls the field naming so balance and allowance share the
+ * same translation logic without duplicating two near-identical inline
+ * blocks at the call sites.
+ */
+export function _formatVftAmountForTests(
+  decoded: unknown,
+  decimals: number | null,
+  kind: 'balance' | 'allowance',
+): { rawStr: string; humanStr: string; decimals: number | null } {
+  const rawStr = decoded === null ? '0' : String(decoded);
+  const humanStr = decimals !== null
+    ? minimalToVara(BigInt(rawStr), decimals)
+    : rawStr;
+  // `kind` is part of the API so callers can't accidentally swap balance
+  // ↔ allowance — keeping it as a discriminator forces sites to be
+  // explicit about which they're emitting.
+  void kind;
+  return { rawStr, humanStr, decimals };
+}
+
+/**
  * Resolve an amount for a VFT transaction.
  *
  * Vocabulary (unified in 0.15.0):
@@ -303,21 +335,14 @@ export function registerVftCommand(program: Command): void {
       // be the standard Vft (returns u256) or VftExtension (returns
       // opt u256), depending on IDL author. Both shapes must be safe.
       const decoded = decodeSailsResult(sails, query.returnTypeDef, raw, serviceName);
-
       const decimals = await queryDecimals(sails, serviceName);
-
-      // Null means the account has no balance row — surface as '0' for
-      // consistency with on-chain semantics (a missing row IS zero
-      // balance from a transfer-spending perspective).
-      const balanceStr = decoded === null ? '0' : String(decoded);
+      const { rawStr, humanStr } = _formatVftAmountForTests(decoded, decimals, 'balance');
 
       output({
         tokenProgram,
         account: address,
-        balance: decimals !== null
-          ? minimalToVara(BigInt(balanceStr), decimals)
-          : balanceStr,
-        balanceRaw: balanceStr,
+        balance: humanStr,
+        balanceRaw: rawStr,
         ...(decimals !== null && { decimals }),
       });
     });
@@ -351,19 +376,15 @@ export function registerVftCommand(program: Command): void {
       // decodeSailsResult so opt u256 returns (no allowance row) come
       // through as null instead of crashing BigInt(null).
       const decoded = decodeSailsResult(sails, query.returnTypeDef, raw, serviceName);
-
       const decimals = await queryDecimals(sails, serviceName);
-
-      const allowanceStr = decoded === null ? '0' : String(decoded);
+      const { rawStr, humanStr } = _formatVftAmountForTests(decoded, decimals, 'allowance');
 
       output({
         tokenProgram,
         owner,
         spender,
-        allowance: decimals !== null
-          ? minimalToVara(BigInt(allowanceStr), decimals)
-          : allowanceStr,
-        allowanceRaw: allowanceStr,
+        allowance: humanStr,
+        allowanceRaw: rawStr,
         ...(decimals !== null && { decimals }),
       });
     });

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -79,8 +79,15 @@ async function queryDecimals(sails: Sails, serviceName: string): Promise<number 
 
 /**
  * Resolve an amount for a VFT transaction.
- * With --units token: queries decimals and converts. Hard-fails if decimals unavailable.
- * Default (raw): passes through as BigInt.
+ *
+ * Vocabulary (unified in 0.15.0):
+ *   - `human` : query the token's decimals via the IDL and convert.
+ *               Hard-fails if decimals query is unavailable.
+ *   - `raw`   : default — pass through as BigInt (minimal units).
+ *
+ * Anything else is INVALID_UNITS. The legacy `token` literal (0.14.x) is
+ * intentionally rejected — `human` is the unified vocabulary across all
+ * commands; for VFT it means "use the token's declared decimals".
  */
 async function resolveVftAmount(
   sails: Sails,
@@ -88,18 +95,18 @@ async function resolveVftAmount(
   amount: string,
   units?: string,
 ): Promise<bigint> {
-  if (units !== undefined && units !== 'raw' && units !== 'token') {
+  if (units !== undefined && units !== 'raw' && units !== 'human') {
     throw new CliError(
-      `Invalid --units value: "${units}". Must be "raw" or "token".`,
+      `Invalid --units value: "${units}". Must be "raw" or "human".`,
       'INVALID_UNITS',
     );
   }
 
-  if (units === 'token') {
+  if (units === 'human') {
     const decimals = await queryDecimals(sails, serviceName);
     if (decimals === null) {
       throw new CliError(
-        'Cannot use --units token: Decimals query is not available on this token program.',
+        'Cannot use --units human: Decimals query is not available on this token program.',
         'DECIMALS_UNAVAILABLE',
       );
     }
@@ -118,7 +125,7 @@ async function resolveVftAmount(
     return BigInt(amount);
   } catch {
     throw new CliError(
-      `Invalid amount: "${amount}". Use a whole number for raw units, or --units token for decimal amounts.`,
+      `Invalid amount: "${amount}". Use a whole number for raw units, or --units human for decimal amounts.`,
       'INVALID_AMOUNT',
     );
   }
@@ -349,7 +356,7 @@ export function registerVftCommand(program: Command): void {
     .argument('<to>', 'destination address')
     .argument('<amount>', 'amount to transfer')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token', undefined)
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)', undefined)
     .option('--voucher <id>', 'voucher ID to pay for the transaction')
     .action(async (tokenProgram: string, to: string, amount: string, options: VftTxOptions) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
@@ -376,7 +383,7 @@ export function registerVftCommand(program: Command): void {
     .argument('<spender>', 'spender address')
     .argument('<amount>', 'amount to approve')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token', undefined)
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)', undefined)
     .option('--voucher <id>', 'voucher ID to pay for the transaction')
     .action(async (tokenProgram: string, spender: string, amount: string, options: VftTxOptions) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
@@ -404,7 +411,7 @@ export function registerVftCommand(program: Command): void {
     .argument('<to>', 'destination address')
     .argument('<amount>', 'amount to transfer')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token', undefined)
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)', undefined)
     .option('--voucher <id>', 'voucher ID to pay for the transaction')
     .action(async (tokenProgram: string, from: string, to: string, amount: string, options: VftTxOptions) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
@@ -431,7 +438,7 @@ export function registerVftCommand(program: Command): void {
     .argument('<to>', 'recipient address')
     .argument('<amount>', 'amount to mint')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token', undefined)
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)', undefined)
     .option('--voucher <id>', 'voucher ID to pay for the transaction')
     .action(async (tokenProgram: string, to: string, amount: string, options: VftTxOptions) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
@@ -458,7 +465,7 @@ export function registerVftCommand(program: Command): void {
     .argument('<from>', 'address to burn from')
     .argument('<amount>', 'amount to burn')
     .option('--idl <path>', 'path to local IDL file')
-    .option('--units <type>', 'amount units: raw (default) or token', undefined)
+    .option('--units <type>', 'amount units: raw (default) or human (uses token decimals)', undefined)
     .option('--voucher <id>', 'voucher ID to pay for the transaction')
     .action(async (tokenProgram: string, from: string, amount: string, options: VftTxOptions) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -294,17 +294,30 @@ export function registerVftCommand(program: Command): void {
       verbose(`Querying VFT balance for ${address} on ${tokenProgram}`);
 
       const query = sails.services[serviceName].queries['BalanceOf'];
-      const result = await query(address).call();
+      const raw = await query(address).call();
+
+      // Route through decodeSailsResult so opt u256 returns (e.g.
+      // VftExtension.BalanceOf for an account with no balance row) come
+      // through as null instead of crashing BigInt(null) downstream.
+      // findVftService picks WHICHEVER service declares BalanceOf — could
+      // be the standard Vft (returns u256) or VftExtension (returns
+      // opt u256), depending on IDL author. Both shapes must be safe.
+      const decoded = decodeSailsResult(sails, query.returnTypeDef, raw, serviceName);
 
       const decimals = await queryDecimals(sails, serviceName);
+
+      // Null means the account has no balance row — surface as '0' for
+      // consistency with on-chain semantics (a missing row IS zero
+      // balance from a transfer-spending perspective).
+      const balanceStr = decoded === null ? '0' : String(decoded);
 
       output({
         tokenProgram,
         account: address,
         balance: decimals !== null
-          ? minimalToVara(BigInt(result), decimals)
-          : String(result),
-        balanceRaw: String(result),
+          ? minimalToVara(BigInt(balanceStr), decimals)
+          : balanceStr,
+        balanceRaw: balanceStr,
         ...(decimals !== null && { decimals }),
       });
     });
@@ -332,18 +345,25 @@ export function registerVftCommand(program: Command): void {
       verbose(`Querying allowance for owner=${owner} spender=${spender} on ${tokenProgram}`);
 
       const query = sails.services[serviceName].queries['Allowance'];
-      const result = await query(owner, spender).call();
+      const raw = await query(owner, spender).call();
+
+      // Same null-safety pattern as `vft balance` above: route through
+      // decodeSailsResult so opt u256 returns (no allowance row) come
+      // through as null instead of crashing BigInt(null).
+      const decoded = decodeSailsResult(sails, query.returnTypeDef, raw, serviceName);
 
       const decimals = await queryDecimals(sails, serviceName);
+
+      const allowanceStr = decoded === null ? '0' : String(decoded);
 
       output({
         tokenProgram,
         owner,
         spender,
         allowance: decimals !== null
-          ? minimalToVara(BigInt(result), decimals)
-          : String(result),
-        allowanceRaw: String(result),
+          ? minimalToVara(BigInt(allowanceStr), decimals)
+          : allowanceStr,
+        allowanceRaw: allowanceStr,
         ...(decimals !== null && { decimals }),
       });
     });

--- a/src/commands/vft.ts
+++ b/src/commands/vft.ts
@@ -7,7 +7,7 @@ import { resolveAccount, resolveAddress, AccountOptions } from '../services/acco
 import { loadSails } from '../services/sails';
 import { resolveBlockNumber } from '../services/tx-executor';
 import { validateVoucher } from '../services/voucher-validator';
-import { output, verbose, CliError, minimalToVara, toMinimalUnits, addressToHex, decodeSailsResult } from '../utils';
+import { output, verbose, CliError, minimalToVara, toMinimalUnits, addressToHex, decodeSailsResult, validateUnits } from '../utils';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -79,33 +79,24 @@ async function queryDecimals(sails: Sails, serviceName: string): Promise<number 
 
 /**
  * Build the JSON output shape for `vft balance` / `vft allowance` from
- * the decoded query result. Pulled out as a pure helper so the U8
- * null-safety contract has a unit-test seam.
+ * the decoded query result. Pure helper exposed for the U8 null-safety
+ * regression test (see `src/__tests__/vft-balance-null-safety.test.ts`).
  *
  * Contract:
  *   - `decoded === null` (Option::None from `opt u256` returns) → '0'.
  *     Mirrors on-chain semantics where a missing balance / allowance
  *     row is indistinguishable from zero from the spend perspective.
- *   - `decimals === null` → emit raw + raw (no human form).
- *   - Otherwise → convert with `minimalToVara(BigInt(raw), decimals)`.
- *
- * `kind` controls the field naming so balance and allowance share the
- * same translation logic without duplicating two near-identical inline
- * blocks at the call sites.
+ *   - `decimals === null` → no human conversion (rawStr === humanStr).
+ *   - Otherwise → human form via `minimalToVara(BigInt(raw), decimals)`.
  */
 export function _formatVftAmountForTests(
   decoded: unknown,
   decimals: number | null,
-  kind: 'balance' | 'allowance',
 ): { rawStr: string; humanStr: string; decimals: number | null } {
   const rawStr = decoded === null ? '0' : String(decoded);
   const humanStr = decimals !== null
     ? minimalToVara(BigInt(rawStr), decimals)
     : rawStr;
-  // `kind` is part of the API so callers can't accidentally swap balance
-  // ↔ allowance — keeping it as a discriminator forces sites to be
-  // explicit about which they're emitting.
-  void kind;
   return { rawStr, humanStr, decimals };
 }
 
@@ -127,14 +118,9 @@ async function resolveVftAmount(
   amount: string,
   units?: string,
 ): Promise<bigint> {
-  if (units !== undefined && units !== 'raw' && units !== 'human') {
-    throw new CliError(
-      `Invalid --units value: "${units}". Must be "raw" or "human".`,
-      'INVALID_UNITS',
-    );
-  }
+  const u = validateUnits(units);
 
-  if (units === 'human') {
+  if (u === 'human') {
     const decimals = await queryDecimals(sails, serviceName);
     if (decimals === null) {
       throw new CliError(
@@ -326,17 +312,18 @@ export function registerVftCommand(program: Command): void {
       verbose(`Querying VFT balance for ${address} on ${tokenProgram}`);
 
       const query = sails.services[serviceName].queries['BalanceOf'];
-      const raw = await query(address).call();
-
-      // Route through decodeSailsResult so opt u256 returns (e.g.
-      // VftExtension.BalanceOf for an account with no balance row) come
-      // through as null instead of crashing BigInt(null) downstream.
-      // findVftService picks WHICHEVER service declares BalanceOf — could
-      // be the standard Vft (returns u256) or VftExtension (returns
-      // opt u256), depending on IDL author. Both shapes must be safe.
+      // Two independent on-chain reads — the balance + decimals queries
+      // don't depend on each other, so race them with Promise.all to
+      // halve the round-trip. Routes through decodeSailsResult so
+      // opt u256 returns (e.g. VftExtension.BalanceOf for an account
+      // with no balance row) come through as null instead of crashing
+      // BigInt(null) downstream.
+      const [raw, decimals] = await Promise.all([
+        query(address).call(),
+        queryDecimals(sails, serviceName),
+      ]);
       const decoded = decodeSailsResult(sails, query.returnTypeDef, raw, serviceName);
-      const decimals = await queryDecimals(sails, serviceName);
-      const { rawStr, humanStr } = _formatVftAmountForTests(decoded, decimals, 'balance');
+      const { rawStr, humanStr } = _formatVftAmountForTests(decoded, decimals);
 
       output({
         tokenProgram,
@@ -370,14 +357,13 @@ export function registerVftCommand(program: Command): void {
       verbose(`Querying allowance for owner=${owner} spender=${spender} on ${tokenProgram}`);
 
       const query = sails.services[serviceName].queries['Allowance'];
-      const raw = await query(owner, spender).call();
-
-      // Same null-safety pattern as `vft balance` above: route through
-      // decodeSailsResult so opt u256 returns (no allowance row) come
-      // through as null instead of crashing BigInt(null).
+      // Same parallel-reads + null-safety pattern as `vft balance` above.
+      const [raw, decimals] = await Promise.all([
+        query(owner, spender).call(),
+        queryDecimals(sails, serviceName),
+      ]);
       const decoded = decodeSailsResult(sails, query.returnTypeDef, raw, serviceName);
-      const decimals = await queryDecimals(sails, serviceName);
-      const { rawStr, humanStr } = _formatVftAmountForTests(decoded, decimals, 'allowance');
+      const { rawStr, humanStr } = _formatVftAmountForTests(decoded, decimals);
 
       output({
         tokenProgram,

--- a/src/commands/voucher.ts
+++ b/src/commands/voucher.ts
@@ -12,7 +12,7 @@ export function registerVoucherCommand(program: Command): void {
     .description('Issue a voucher for a spender')
     .argument('<spender>', 'spender address (hex or SS58)')
     .argument('<value>', 'voucher value (in VARA)')
-    .option('--units <units>', 'amount units: vara (default) or raw')
+    .option('--units <units>', 'amount units: human (default, = VARA) or raw')
     .option('--duration <blocks>', 'voucher duration in blocks')
     .option('--programs <ids>', 'comma-separated program IDs to restrict')
     .action(async (spender: string, value: string, options: {
@@ -23,8 +23,7 @@ export function registerVoucherCommand(program: Command): void {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       const api = await getApi(opts.ws);
       const account = await resolveAccount(opts);
-      const isRaw = options.units === 'raw';
-      const amount = resolveAmount(value, isRaw);
+      const amount = resolveAmount(value, options.units);
 
       const duration = options.duration ? parseInt(options.duration, 10) : undefined;
       const programs = options.programs

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -79,12 +79,19 @@ export function registerWatchCommand(program: Command): void {
           unsub = await api.gearEvents.subscribeToUserMessageSentByActor(
             { from: programIdHex },
             (event) => {
-              const decoded = formatUserMessageSentMaybeDecoded(event, sails, programIdHex);
-              const sailsBlock = (decoded as { sails?: { service: string; event: string } }).sails;
-              if (!sailsBlock || sailsBlock.service !== filter.service || sailsBlock.event !== filter.event) {
+              const formatted = formatUserMessageSentMaybeDecoded(event, sails, programIdHex);
+              const decodedBlock = (formatted as {
+                decoded?: { kind: string; service: string; event: string };
+              }).decoded;
+              if (
+                !decodedBlock ||
+                decodedBlock.kind !== 'sails' ||
+                decodedBlock.service !== filter.service ||
+                decodedBlock.event !== filter.event
+              ) {
                 return;
               }
-              outputNdjson({ event: 'UserMessageSent', ...decoded, timestamp: Date.now() });
+              outputNdjson({ event: 'UserMessageSent', ...formatted, timestamp: Date.now() });
             },
           );
         }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -7,6 +7,7 @@ import {
   installEpipeHandler,
   formatUserMessageSent,
   formatUserMessageSentMaybeDecoded,
+  matchesSailsFilter,
   resolveSubscribeFilter,
 } from './subscribe/shared';
 
@@ -80,17 +81,7 @@ export function registerWatchCommand(program: Command): void {
             { from: programIdHex },
             (event) => {
               const formatted = formatUserMessageSentMaybeDecoded(event, sails, programIdHex);
-              const decodedBlock = (formatted as {
-                decoded?: { kind: string; service: string; event: string };
-              }).decoded;
-              if (
-                !decodedBlock ||
-                decodedBlock.kind !== 'sails' ||
-                decodedBlock.service !== filter.service ||
-                decodedBlock.event !== filter.event
-              ) {
-                return;
-              }
+              if (!matchesSailsFilter(formatted, filter)) return;
               outputNdjson({ event: 'UserMessageSent', ...formatted, timestamp: Date.now() });
             },
           );

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -15,14 +15,12 @@ export function registerWatchCommand(program: Command): void {
     .command('watch')
     .description('Stream program events as NDJSON')
     .argument('<programId>', 'program ID to watch (hex or SS58)')
-    .option('--event <type>', 'event type to filter (UserMessageSent, MessageQueued, or Service/Event for Sails)')
+    .option('--event <type>', 'event filter: Gear pallet name (UserMessageSent), Sails Service/Event, bare Sails event, or pallet:Name to force pallet vocab')
     .option('--idl <path>', 'path to local IDL file (forces Sails-aware decode)')
-    .option('--pallet-event', 'force Gear pallet event resolution even when an IDL is loaded')
     .option('--no-decode', 'disable opportunistic IDL auto-load (raw output only)')
     .action(async (programId: string, options: {
       event?: string;
       idl?: string;
-      palletEvent?: boolean;
       decode?: boolean;
     }) => {
       const opts = program.optsWithGlobals() as { ws?: string };
@@ -54,7 +52,7 @@ export function registerWatchCommand(program: Command): void {
       let unsub: () => void;
 
       if (options.event) {
-        const filter = resolveSubscribeFilter(options.event, sails, options.palletEvent === true);
+        const filter = resolveSubscribeFilter(options.event, sails);
 
         if (filter.kind === 'pallet') {
           // Pallet event path — back-compat with the original behavior.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -81,10 +81,11 @@ export async function getApi(wsEndpoint?: string): Promise<GearApi> {
 // regardless of how esbuild bundles module scopes.
 const origStderrWrite = process.stderr.write.bind(process.stderr);
 const rpcCoreRe = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\s+RPC-CORE:/;
-process.stderr.write = ((chunk: Uint8Array | string, ...rest: unknown[]) => {
-  const s = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+process.stderr.write = ((...args: unknown[]) => {
+  const chunk = args[0];
+  const s = typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString();
   if (rpcCoreRe.test(s)) return true;
-  return origStderrWrite(chunk as any, ...rest);
+  return (origStderrWrite as (...a: unknown[]) => boolean)(...args);
 }) as typeof process.stderr.write;
 
 export function disconnectApi(): void {

--- a/src/services/idl-cache.ts
+++ b/src/services/idl-cache.ts
@@ -146,11 +146,22 @@ export function enumerateCacheEntries(): CacheEntrySummary[] {
     if (!name.endsWith('.cache.json')) continue;
     const codeId = name.slice(0, -'.cache.json'.length);
     const file = path.join(dir, name);
+    // Single corrupted-row template — both unparsable JSON (catch) and
+    // unexpected-shape JSON (if-branch) surface the same row to the
+    // caller, who can `idl remove` either kind by codeId.
+    const corruptedRow: CacheEntrySummary = {
+      codeId,
+      version: 'unknown',
+      source: 'unknown',
+      importedAt: null,
+      idlSizeBytes: 0,
+      error: 'corrupted',
+    };
     try {
       const raw = fs.readFileSync(file, 'utf-8');
       const parsed = JSON.parse(raw) as Partial<CacheFile>;
       if (!parsed || typeof parsed.idl !== 'string') {
-        out.push({ codeId, version: 'unknown', source: 'unknown', importedAt: null, idlSizeBytes: 0, error: 'corrupted' });
+        out.push(corruptedRow);
         continue;
       }
       out.push({
@@ -161,7 +172,7 @@ export function enumerateCacheEntries(): CacheEntrySummary[] {
         idlSizeBytes: Buffer.byteLength(parsed.idl, 'utf-8'),
       });
     } catch {
-      out.push({ codeId, version: 'unknown', source: 'unknown', importedAt: null, idlSizeBytes: 0, error: 'corrupted' });
+      out.push(corruptedRow);
     }
   }
   return out;

--- a/src/services/idl-cache.ts
+++ b/src/services/idl-cache.ts
@@ -104,3 +104,65 @@ export function evictCachedIdl(codeId: string): void {
     }
   }
 }
+
+/**
+ * Summary row for `idl list` and `idl clear` preview. One per cache entry.
+ *
+ * Forward-compat note: every meta field uses optional chaining at read time
+ * so a future writer adding new fields, or an older entry missing one,
+ * never crashes the listing.
+ */
+export interface CacheEntrySummary {
+  codeId: string;
+  version: IdlVersion | 'unknown';
+  source: 'chain' | 'import' | 'unknown';
+  importedAt: string | null;
+  idlSizeBytes: number;
+  /** Present only when the entry's JSON failed to parse / had unexpected shape. */
+  error?: 'corrupted';
+}
+
+/**
+ * Enumerate every entry in the IDL cache directory. Returns `[]` when the
+ * directory doesn't exist (fresh install). Per-entry parse errors surface
+ * as `{ codeId, error: 'corrupted', ... }` rows so the user can see and
+ * `idl remove` them — a single bad file does NOT crash the listing.
+ *
+ * Permission / IO errors on the directory itself propagate (mapped to a
+ * clean error code at the command layer).
+ */
+export function enumerateCacheEntries(): CacheEntrySummary[] {
+  const dir = getIdlCacheDir();
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return [];
+    throw err;
+  }
+  const out: CacheEntrySummary[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.cache.json')) continue;
+    const codeId = name.slice(0, -'.cache.json'.length);
+    const file = path.join(dir, name);
+    try {
+      const raw = fs.readFileSync(file, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<CacheFile>;
+      if (!parsed || typeof parsed.idl !== 'string') {
+        out.push({ codeId, version: 'unknown', source: 'unknown', importedAt: null, idlSizeBytes: 0, error: 'corrupted' });
+        continue;
+      }
+      out.push({
+        codeId,
+        version: parsed.meta?.version ?? 'unknown',
+        source: parsed.meta?.source ?? 'unknown',
+        importedAt: parsed.meta?.importedAt ?? null,
+        idlSizeBytes: Buffer.byteLength(parsed.idl, 'utf-8'),
+      });
+    } catch {
+      out.push({ codeId, version: 'unknown', source: 'unknown', importedAt: null, idlSizeBytes: 0, error: 'corrupted' });
+    }
+  }
+  return out;
+}

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -339,6 +339,13 @@ async function resolveIdl(
  *  Malformed WASM bytes surface as an `IDL_PARSE_ERROR` (chain-consistency
  *  bug worth flagging rather than silently falling back).
  */
+export async function _tryExtractFromChainForTests(
+  api: GearApi,
+  codeId: string,
+): Promise<string | null> {
+  return tryExtractFromChain(api, codeId);
+}
+
 async function tryExtractFromChain(api: GearApi, codeId: string): Promise<string | null> {
   verbose(`Fetching original WASM from chain for codeId ${codeId}...`);
   let option: Option<Bytes>;
@@ -352,7 +359,12 @@ async function tryExtractFromChain(api: GearApi, codeId: string): Promise<string
     verbose(`originalCodeStorage returned None for codeId ${codeId}`);
     return null;
   }
-  const bytes = option.unwrap().toU8a();
+  // .toU8a() on a Bytes codec includes the SCALE compact-length prefix.
+  // We want the raw inner WASM bytes (starting with the 0061736d magic),
+  // so pass isBare=true. Without this, the WASM-magic check downstream
+  // fails on every program, turning "no sails:idl section" into a
+  // misleading IDL_PARSE_ERROR.
+  const bytes = option.unwrap().toU8a(true);
   if (bytes.length > MAX_WASM_BYTES) {
     verbose(`WASM size ${bytes.length} exceeds MAX_WASM_BYTES; refusing to parse`);
     return null;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 export { output, outputNdjson, verbose, setOutputOptions } from './output';
 export { CliError, errorMessage, outputError, formatError, classifyProgramError, installGlobalErrorHandler } from './errors';
-export { varaToMinimal, minimalToVara, toMinimalUnits, resolveAmount } from './units';
+export { varaToMinimal, minimalToVara, toMinimalUnits, resolveAmount, validateUnits, type UnitsFlag } from './units';
 export { addressToHex } from './address';
 export { textToHex, tryHexToText, resolvePayload } from './payload';
 export { coerceArgs, coerceArgsV2, coerceArgsAuto, coerceHexToBytes, coerceHexToBytesV2 } from './hex-bytes';

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -72,12 +72,35 @@ export function toMinimalUnits(amount: string, decimals: number): bigint {
 }
 
 /**
- * Resolve amount based on --units flag.
- * Default: treat as VARA (multiply by 10^12).
- * With --units raw: passthrough as-is.
+ * Resolve a native VARA amount based on the --units flag.
+ *
+ * Vocabulary (unified in 0.15.0):
+ *   - `human` (default): multiply by 10^12 (VARA → minimal units).
+ *   - `raw`            : pass through as a bigint.
+ *
+ * Anything else throws INVALID_UNITS. The legacy `vara` literal (0.10.0
+ * vocabulary) is intentionally rejected — npm registry was on 0.10.0
+ * when this rename landed, and the audience for the new vocabulary is
+ * post-0.10.0 only.
+ *
+ * For VFT / DEX commands the same `human|raw` vocabulary applies but
+ * `human` means "use the token's declared decimals", not VARA's 12.
+ * Those resolvers live in their respective command files; this helper
+ * is native-VARA only.
+ *
+ * Imports `CliError` directly from `./errors` to keep the helper
+ * usable from any utils consumer without circular dependency risk.
  */
-export function resolveAmount(amount: string, unitsRaw?: boolean): bigint {
-  if (unitsRaw) {
+import { CliError } from './errors';
+
+export function resolveAmount(amount: string, units?: string): bigint {
+  if (units !== undefined && units !== 'human' && units !== 'raw') {
+    throw new CliError(
+      `Invalid --units value: "${units}". Must be "human" or "raw".`,
+      'INVALID_UNITS',
+    );
+  }
+  if (units === 'raw') {
     return BigInt(amount);
   }
   return varaToMinimal(amount);

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -93,15 +93,29 @@ export function toMinimalUnits(amount: string, decimals: number): bigint {
  * Imports `CliError` directly from `./errors` to keep the helper
  * usable from any utils consumer without circular dependency risk.
  */
-export function resolveAmount(amount: string, units?: string): bigint {
-  if (units !== undefined && units !== 'human' && units !== 'raw') {
+export type UnitsFlag = 'human' | 'raw';
+
+/**
+ * Validate the `--units` value against the unified vocabulary.
+ * Returns the typed flag (or `undefined` for omitted) and throws
+ * `INVALID_UNITS` for everything else — including the legacy literals
+ * `vara` / `token` from pre-0.15. Single source of truth used by
+ * native (`resolveAmount`), VFT (`resolveVftAmount`), and DEX
+ * (`resolveTokenAmount`) so future vocabulary changes are one edit.
+ */
+export function validateUnits(units: string | undefined): UnitsFlag | undefined {
+  if (units === undefined) return undefined;
+  if (units !== 'human' && units !== 'raw') {
     throw new CliError(
       `Invalid --units value: "${units}". Must be "human" or "raw".`,
       'INVALID_UNITS',
     );
   }
-  if (units === 'raw') {
-    return BigInt(amount);
-  }
+  return units;
+}
+
+export function resolveAmount(amount: string, units?: string): bigint {
+  const u = validateUnits(units);
+  if (u === 'raw') return BigInt(amount);
   return varaToMinimal(amount);
 }

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -1,3 +1,5 @@
+import { CliError } from './errors';
+
 const VARA_DECIMALS = 12;
 const MULTIPLIER = BigInt(10 ** VARA_DECIMALS);
 
@@ -91,8 +93,6 @@ export function toMinimalUnits(amount: string, decimals: number): bigint {
  * Imports `CliError` directly from `./errors` to keep the helper
  * usable from any utils consumer without circular dependency risk.
  */
-import { CliError } from './errors';
-
 export function resolveAmount(amount: string, units?: string): bigint {
   if (units !== undefined && units !== 'human' && units !== 'raw') {
     throw new CliError(


### PR DESCRIPTION
## Summary

First npm publish since `vara-wallet@0.10.0`. Bundles every shipped-in-git but never-published feature from 0.11.x → 0.14.x plus a UX-cleanup wave that the verification pass surfaced. Closes the gap between "what's in the codebase" and "what's on npm" in one cut.

## Why one big release instead of intermediate tags

npm registry has been on `0.10.0` for the duration. Tagging `v0.11.0` … `v0.14.1` retroactively would publish 5 npm versions for an audience nobody used in production. Instead: collapse everything into `v0.15.0`, take the breaking-rename surface now while it's free (no published-version users have ever seen `--type` / `sails:` / `--units vara` / `--units token` / `--pallet-event`), and ship one clean upgrade `0.10.0 → 0.15.0`.

## What's new since 0.10.0

### Bug fixes (this release)
- **B1** `option.unwrap().toU8a()` in `tryExtractFromChain` was returning bytes with a SCALE compact-length prefix, so the WASM-magic check downstream failed on every program with a confusing `IDL_PARSE_ERROR`. Fixed with `.toU8a(true)` + 5 regression tests.
- **B2** `call --dry-run` `encodedPayload` was actually the program ID (sails-js's `txBuilder.payload` returns `this._tx.args[0].toHex()`). Now uses `func.encodePayload(...args)` (real SCALE bytes) and surfaces destination separately.
- **U8** `vft balance` / `vft allowance` crashed with `BigInt(null)` against `VftExtension.BalanceOf` (declared `opt u256`) for accounts with no row. Routed through `decodeSailsResult`; null surfaces as `'0'`. Closes TODOS.md P2.
- **0.14.1's stderr-leak fix** (commits a85194c, e7cfc4c) carried forward — the `--json` mode RPC-CORE noise filter.

### Breaking renames (only against unreleased 0.11+ surface — npm users see them as new features)
- **U1** `subscribe messages --type` → `--event`. Same accepted values, unified with `watch`.
- **U2** `--pallet-event` flag removed; replaced with `--event pallet:<Name>` prefix.
- **U3** NDJSON `sails: { ... }` → `decoded: { kind: 'sails', ... }`. The `kind` discriminator future-proofs for additional decoder types.
- **U7** `--units vara|raw` (native) and `--units raw|token` (VFT/DEX) unified to `--units human|raw` everywhere. Per-command defaults preserved.

### Additions
- **U4** `vara-wallet idl list / remove / clear`. Terraform-style: bare `idl clear` previews; `--yes` commits.
- **U5** `call --dry-run --estimate` now compose. Output merges `encodedPayload`, `destination`, `estimateGas`.
- **U6** Smoke test (`scripts/smoke.mjs`) extended with 7 bundled-CLI checks for the new idl subcommands.

## Verification

- `npm run build` — clean
- `npm test` — **551 / 551 pass** (47 suites; was 525 in 0.14.0, added 26 new tests)
- `node scripts/smoke.mjs` — all 9 checks pass against bundled `dist/app.js`
- Manual verification ran earlier against polybaskets contracts (12/18 claims passed cleanly; 4 failures all turned into the fixes B1, B2, U1+U2 above)

## Migration (git users only — npm jumps 0.10.0 → 0.15.0 in one go, no migration needed)

See `### Migration from 0.14.x` block in CHANGELOG.md.

## Companion PR

`gear-foundation/vara-skills` PR opened separately to update the `vara-wallet` skill for the new surface. The two PRs land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)