### PR TITLE
fix: classify transport-layer failures with TRANSPORT_ERROR + reason subcodes (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`TRANSPORT_ERROR` code with `reason` subcodes** (issue #58). Transport-layer failures (DNS lookup, WS handshake, RPC disconnect, TLS, timeout) now surface as `code: "TRANSPORT_ERROR"` with a structured `reason` field instead of the historical opaque `{"error":"{}","code":"UNKNOWN_ERROR"}`. Reason taxonomy: `dns_failure`, `connection_refused`, `timeout`, `ws_close_abnormal`, `protocol_mismatch`, `unreachable`, `tls_failure`, `unknown`. Each error carries `meta.endpoint` and, for DNS, `meta.host`; `meta.cause` preserves the raw underlying message for triage. Agents can switch on `.reason` to distinguish transient (retry) from permanent (don't retry) failures.
+- **`--verbose` cause echo.** When `--verbose` is set, `outputError` writes a `[verbose] cause: code=<x>, message=<y>` line to stderr immediately before the structured JSON. Wrapped to swallow EPIPE so a closed-stderr consumer doesn't crash the CLI tail.
+- **Light-client transport classification.** `--light` failures (chainspec fetch DNS error, ECONNREFUSED, non-JSON response, smoldot init failure) route through the same `TRANSPORT_ERROR` taxonomy instead of bubbling up as raw `SyntaxError` / `INTERNAL_ERROR`. `VARA_CHAIN_SPEC_RPC` env var supported for testing.
+
+### Changed
+
+- **`CONNECTION_TIMEOUT` (WS connect timeout) migrated to `TRANSPORT_ERROR { reason: 'timeout' }`.** The internal sentinel thrown by `withTimeout()` in `api.ts` is now remapped before reaching the user. Faucet HTTP `CONNECTION_FAILED` is unchanged (different consumer surface).
+- **`api.ts` constructs `WsProvider` explicitly** instead of relying on `GearApi.create({ providerAddress })`. An `on('error')` listener captures the underlying Node socket error code (ENOTFOUND, ECONNREFUSED, ETIMEDOUT) before `@polkadot/api`'s browser-style Event rejection laundering strips it. Detached after handshake.
+
+### Fixed
+
+- **`{"error":"{}","code":"UNKNOWN_ERROR"}` opacity on transport failures** (issue #58). The original repro — `vara-wallet --ws wss://nonexistent-host` returning an empty `{}` payload — now produces `{"error":"Cannot resolve host nonexistent-host","code":"TRANSPORT_ERROR","reason":"dns_failure","endpoint":"wss://nonexistent-host","host":"nonexistent-host"}`.
+
 ## [0.16.0] - 2026-04-26
 
 Two themes since 0.15.0: **networking performance** (PR #56 — every CLI invocation drops from ~2.8s to ~0.55s on warm runs, 5.2x) and **agent-UX hardening** (PR #54 — gas-error classification, arity-aware args validation, sharper IDL diagnostics). The networking work has two roots: `@polkadot/api` keeps WS heartbeat timers alive ~1.7s after disconnect (we now exit immediately, draining stdout/stderr first), and `state_getMetadata` was being refetched on every connect (now cached on disk, keyed by `genesisHash-specVersion`, with auto-invalidation handled by polkadot/api on runtime upgrade). The agent-UX work was surfaced by a field report from a betting agent and an adversarial cross-model review (Codex).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - **`CONNECTION_TIMEOUT` (WS connect timeout) migrated to `TRANSPORT_ERROR { reason: 'timeout' }`.** The internal sentinel thrown by `withTimeout()` in `api.ts` is now remapped before reaching the user. Faucet HTTP `CONNECTION_FAILED` is unchanged (different consumer surface).
+- **Program-path `TIMEOUT` / `CONNECTION_FAILED` migrated to `TRANSPORT_ERROR` with `reason` subcode.** `classifyProgramError` (used by `call`, `program upload/create`, `dex`, `vft`, `message`) now routes RPC-roundtrip timeouts to `TRANSPORT_ERROR { reason: 'timeout' }` and `ECONNREFUSED`-style failures to `TRANSPORT_ERROR { reason: 'connection_refused' }` instead of the legacy bare `TIMEOUT` / `CONNECTION_FAILED` codes. Agent scripts that grep for `"code":"TIMEOUT"` from these surfaces must switch to `"code":"TRANSPORT_ERROR"` + `"reason":"timeout"`. Non-transport classifications (`NOT_FOUND` from `ENOENT`, etc.) are unchanged.
 - **`api.ts` constructs `WsProvider` explicitly** instead of relying on `GearApi.create({ providerAddress })`. An `on('error')` listener captures the underlying Node socket error code (ENOTFOUND, ECONNREFUSED, ETIMEDOUT) before `@polkadot/api`'s browser-style Event rejection laundering strips it. Detached after handshake.
 
 ### Fixed

--- a/src/__tests__/api-timeout.test.ts
+++ b/src/__tests__/api-timeout.test.ts
@@ -1,4 +1,4 @@
-import { CliError } from '../utils/errors';
+import { CliError, classifyTransportError, formatError } from '../utils/errors';
 
 // Test the withTimeout pattern used in api.ts
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
@@ -65,5 +65,28 @@ describe('withTimeout', () => {
     await withTimeout(failing, 10000, 'msg').catch(() => {});
     expect(clearSpy).toHaveBeenCalled();
     clearSpy.mockRestore();
+  });
+
+  describe('CONNECTION_TIMEOUT → TRANSPORT_ERROR migration (issue #58)', () => {
+    it('classifyTransportError remaps CONNECTION_TIMEOUT to TRANSPORT_ERROR / timeout', () => {
+      const sentinel = new CliError('Connection timed out', 'CONNECTION_TIMEOUT');
+      const remapped = classifyTransportError(sentinel, { endpoint: 'wss://rpc.vara.network' });
+      expect(remapped).not.toBeNull();
+      expect(remapped!.code).toBe('TRANSPORT_ERROR');
+      expect(remapped!.meta?.reason).toBe('timeout');
+      expect(remapped!.meta?.endpoint).toBe('wss://rpc.vara.network');
+    });
+
+    it('end-to-end: api.ts wraps the CONNECTION_TIMEOUT sentinel before it reaches the user', () => {
+      // Simulates the api.ts attemptConnect catch path: when withTimeout fires
+      // its CONNECTION_TIMEOUT, api.ts runs classifyTransportError(...) over it
+      // and throws the migrated CliError. The user-facing output is then
+      // TRANSPORT_ERROR { reason: 'timeout' }, never the internal sentinel.
+      const sentinel = new CliError('Timed out', 'CONNECTION_TIMEOUT');
+      const userFacing = classifyTransportError(sentinel, { endpoint: 'wss://example' }) ?? sentinel;
+      const json = formatError(userFacing);
+      expect(json.code).toBe('TRANSPORT_ERROR');
+      expect(json.reason).toBe('timeout');
+    });
   });
 });

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,4 +1,4 @@
-import { CliError, formatError, classifyProgramError } from '../utils/errors';
+import { CliError, formatError, classifyProgramError, classifyTransportError } from '../utils/errors';
 
 describe('CliError', () => {
   it('stores message and code', () => {
@@ -15,15 +15,21 @@ describe('formatError', () => {
     expect(formatError(err)).toEqual({ error: 'bad input', code: 'INVALID_INPUT' });
   });
 
-  it('classifies connection errors', () => {
+  it('classifies plain connection errors as legacy CONNECTION_FAILED', () => {
+    // No transport reason matches "WebSocket connection failed" alone (no ENOTFOUND/
+    // ECONNREFUSED/close-code), so this falls through to the legacy classifier.
     const err = new Error('WebSocket connection failed');
     const result = formatError(err);
     expect(result.code).toBe('CONNECTION_FAILED');
   });
 
-  it('classifies timeout errors', () => {
+  it('classifies timeout errors as TRANSPORT_ERROR / timeout', () => {
+    // 'timeout' in the message is a transport signal — classifyTransportError
+    // now runs first in formatError and upgrades these to the new taxonomy.
     const err = new Error('Request timeout');
-    expect(formatError(err).code).toBe('TIMEOUT');
+    const result = formatError(err);
+    expect(result.code).toBe('TRANSPORT_ERROR');
+    expect(result.reason).toBe('timeout');
   });
 
   it('classifies not-found errors', () => {
@@ -140,9 +146,15 @@ describe('classifyProgramError', () => {
   });
 
   it('does NOT touch transport/timeout/connection classification', () => {
-    // These continue to flow through formatError + classifyError, not classifyProgramError.
-    expect(formatError(new Error('Request timeout')).code).toBe('TIMEOUT');
-    expect(formatError(new Error('WebSocket connect failed')).code).toBe('CONNECTION_FAILED');
+    // Timeout / connection_refused now route through the new TRANSPORT_ERROR
+    // taxonomy with reason subcodes (issue #58). ENOENT has no transport
+    // signal so still falls through to the legacy NOT_FOUND classifier.
+    const t = formatError(new Error('Request timeout'));
+    expect(t.code).toBe('TRANSPORT_ERROR');
+    expect(t.reason).toBe('timeout');
+    const wsPlain = formatError(new Error('WebSocket connect failed'));
+    // No ECONNREFUSED in the message — legacy fallback wins.
+    expect(wsPlain.code).toBe('CONNECTION_FAILED');
     expect(formatError(new Error('ENOENT: no such file')).code).toBe('NOT_FOUND');
   });
 
@@ -173,30 +185,191 @@ describe('classifyProgramError', () => {
     expect(result.meta).toBeUndefined();
   });
 
-  it('preserves transport TIMEOUT classification when program path bubbles a timeout', () => {
+  it('routes program-path timeouts to TRANSPORT_ERROR / timeout', () => {
     // Simulates queryBuilder.call() rejecting because the RPC roundtrip timed out.
-    // The fix must NOT mask this as PROGRAM_ERROR — agents distinguish "retry the
-    // network" from "do not retry, the program logic failed".
+    // After issue #58, transport classifier runs first in classifyProgramError
+    // so the contract is now TRANSPORT_ERROR { reason: 'timeout' }, NOT a bare
+    // 'TIMEOUT' code. Agent contract: retry the network, do not retry the program.
     const err = new Error('Request timeout after 60s');
     const result = classifyProgramError(err);
-    expect(result.code).toBe('TIMEOUT');
-    expect(result.meta).toBeUndefined();
+    expect(result.code).toBe('TRANSPORT_ERROR');
+    expect(result.meta?.reason).toBe('timeout');
   });
 
-  it('preserves transport CONNECTION_FAILED classification through the program path', () => {
+  it('routes program-path connection_refused to TRANSPORT_ERROR / connection_refused', () => {
     const err = new Error('WebSocket connect failed: ECONNREFUSED');
     const result = classifyProgramError(err);
-    expect(result.code).toBe('CONNECTION_FAILED');
+    expect(result.code).toBe('TRANSPORT_ERROR');
+    expect(result.meta?.reason).toBe('connection_refused');
   });
 
-  it('preserves NOT_FOUND transport classification (e.g. ENOENT) through the program path', () => {
-    // Important: program-level "not_found" requires the word "Program" so this
-    // ENOENT-style error must fall through to the transport classifier and come
-    // back as NOT_FOUND, not as PROGRAM_ERROR { reason: 'not_found' }.
+  it('preserves NOT_FOUND (non-transport) classification through the program path', () => {
+    // ENOENT has no transport reason, so program-path classification falls
+    // through to the legacy classifyError → NOT_FOUND. Critically NOT mapped
+    // to PROGRAM_ERROR { reason: 'not_found' } (which requires the word "Program").
     const err = new Error('ENOENT: no such file');
     const result = classifyProgramError(err);
     expect(result.code).toBe('NOT_FOUND');
     expect(result.meta).toBeUndefined();
+  });
+});
+
+describe('classifyTransportError', () => {
+  it('classifies ENOTFOUND with .code as dns_failure and extracts host from endpoint', () => {
+    const err = Object.assign(new Error('getaddrinfo ENOTFOUND nonexistent.example.invalid'), {
+      code: 'ENOTFOUND',
+    });
+    const cli = classifyTransportError(err, { endpoint: 'wss://nonexistent.example.invalid' });
+    expect(cli).not.toBeNull();
+    expect(cli!.code).toBe('TRANSPORT_ERROR');
+    expect(cli!.meta?.reason).toBe('dns_failure');
+    expect(cli!.meta?.host).toBe('nonexistent.example.invalid');
+    expect(cli!.meta?.endpoint).toBe('wss://nonexistent.example.invalid');
+    expect(cli!.message).toContain('nonexistent.example.invalid');
+  });
+
+  it('falls back to extracting host from the error message when endpoint is missing', () => {
+    const err = new Error('getaddrinfo ENOTFOUND bad-host.example');
+    const cli = classifyTransportError(err);
+    expect(cli!.meta?.reason).toBe('dns_failure');
+    expect(cli!.meta?.host).toBe('bad-host.example');
+  });
+
+  it('classifies ECONNREFUSED as connection_refused', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9944'), {
+      code: 'ECONNREFUSED',
+    });
+    const cli = classifyTransportError(err, { endpoint: 'ws://127.0.0.1:9944' });
+    expect(cli!.meta?.reason).toBe('connection_refused');
+  });
+
+  it('classifies ETIMEDOUT as timeout', () => {
+    const err = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    const cli = classifyTransportError(err);
+    expect(cli!.meta?.reason).toBe('timeout');
+  });
+
+  it('migrates the legacy CONNECTION_TIMEOUT sentinel to TRANSPORT_ERROR / timeout', () => {
+    // withTimeout() in api.ts still throws a CliError(CONNECTION_TIMEOUT) as
+    // its internal sentinel; the unified classifier remaps it for output.
+    const legacy = new CliError('Connection timed out', 'CONNECTION_TIMEOUT');
+    const cli = classifyTransportError(legacy, { endpoint: 'wss://rpc.vara.network' });
+    expect(cli!.code).toBe('TRANSPORT_ERROR');
+    expect(cli!.meta?.reason).toBe('timeout');
+    expect(cli!.meta?.endpoint).toBe('wss://rpc.vara.network');
+  });
+
+  it('classifies WS close code 1006 in the message as ws_close_abnormal', () => {
+    const err = new Error('disconnected from wss://rpc with code 1006');
+    const cli = classifyTransportError(err);
+    expect(cli!.meta?.reason).toBe('ws_close_abnormal');
+  });
+
+  it('classifies "Unexpected server response: 200" as protocol_mismatch', () => {
+    const err = new Error('Unexpected server response: 200');
+    const cli = classifyTransportError(err);
+    expect(cli!.meta?.reason).toBe('protocol_mismatch');
+  });
+
+  it('classifies EHOSTUNREACH as unreachable', () => {
+    const err = Object.assign(new Error('connect EHOSTUNREACH'), { code: 'EHOSTUNREACH' });
+    const cli = classifyTransportError(err);
+    expect(cli!.meta?.reason).toBe('unreachable');
+  });
+
+  it('classifies TLS handshake failures as tls_failure', () => {
+    const err = Object.assign(new Error('UNABLE_TO_VERIFY_LEAF_SIGNATURE'), {
+      code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    });
+    const cli = classifyTransportError(err);
+    expect(cli!.meta?.reason).toBe('tls_failure');
+  });
+
+  it('walks the extraction chain: err.error?.code wins when err.code is absent (ws library shape)', () => {
+    // The `ws` library wraps Node socket errors as { error: NetError, message, ... }.
+    // Extraction order (per plan): err.code → err.error?.code → message regex → ctx.cause.
+    const wsWrap = {
+      message: 'failed',
+      error: { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND ws-host' },
+    };
+    const cli = classifyTransportError(wsWrap, { endpoint: 'wss://ws-host' });
+    expect(cli!.meta?.reason).toBe('dns_failure');
+  });
+
+  it('uses ctx.cause from the listener when reject payload is empty', () => {
+    // Last layer of the chain: WsProvider rejected with {} but the on('error')
+    // listener captured ENOTFOUND first.
+    const cli = classifyTransportError(
+      {},
+      { endpoint: 'wss://bad', cause: { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND bad' } },
+    );
+    expect(cli!.meta?.reason).toBe('dns_failure');
+  });
+
+  it('returns null for non-transport Error instances (e.g. PROGRAM_ERROR-style panics)', () => {
+    expect(classifyTransportError(new Error('something else broke'))).toBeNull();
+    expect(classifyTransportError(new Error('ENOENT: no such file'))).toBeNull();
+  });
+
+  it('returns null for already-classified CliErrors that are not CONNECTION_TIMEOUT', () => {
+    expect(classifyTransportError(new CliError('boom', 'PROGRAM_ERROR'))).toBeNull();
+    expect(classifyTransportError(new CliError('boom', 'INVALID_ADDRESS'))).toBeNull();
+  });
+
+  it('classifies empty {} payload as TRANSPORT_ERROR / unknown when context exists', () => {
+    // The original issue #58 repro 1 shape: WsProvider rejects with {}.
+    // We have no listener-captured cause this time, but we DO know we tried
+    // to talk to an endpoint, so the value-shape gives us "unknown" instead
+    // of the historical UNKNOWN_ERROR opacity.
+    const cli = classifyTransportError({}, { endpoint: 'wss://bad' });
+    expect(cli).not.toBeNull();
+    expect(cli!.code).toBe('TRANSPORT_ERROR');
+    expect(cli!.meta?.reason).toBe('unknown');
+    expect(cli!.meta?.endpoint).toBe('wss://bad');
+  });
+});
+
+describe('formatError transport fallback (issue #58 regression)', () => {
+  it('upgrades the original empty-{} repro shape to TRANSPORT_ERROR / unknown when ctx is supplied', () => {
+    // EXACT shape from issue #58 repro 1: WsProvider rejected with {} when DNS
+    // failed. Pre-fix: { error: '{}', code: 'UNKNOWN_ERROR' }.
+    // Post-fix: api.ts's catch site supplies ctx.endpoint (and ctx.cause from
+    // the on('error') listener) so the empty payload routes through
+    // TRANSPORT_ERROR / unknown instead of the opaque UNKNOWN_ERROR.
+    const cli = classifyTransportError({}, { endpoint: 'wss://nonexistent.example' });
+    expect(cli).not.toBeNull();
+    const formatted = formatError(cli);
+    expect(formatted.code).toBe('TRANSPORT_ERROR');
+    expect(formatted.reason).toBe('unknown');
+    expect(formatted.endpoint).toBe('wss://nonexistent.example');
+  });
+
+  it('keeps a context-less empty-{} payload as UNKNOWN_ERROR (no false-positive transport claim)', () => {
+    // Without an endpoint or captured cause, we can't honestly call {} a
+    // transport failure — it might be a stray throw from any layer.
+    expect(formatError({}).code).toBe('UNKNOWN_ERROR');
+  });
+
+  it('upgrades a raw ENOTFOUND Error to TRANSPORT_ERROR / dns_failure', () => {
+    const err = Object.assign(new Error('getaddrinfo ENOTFOUND host.example'), {
+      code: 'ENOTFOUND',
+    });
+    const formatted = formatError(err);
+    expect(formatted.code).toBe('TRANSPORT_ERROR');
+    expect(formatted.reason).toBe('dns_failure');
+    expect(formatted.host).toBe('host.example');
+  });
+
+  it('preserves the legacy CONNECTION_TIMEOUT CliError as TRANSPORT_ERROR / timeout', () => {
+    const legacy = new CliError(
+      'Connection to wss://rpc.vara.network timed out after 10s. Check your network or VARA_WS setting.',
+      'CONNECTION_TIMEOUT',
+    );
+    const formatted = formatError(legacy);
+    // Legacy code passes through to JSON output because formatError doesn't
+    // remap CliErrors it sees (only outputError pre-routes raw errors).
+    // The remap happens at the api.ts catch site via classifyTransportError.
+    expect(formatted.code).toBe('CONNECTION_TIMEOUT');
   });
 });
 

--- a/src/__tests__/light-client-transport.test.ts
+++ b/src/__tests__/light-client-transport.test.ts
@@ -1,0 +1,90 @@
+describe('SmoldotProvider transport classification (issue #58 scope expansion)', () => {
+  let origFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    origFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('classifies ENOTFOUND on chainspec fetch as TRANSPORT_ERROR / dns_failure', async () => {
+    await jest.isolateModulesAsync(async () => {
+      globalThis.fetch = jest.fn(async () => {
+        throw Object.assign(new Error('getaddrinfo ENOTFOUND rpc.vara.network'), {
+          code: 'ENOTFOUND',
+        });
+      }) as any;
+      // Import inside the isolated block — each isolateModulesAsync creates a
+      // fresh module graph, so the CliError instanceof check has to come from
+      // the same instance the SmoldotProvider sees.
+      const { CliError } = await import('../utils/errors');
+      const { SmoldotProvider } = await import('../services/light-client');
+      const provider = new SmoldotProvider();
+      let captured: unknown;
+      try {
+        await provider.connect();
+      } catch (e) {
+        captured = e;
+      }
+      expect(captured).toBeInstanceOf(CliError);
+      const cli = captured as InstanceType<typeof CliError>;
+      expect(cli.code).toBe('TRANSPORT_ERROR');
+      expect(cli.meta?.reason).toBe('dns_failure');
+      expect(cli.meta?.host).toBe('rpc.vara.network');
+      expect(cli.meta?.endpoint).toBe('https://rpc.vara.network');
+    });
+  });
+
+  it('classifies a 200-but-non-JSON response as TRANSPORT_ERROR / protocol_mismatch', async () => {
+    await jest.isolateModulesAsync(async () => {
+      globalThis.fetch = jest.fn(async () => {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new SyntaxError('Unexpected token < in JSON at position 0');
+          },
+        } as unknown as Response;
+      }) as any;
+      const { CliError } = await import('../utils/errors');
+      const { SmoldotProvider } = await import('../services/light-client');
+      const provider = new SmoldotProvider();
+      let captured: unknown;
+      try {
+        await provider.connect();
+      } catch (e) {
+        captured = e;
+      }
+      expect(captured).toBeInstanceOf(CliError);
+      const cli = captured as InstanceType<typeof CliError>;
+      expect(cli.code).toBe('TRANSPORT_ERROR');
+      expect(cli.meta?.reason).toBe('protocol_mismatch');
+      expect(cli.meta?.endpoint).toBe('https://rpc.vara.network');
+    });
+  });
+
+  it('classifies ECONNREFUSED on chainspec fetch as TRANSPORT_ERROR / connection_refused', async () => {
+    await jest.isolateModulesAsync(async () => {
+      globalThis.fetch = jest.fn(async () => {
+        throw Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
+          code: 'ECONNREFUSED',
+        });
+      }) as any;
+      const { CliError } = await import('../utils/errors');
+      const { SmoldotProvider } = await import('../services/light-client');
+      const provider = new SmoldotProvider();
+      let captured: unknown;
+      try {
+        await provider.connect();
+      } catch (e) {
+        captured = e;
+      }
+      expect(captured).toBeInstanceOf(CliError);
+      const cli = captured as InstanceType<typeof CliError>;
+      expect(cli.code).toBe('TRANSPORT_ERROR');
+      expect(cli.meta?.reason).toBe('connection_refused');
+    });
+  });
+});

--- a/src/__tests__/verbose-cause.test.ts
+++ b/src/__tests__/verbose-cause.test.ts
@@ -1,0 +1,84 @@
+import { setOutputOptions } from '../utils/output';
+import { CliError, outputError } from '../utils/errors';
+
+describe('outputError --verbose cause echo (issue #58)', () => {
+  let stderrWrites: string[] = [];
+  let origStderrWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    stderrWrites = [];
+    origStderrWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr.write as any) = (chunk: any) => {
+      stderrWrites.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    (process.stderr.write as any) = origStderrWrite;
+    setOutputOptions({});
+  });
+
+  it('writes a [verbose] cause line before the structured JSON when --verbose is set', () => {
+    setOutputOptions({ verbose: true });
+    const err = new CliError('Cannot resolve host bad.example', 'TRANSPORT_ERROR', {
+      reason: 'dns_failure',
+      endpoint: 'wss://bad.example',
+      host: 'bad.example',
+      cause: 'getaddrinfo ENOTFOUND bad.example',
+    });
+    outputError(err);
+
+    expect(stderrWrites.length).toBeGreaterThanOrEqual(2);
+    const verboseLine = stderrWrites[0];
+    const jsonLine = stderrWrites[stderrWrites.length - 1];
+
+    expect(verboseLine).toMatch(/^\[verbose\] cause:/);
+    expect(verboseLine).toContain('dns_failure');
+    // Verbose line precedes the JSON payload.
+    expect(jsonLine).toContain('"code":"TRANSPORT_ERROR"');
+    expect(jsonLine).toContain('"reason":"dns_failure"');
+  });
+
+  it('does NOT write the [verbose] line when --verbose is unset', () => {
+    setOutputOptions({});
+    const err = new CliError('boom', 'TRANSPORT_ERROR', { reason: 'unknown' });
+    outputError(err);
+    const hasVerbose = stderrWrites.some(w => w.startsWith('[verbose]'));
+    expect(hasVerbose).toBe(false);
+    // The JSON still goes out.
+    expect(stderrWrites.some(w => w.includes('"code":"TRANSPORT_ERROR"'))).toBe(true);
+  });
+
+  it('swallows EPIPE / closed-stderr errors from the verbose write without crashing', () => {
+    setOutputOptions({ verbose: true });
+    let calls = 0;
+    (process.stderr.write as any) = () => {
+      calls++;
+      // First write (the verbose line) throws EPIPE. Subsequent calls succeed
+      // so the structured JSON can still surface to a non-closed sink.
+      if (calls === 1) {
+        const e: any = new Error('write EPIPE');
+        e.code = 'EPIPE';
+        throw e;
+      }
+      return true;
+    };
+    expect(() => {
+      outputError(new CliError('boom', 'TRANSPORT_ERROR', { reason: 'unknown' }));
+    }).not.toThrow();
+    // The verbose write was attempted, swallowed; we don't assert the JSON
+    // succeeded — only that no crash escapes outputError.
+    expect(calls).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits UNKNOWN_ERROR for a raw context-less {} payload — outputError will not invent a transport claim', () => {
+    // A bare {} reaching outputError without endpoint/cause hints stays
+    // UNKNOWN_ERROR; the transport classification happens at the api.ts catch
+    // site where ctx.endpoint is known (covered by light-client + errors tests).
+    setOutputOptions({});
+    outputError({});
+    const jsonLine = stderrWrites[stderrWrites.length - 1];
+    expect(jsonLine).toContain('"code":"UNKNOWN_ERROR"');
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -124,10 +124,9 @@ export async function getApi(wsEndpoint?: string): Promise<GearApi> {
       markStage('connect_begin', { endpoint, cachedMetadataKeys: cachedKeyCount });
       const connectPromise = (async (): Promise<GearApi> => {
         // Construct WsProvider explicitly (instead of GearApi.create({ providerAddress }))
-        // so we can attach an error listener and capture the underlying Node socket
-        // error code (ENOTFOUND / ECONNREFUSED / ETIMEDOUT) before WsProvider's
-        // browser-style Event rejection laundering strips it. This is what closes
-        // the `{"error":"{}","code":"UNKNOWN_ERROR"}` opacity from issue #58.
+        // so we can attach an error listener and capture the underlying Node
+        // socket error code (ENOTFOUND / ECONNREFUSED / ETIMEDOUT) before
+        // WsProvider's browser-style Event rejection laundering strips it.
         const provider = new WsProvider(endpoint, /* autoConnect */ false);
         let lastSocketError: { code?: string; message?: string } | undefined;
         const unsubError = provider.on('error', (e: unknown) => {
@@ -139,12 +138,15 @@ export async function getApi(wsEndpoint?: string): Promise<GearApi> {
         });
 
         const attemptConnect = async (metadata: Record<string, `0x${string}`>): Promise<GearApi> => {
+          // Clear any cause captured by a prior attempt — the metadata-cache
+          // retry calls attemptConnect twice and stale state would otherwise
+          // leak into the second attempt's classification.
+          lastSocketError = undefined;
           try {
-            // GearApi.create both opens the provider (if not connected) AND
-            // fetches genesis/metadata. WsProvider.connect() can resolve
-            // before the WS handshake actually completes, so transport
-            // failures surface inside GearApi.create rather than in our
-            // explicit provider.connect() — both have to be inside the catch.
+            // WsProvider.connect() can resolve before the WS handshake
+            // actually completes; transport failures surface inside
+            // GearApi.create rather than in our explicit provider.connect().
+            // Both have to be inside the catch.
             await withTimeout(
               provider.connect(),
               CONNECTION_TIMEOUT_MS,
@@ -156,16 +158,15 @@ export async function getApi(wsEndpoint?: string): Promise<GearApi> {
               `Connection to ${endpoint} timed out after 10s. Check your network or VARA_WS setting.`,
             );
           } catch (rawErr) {
-            // Metadata-cache mismatch errors must propagate raw — the caller
-            // detects them via isMetadataError() and retries with an empty
-            // cache. Don't translate them to TRANSPORT_ERROR here.
+            // Metadata-cache mismatch errors must propagate raw so the caller
+            // can detect them via isMetadataError() and retry with an empty
+            // cache.
             if (isMetadataError(rawErr)) throw rawErr;
-            // Post-mortem DNS probe: Node's built-in WebSocket sanitizes the
-            // underlying error to "Received network error or non-101 status
-            // code" so we can't read .code directly. On failure path only,
-            // do a quick dns.lookup on the endpoint host — if it fails, the
-            // root cause was DNS. Only runs once per failed connect, never
-            // on the success path.
+            // Post-mortem DNS probe: Node's built-in WebSocket sanitizes
+            // the underlying error to "Received network error or non-101
+            // status code", so we can't read .code directly. A quick
+            // dns.lookup on the endpoint host disambiguates DNS failure
+            // from protocol mismatch. Failure path only.
             const probed = await probeTransportCause(endpoint, lastSocketError);
             const cli = classifyTransportError(rawErr, {
               endpoint,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,7 @@
 import { GearApi } from '@gear-js/api';
-import { verbose, CliError, errorMessage, markStage } from '../utils';
+import { WsProvider } from '@polkadot/api';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { verbose, CliError, errorMessage, markStage, classifyTransportError } from '../utils';
 import { readConfig } from './config';
 import { SmoldotProvider } from './light-client';
 import { buildCacheKey, clearMetadataCache, loadMetadataCache, saveMetadataIfNew } from './metadata-cache';
@@ -35,6 +37,43 @@ function isMetadataError(err: unknown): boolean {
     msg.includes('unable to decode metadata') ||
     msg.includes('metadata version')
   );
+}
+
+/**
+ * Post-mortem cause probe. Node's built-in WebSocket (used by recent
+ * @polkadot/api) sanitizes the underlying error to "Received network error
+ * or non-101 status code", so neither the rejection nor the on('error')
+ * listener exposes the real socket error code. After a WS connect fails,
+ * we do a quick DNS lookup on the endpoint host — if that resolves, the
+ * root cause was almost certainly handshake / protocol; if it doesn't, the
+ * root cause was DNS. Only runs on the failure path; the success path is
+ * untouched. Best-effort: a probe that itself errors out is ignored.
+ */
+async function probeTransportCause(
+  endpoint: string,
+  existing: { code?: string; message?: string } | undefined,
+): Promise<{ code?: string; message?: string } | undefined> {
+  // If we already have a real socket error code from the listener, don't probe.
+  if (existing?.code && existing.code !== 'unknown') return existing;
+  let host: string | undefined;
+  try {
+    host = new URL(endpoint).hostname;
+  } catch {
+    return existing;
+  }
+  if (!host) return existing;
+  try {
+    await dnsLookup(host);
+    // Host resolves — connect failed for some other reason (TLS, protocol,
+    // refused). Leave the existing/raw cause in place.
+    return existing;
+  } catch (e) {
+    const code = (e as { code?: string })?.code;
+    if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+      return { code, message: `getaddrinfo ${code} ${host}` };
+    }
+    return existing;
+  }
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
@@ -84,29 +123,84 @@ export async function getApi(wsEndpoint?: string): Promise<GearApi> {
       const cachedKeyCount = Object.keys(cachedMetadata).length;
       markStage('connect_begin', { endpoint, cachedMetadataKeys: cachedKeyCount });
       const connectPromise = (async (): Promise<GearApi> => {
-        const attemptConnect = (metadata: Record<string, `0x${string}`>): Promise<GearApi> =>
-          withTimeout(
-            GearApi.create({ providerAddress: endpoint, metadata }),
-            CONNECTION_TIMEOUT_MS,
-            `Connection to ${endpoint} timed out after 10s. Check your network or VARA_WS setting.`,
-          );
+        // Construct WsProvider explicitly (instead of GearApi.create({ providerAddress }))
+        // so we can attach an error listener and capture the underlying Node socket
+        // error code (ENOTFOUND / ECONNREFUSED / ETIMEDOUT) before WsProvider's
+        // browser-style Event rejection laundering strips it. This is what closes
+        // the `{"error":"{}","code":"UNKNOWN_ERROR"}` opacity from issue #58.
+        const provider = new WsProvider(endpoint, /* autoConnect */ false);
+        let lastSocketError: { code?: string; message?: string } | undefined;
+        const unsubError = provider.on('error', (e: unknown) => {
+          const anyE = e as { code?: string; message?: string; error?: { code?: string; message?: string } };
+          lastSocketError = {
+            code: anyE?.error?.code ?? anyE?.code,
+            message: anyE?.message ?? anyE?.error?.message ?? String(e),
+          };
+        });
+
+        const attemptConnect = async (metadata: Record<string, `0x${string}`>): Promise<GearApi> => {
+          try {
+            // GearApi.create both opens the provider (if not connected) AND
+            // fetches genesis/metadata. WsProvider.connect() can resolve
+            // before the WS handshake actually completes, so transport
+            // failures surface inside GearApi.create rather than in our
+            // explicit provider.connect() — both have to be inside the catch.
+            await withTimeout(
+              provider.connect(),
+              CONNECTION_TIMEOUT_MS,
+              `Connection to ${endpoint} timed out after 10s. Check your network or VARA_WS setting.`,
+            );
+            return await withTimeout(
+              GearApi.create({ provider, metadata }),
+              CONNECTION_TIMEOUT_MS,
+              `Connection to ${endpoint} timed out after 10s. Check your network or VARA_WS setting.`,
+            );
+          } catch (rawErr) {
+            // Metadata-cache mismatch errors must propagate raw — the caller
+            // detects them via isMetadataError() and retries with an empty
+            // cache. Don't translate them to TRANSPORT_ERROR here.
+            if (isMetadataError(rawErr)) throw rawErr;
+            // Post-mortem DNS probe: Node's built-in WebSocket sanitizes the
+            // underlying error to "Received network error or non-101 status
+            // code" so we can't read .code directly. On failure path only,
+            // do a quick dns.lookup on the endpoint host — if it fails, the
+            // root cause was DNS. Only runs once per failed connect, never
+            // on the success path.
+            const probed = await probeTransportCause(endpoint, lastSocketError);
+            const cli = classifyTransportError(rawErr, {
+              endpoint,
+              cause: probed ?? lastSocketError,
+            });
+            throw cli ?? rawErr;
+          }
+        };
+
         let api: GearApi;
         try {
-          api = await attemptConnect(cachedMetadata);
-        } catch (err) {
-          // Cached metadata that passed magic-byte validation but trips
-          // @polkadot/api's deeper Metadata wrap (e.g. version/struct
-          // mismatch in a future polkadot/api). Clear and retry once
-          // without cache so the user isn't stuck with a poisoned entry.
-          if (cachedKeyCount > 0 && isMetadataError(err)) {
-            verbose(
-              `metadata-cache: connect failed with cached metadata (${errorMessage(err)}); clearing cache and retrying`,
-            );
-            clearMetadataCache();
-            api = await attemptConnect({});
-          } else {
-            throw err;
+          try {
+            api = await attemptConnect(cachedMetadata);
+          } catch (err) {
+            // Cached metadata that passed magic-byte validation but trips
+            // @polkadot/api's deeper Metadata wrap (e.g. version/struct
+            // mismatch in a future polkadot/api). Clear and retry once
+            // without cache so the user isn't stuck with a poisoned entry.
+            if (cachedKeyCount > 0 && isMetadataError(err)) {
+              verbose(
+                `metadata-cache: connect failed with cached metadata (${errorMessage(err)}); clearing cache and retrying`,
+              );
+              clearMetadataCache();
+              // Disconnect the existing provider so retry uses a clean state.
+              try { await provider.disconnect(); } catch { /* ignore */ }
+              api = await attemptConnect({});
+            } else {
+              throw err;
+            }
           }
+        } finally {
+          // Detach the connect-time error listener now that the handshake
+          // outcome is known. Runtime errors mid-call surface through
+          // formatError's transport fallback instead.
+          try { unsubError(); } catch { /* ignore */ }
         }
         apiInstance = api;
         verbose(`Connected to ${endpoint} (spec: ${api.specVersion})`);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -197,6 +197,14 @@ export async function getApi(wsEndpoint?: string): Promise<GearApi> {
               throw err;
             }
           }
+        } catch (err) {
+          // Terminal connect failure: release the WS handle and background
+          // heartbeat timers WsProvider keeps alive even after a rejected
+          // connect. Without this the process can hang on exit until the
+          // ~1.7s heartbeat clears (fastExit helps but doesn't substitute
+          // for proper teardown).
+          try { await provider.disconnect(); } catch { /* ignore */ }
+          throw err;
         } finally {
           // Detach the connect-time error listener now that the handshake
           // outcome is known. Runtime errors mid-call surface through

--- a/src/services/light-client.ts
+++ b/src/services/light-client.ts
@@ -1,26 +1,54 @@
 import { EventEmitter } from 'events';
 import type { ProviderInterface, ProviderInterfaceCallback, ProviderInterfaceEmitCb, ProviderInterfaceEmitted } from '@polkadot/rpc-provider/types';
+import { classifyTransportError, CliError } from '../utils';
 
-// Vara mainnet chain spec URL — fetched once and cached
-const VARA_CHAIN_SPEC_RPC = 'https://rpc.vara.network';
+// Vara mainnet chain spec URL — fetched once and cached.
+// Override via VARA_CHAIN_SPEC_RPC for testing transport classification.
+const VARA_CHAIN_SPEC_RPC =
+  process.env.VARA_CHAIN_SPEC_RPC || 'https://rpc.vara.network';
 
 let cachedChainSpec: string | null = null;
 
 async function fetchChainSpec(): Promise<string> {
   if (cachedChainSpec) return cachedChainSpec;
 
-  const response = await fetch(VARA_CHAIN_SPEC_RPC, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'sync_state_genSyncSpec',
-      params: [true],
-      id: 1,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(VARA_CHAIN_SPEC_RPC, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'sync_state_genSyncSpec',
+        params: [true],
+        id: 1,
+      }),
+    });
+  } catch (err) {
+    // Network-layer fetch failures (DNS, ECONNREFUSED, TLS) — route through
+    // the unified transport classifier so --light failures don't show up as
+    // opaque UNKNOWN_ERROR (issue #58 scope expansion).
+    const cli = classifyTransportError(err, { endpoint: VARA_CHAIN_SPEC_RPC });
+    throw cli ?? err;
+  }
 
-  const data = await response.json();
+  let data: any;
+  try {
+    data = await response.json();
+  } catch (err) {
+    // 200 OK but response body isn't JSON — the endpoint is reachable but
+    // doesn't speak the chain-spec RPC. Classify as protocol_mismatch so
+    // agents can distinguish "DNS failed" from "wrong endpoint".
+    throw new CliError(
+      `Endpoint ${VARA_CHAIN_SPEC_RPC} returned non-JSON response`,
+      'TRANSPORT_ERROR',
+      {
+        reason: 'protocol_mismatch',
+        endpoint: VARA_CHAIN_SPEC_RPC,
+        cause: err instanceof Error ? err.message : String(err),
+      },
+    );
+  }
   cachedChainSpec = JSON.stringify(data.result);
   return cachedChainSpec;
 }
@@ -84,18 +112,34 @@ export class SmoldotProvider implements ProviderInterface {
   async connect(): Promise<void> {
     if (this.connected) return;
 
-    const { start } = await import('smoldot');
+    let chainSpec: string;
+    try {
+      // fetchChainSpec already routes its own failures through classifyTransportError.
+      chainSpec = await fetchChainSpec();
+    } catch (err) {
+      // Pass through pre-classified CliErrors; classify anything raw.
+      if (err instanceof CliError) throw err;
+      const cli = classifyTransportError(err, { endpoint: VARA_CHAIN_SPEC_RPC });
+      throw cli ?? err;
+    }
 
-    const chainSpec = await fetchChainSpec();
+    try {
+      const { start } = await import('smoldot');
 
-    this.client = start({
-      maxLogLevel: 3,
-      logCallback: (_level: number, _target: string, _message: string) => {
-        // Suppress smoldot logs — they're noisy
-      },
-    });
+      this.client = start({
+        maxLogLevel: 3,
+        logCallback: (_level: number, _target: string, _message: string) => {
+          // Suppress smoldot logs — they're noisy
+        },
+      });
 
-    this.chain = await this.client.addChain({ chainSpec });
+      this.chain = await this.client.addChain({ chainSpec });
+    } catch (err) {
+      if (err instanceof CliError) throw err;
+      const cli = classifyTransportError(err, { endpoint: 'light://smoldot' });
+      throw cli ?? err;
+    }
+
     this.connected = true;
     this.startPump();
     this.emitter.emit('connected');

--- a/src/services/light-client.ts
+++ b/src/services/light-client.ts
@@ -27,7 +27,7 @@ async function fetchChainSpec(): Promise<string> {
   } catch (err) {
     // Network-layer fetch failures (DNS, ECONNREFUSED, TLS) — route through
     // the unified transport classifier so --light failures don't show up as
-    // opaque UNKNOWN_ERROR (issue #58 scope expansion).
+    // opaque UNKNOWN_ERROR.
     const cli = classifyTransportError(err, { endpoint: VARA_CHAIN_SPEC_RPC });
     throw cli ?? err;
   }

--- a/src/services/light-client.ts
+++ b/src/services/light-client.ts
@@ -135,6 +135,12 @@ export class SmoldotProvider implements ProviderInterface {
 
       this.chain = await this.client.addChain({ chainSpec });
     } catch (err) {
+      // Terminate the smoldot client if it was started — addChain failure
+      // leaves a running worker that holds the process open otherwise.
+      if (this.client) {
+        try { await this.client.terminate(); } catch { /* ignore */ }
+        this.client = null;
+      }
       if (err instanceof CliError) throw err;
       const cli = classifyTransportError(err, { endpoint: 'light://smoldot' });
       throw cli ?? err;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,5 @@
+import { isVerboseEnabled } from './output';
+
 /**
  * Extract a string message from anything that might be thrown. Preferred
  * over inline `err instanceof Error ? err.message : String(err)` so error
@@ -34,15 +36,14 @@ export function outputError(error: unknown): void {
   const formatted = formatError(routed);
 
   // Verbose cause echo: surface the underlying error code + message before
-  // the structured JSON. Gated on globalOptions.verbose to avoid log noise.
-  // Wrapped in try/catch so EPIPE (stderr closed by a piping consumer)
-  // doesn't crash the CLI tail.
+  // the structured JSON. Wrapped in try/catch so EPIPE (stderr closed by a
+  // piping consumer) doesn't crash the CLI tail.
   if (isVerboseEnabled()) {
     try {
       const cause = extractCauseChain(error);
       if (cause) process.stderr.write(`[verbose] cause: ${cause}\n`);
     } catch {
-      // ignore — verbose is best-effort
+      // best-effort
     }
   }
 
@@ -89,17 +90,6 @@ export function formatError(error: unknown): { error: string; code: string } & E
     ? JSON.stringify(error)
     : String(error);
   return { error: msg, code: 'UNKNOWN_ERROR' };
-}
-
-function isVerboseEnabled(): boolean {
-  try {
-    // Lazy require to avoid circular import between utils/output and utils/errors.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const out = require('./output');
-    return typeof out.isVerboseEnabled === 'function' ? out.isVerboseEnabled() : false;
-  } catch {
-    return false;
-  }
 }
 
 function extractCauseChain(error: unknown): string | undefined {
@@ -289,11 +279,12 @@ export interface TransportContext {
  * `reason` subcode. Returns `null` when the value doesn't match any
  * transport signature — caller falls through to the existing classifier.
  *
- * Extraction order (per plan / issue #58):
+ * Extraction order:
  *   1. err.code                (Node net errors thrown directly)
  *   2. err.error?.code         (ws library wrap: { error: NetError, message, type, target })
- *   3. err.message regex       (string-only signals: 'ENOTFOUND', '1006', 'Unexpected response: 200')
- *   4. ctx.cause               (last resort — captured by on('error') listener)
+ *   3. err.cause?.code         (Node fetch wraps the underlying network error as err.cause)
+ *   4. err.message regex       (string-only signals: 'ENOTFOUND', '1006', 'Unexpected response: 200')
+ *   5. ctx.cause               (last resort — captured by on('error') listener)
  *
  * If nothing matches and we have at least an endpoint or a captured cause,
  * emit `{ reason: 'unknown', cause: ... }`. Otherwise return null.

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -21,8 +21,37 @@ export class CliError extends Error {
 }
 
 export function outputError(error: unknown): void {
-  const formatted = formatError(error);
-  process.stderr.write(JSON.stringify(formatted) + '\n');
+  // First try transport classification on raw error — this also kicks in
+  // when the value isn't a CliError yet (mid-call WS disconnect, empty {}
+  // payload from WsProvider) and remaps the legacy CONNECTION_TIMEOUT
+  // sentinel to TRANSPORT_ERROR/timeout. classifyTransportError returns
+  // null for any other already-classified CliError, so non-transport
+  // codes (PROGRAM_ERROR, INVALID_ADDRESS, etc.) pass through unchanged.
+  let routed: unknown = error;
+  const transport = classifyTransportError(error);
+  if (transport) routed = transport;
+
+  const formatted = formatError(routed);
+
+  // Verbose cause echo: surface the underlying error code + message before
+  // the structured JSON. Gated on globalOptions.verbose to avoid log noise.
+  // Wrapped in try/catch so EPIPE (stderr closed by a piping consumer)
+  // doesn't crash the CLI tail.
+  if (isVerboseEnabled()) {
+    try {
+      const cause = extractCauseChain(error);
+      if (cause) process.stderr.write(`[verbose] cause: ${cause}\n`);
+    } catch {
+      // ignore — verbose is best-effort
+    }
+  }
+
+  try {
+    process.stderr.write(JSON.stringify(formatted) + '\n');
+  } catch {
+    // stderr write failure on the final line is fatal-ish but unrecoverable;
+    // process.exitCode is already set by the caller.
+  }
 }
 
 export function formatError(error: unknown): { error: string; code: string } & ErrorMeta {
@@ -38,6 +67,19 @@ export function formatError(error: unknown): { error: string; code: string } & E
     return error.meta ? { ...error.meta, ...base } : base;
   }
 
+  // Transport-layer fallback for non-CliError values. Runs before the
+  // generic Error / object branches so empty {} from WsProvider and
+  // bare Error('ENOTFOUND ...') both surface as TRANSPORT_ERROR with
+  // a `reason` subcode rather than UNKNOWN_ERROR / INTERNAL_ERROR.
+  const transport = classifyTransportError(error);
+  if (transport) {
+    const base = {
+      error: sanitizeErrorMessage(transport.message),
+      code: transport.code,
+    };
+    return transport.meta ? { ...transport.meta, ...base } : base;
+  }
+
   if (error instanceof Error) {
     const message = sanitizeErrorMessage(error.message);
     return { error: message, code: classifyError(error) };
@@ -47,6 +89,37 @@ export function formatError(error: unknown): { error: string; code: string } & E
     ? JSON.stringify(error)
     : String(error);
   return { error: msg, code: 'UNKNOWN_ERROR' };
+}
+
+function isVerboseEnabled(): boolean {
+  try {
+    // Lazy require to avoid circular import between utils/output and utils/errors.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const out = require('./output');
+    return typeof out.isVerboseEnabled === 'function' ? out.isVerboseEnabled() : false;
+  } catch {
+    return false;
+  }
+}
+
+function extractCauseChain(error: unknown): string | undefined {
+  if (error == null) return undefined;
+  if (error instanceof CliError) {
+    const cause = error.meta?.cause as string | undefined;
+    const code = error.meta?.reason as string | undefined;
+    if (cause || code) return `code=${code ?? 'unknown'}, message=${cause ?? error.message}`;
+    return undefined;
+  }
+  const anyErr = error as { code?: string; message?: string; error?: { code?: string; message?: string } };
+  const code = anyErr?.code ?? anyErr?.error?.code;
+  const message = anyErr?.message ?? anyErr?.error?.message;
+  if (code || message) {
+    return `code=${code ?? 'unknown'}, message=${(message ?? '').slice(0, 200)}`;
+  }
+  if (typeof error === 'object' && error !== null) {
+    return `code=unknown, message=${JSON.stringify(error).slice(0, 200)}`;
+  }
+  return `code=unknown, message=${String(error).slice(0, 200)}`;
 }
 
 function sanitizeErrorMessage(message: string): string {
@@ -178,6 +251,13 @@ export function classifyProgramError(err: unknown): CliError {
   // the RPC layer (timeout, websocket disconnect, etc). Misclassifying those
   // as PROGRAM_ERROR tells agent consumers "the program failed, do not retry"
   // when the right signal is "the network blipped, retry it".
+  //
+  // Order: transport classifier first (richer reason subcodes), then the
+  // legacy classifyError fallback for non-transport system errors
+  // (ENOENT/NOT_FOUND, EACCES/PERMISSION_DENIED, ENOSPC/DISK_FULL).
+  const transport = classifyTransportError(err);
+  if (transport) return transport;
+
   if (err instanceof Error) {
     const code = classifyError(err);
     if (code !== 'INTERNAL_ERROR') {
@@ -186,6 +266,206 @@ export function classifyProgramError(err: unknown): CliError {
   }
 
   return new CliError(`Program execution failed: ${raw}`, 'PROGRAM_ERROR');
+}
+
+export type TransportReason =
+  | 'dns_failure'
+  | 'connection_refused'
+  | 'timeout'
+  | 'ws_close_abnormal'
+  | 'protocol_mismatch'
+  | 'unreachable'
+  | 'tls_failure'
+  | 'unknown';
+
+export interface TransportContext {
+  endpoint?: string;
+  cause?: { code?: string; message?: string };
+}
+
+/**
+ * Classify a transport-layer failure (DNS, WS handshake, RPC disconnect,
+ * TLS, timeout) into a `TRANSPORT_ERROR` CliError with a structured
+ * `reason` subcode. Returns `null` when the value doesn't match any
+ * transport signature — caller falls through to the existing classifier.
+ *
+ * Extraction order (per plan / issue #58):
+ *   1. err.code                (Node net errors thrown directly)
+ *   2. err.error?.code         (ws library wrap: { error: NetError, message, type, target })
+ *   3. err.message regex       (string-only signals: 'ENOTFOUND', '1006', 'Unexpected response: 200')
+ *   4. ctx.cause               (last resort — captured by on('error') listener)
+ *
+ * If nothing matches and we have at least an endpoint or a captured cause,
+ * emit `{ reason: 'unknown', cause: ... }`. Otherwise return null.
+ */
+export function classifyTransportError(err: unknown, ctx: TransportContext = {}): CliError | null {
+  // Honor an upstream CONNECTION_TIMEOUT sentinel (thrown by api.ts:withTimeout)
+  // by remapping it to the unified TRANSPORT_ERROR taxonomy.
+  if (err instanceof CliError && err.code === 'CONNECTION_TIMEOUT') {
+    return new CliError(err.message, 'TRANSPORT_ERROR', {
+      reason: 'timeout' as TransportReason,
+      ...(ctx.endpoint ? { endpoint: ctx.endpoint } : {}),
+    });
+  }
+  // Don't touch errors that already have a structured CliError code —
+  // only the CONNECTION_TIMEOUT sentinel above is migrated.
+  if (err instanceof CliError) return null;
+
+  // 1+2. Direct `.code` or wrapped `.error.code` / `.cause.code`.
+  //   - Node net errors throw directly with `.code` (ENOTFOUND, ECONNREFUSED, …).
+  //   - The `ws` library wraps as `{ error: NetError, message, type, target }`.
+  //   - Node's `fetch` wraps the underlying network error as `err.cause`.
+  const anyErr = err as {
+    code?: string;
+    message?: string;
+    error?: { code?: string; message?: string };
+    cause?: { code?: string; message?: string };
+  } | null;
+  const directCode = anyErr?.code ?? anyErr?.error?.code ?? anyErr?.cause?.code;
+  const directMessage = anyErr?.message ?? anyErr?.error?.message ?? anyErr?.cause?.message;
+
+  // 3. Message string. Available for direct Error instances, listener-captured
+  //    causes, and even empty {} (which yields '').
+  const msg = directMessage ?? (typeof err === 'string' ? err : '');
+
+  // 4. Listener fallback. Used when the rejection is empty (e.g., browser-style
+  //    `Event` from WsProvider) but the on('error') listener captured the
+  //    underlying socket error first.
+  const ctxCode = ctx.cause?.code;
+  const ctxMsg = ctx.cause?.message;
+
+  const code = directCode ?? ctxCode;
+  const combinedMsg = `${msg} ${ctxMsg ?? ''}`.trim();
+
+  const reason = matchReason(code, combinedMsg);
+  if (!reason) {
+    // Last-ditch fallback: only classify as 'unknown' transport if the caller
+    // gave us a hint (endpoint or listener-captured cause). Without ctx we
+    // can't tell a transport failure from a Sails program error that arrived
+    // as a bare `{ method: '...' }` object — return null and let the
+    // legacy UNKNOWN_ERROR / PROGRAM_ERROR paths take over.
+    if (ctx.endpoint || ctx.cause) {
+      return buildTransportError('unknown', ctx, code, combinedMsg);
+    }
+    return null;
+  }
+  return buildTransportError(reason, ctx, code, combinedMsg);
+}
+
+function matchReason(code: string | undefined, message: string): TransportReason | null {
+  if (code) {
+    if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return 'dns_failure';
+    if (code === 'ECONNREFUSED') return 'connection_refused';
+    if (code === 'ETIMEDOUT') return 'timeout';
+    if (code === 'EHOSTUNREACH' || code === 'ENETUNREACH') return 'unreachable';
+    if (code.startsWith('ERR_TLS_') || code.startsWith('CERT_') || code.includes('UNABLE_TO_VERIFY')) {
+      return 'tls_failure';
+    }
+    if (code === 'WS_ERR_UNEXPECTED_RESPONSE') return 'protocol_mismatch';
+  }
+  if (!message) return null;
+  const lower = message.toLowerCase();
+  // DNS / network errors that may arrive as bare Error('getaddrinfo ENOTFOUND ...').
+  if (lower.includes('enotfound') || lower.includes('getaddrinfo')) return 'dns_failure';
+  if (lower.includes('econnrefused')) return 'connection_refused';
+  if (lower.includes('etimedout') || lower.includes('timed out') || lower.includes('timeout')) {
+    return 'timeout';
+  }
+  if (lower.includes('ehostunreach') || lower.includes('enetunreach')) return 'unreachable';
+  if (
+    lower.includes('cert') ||
+    lower.includes('tls handshake') ||
+    lower.includes('unable to verify')
+  ) {
+    return 'tls_failure';
+  }
+  // WS protocol handshake failures: ws library reports 'Unexpected server response: 200',
+  // 'Unexpected response: 426', etc. Node's built-in WebSocket sanitizes these to
+  // 'Received network error or non-101 status code' — same root cause.
+  if (lower.includes('unexpected server response') || lower.includes('unexpected response')) {
+    return 'protocol_mismatch';
+  }
+  if (lower.includes('non-101 status code') || lower.includes('non-101')) {
+    return 'protocol_mismatch';
+  }
+  // Abnormal WS close codes — explicit close-code mention.
+  if (/\b(1006|1011|1012|1013)\b/.test(message)) return 'ws_close_abnormal';
+  if (lower.includes('disconnected from')) return 'ws_close_abnormal';
+  return null;
+}
+
+function buildTransportError(
+  reason: TransportReason,
+  ctx: TransportContext,
+  code: string | undefined,
+  message: string,
+): CliError {
+  const meta: ErrorMeta = { reason };
+  if (ctx.endpoint) meta.endpoint = ctx.endpoint;
+
+  let humanMessage: string;
+  switch (reason) {
+    case 'dns_failure': {
+      const host = extractHost(ctx.endpoint) ?? extractHostFromMessage(message);
+      if (host) meta.host = host;
+      humanMessage = host
+        ? `Cannot resolve host ${host}`
+        : 'DNS lookup failed';
+      break;
+    }
+    case 'connection_refused':
+      humanMessage = ctx.endpoint ? `Connection refused by ${ctx.endpoint}` : 'Connection refused';
+      break;
+    case 'timeout':
+      humanMessage = ctx.endpoint ? `Connection to ${ctx.endpoint} timed out` : 'Connection timed out';
+      break;
+    case 'ws_close_abnormal':
+      humanMessage = ctx.endpoint
+        ? `WebSocket connection to ${ctx.endpoint} closed abnormally`
+        : 'WebSocket connection closed abnormally';
+      break;
+    case 'protocol_mismatch':
+      humanMessage = ctx.endpoint
+        ? `Endpoint ${ctx.endpoint} does not speak WebSocket`
+        : 'Endpoint does not speak WebSocket';
+      break;
+    case 'unreachable':
+      humanMessage = ctx.endpoint ? `Host ${ctx.endpoint} is unreachable` : 'Host is unreachable';
+      break;
+    case 'tls_failure':
+      humanMessage = ctx.endpoint
+        ? `TLS handshake failed for ${ctx.endpoint}`
+        : 'TLS handshake failed';
+      break;
+    case 'unknown':
+    default:
+      humanMessage = ctx.endpoint
+        ? `Transport failure communicating with ${ctx.endpoint}`
+        : 'Transport failure';
+      break;
+  }
+
+  // Always preserve the underlying signal in meta.cause for triage.
+  const causeText = message || code;
+  if (causeText) meta.cause = causeText;
+
+  return new CliError(humanMessage, 'TRANSPORT_ERROR', meta);
+}
+
+function extractHost(endpoint: string | undefined): string | undefined {
+  if (!endpoint) return undefined;
+  try {
+    // Accept ws/wss/http/https; URL constructor handles all.
+    return new URL(endpoint).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractHostFromMessage(message: string): string | undefined {
+  // Node's getaddrinfo emits "getaddrinfo ENOTFOUND host.example.com".
+  const m = message.match(/(?:ENOTFOUND|EAI_AGAIN|getaddrinfo\s+\S+)\s+([\w.-]+)/);
+  return m ? m[1] : undefined;
 }
 
 export function installGlobalErrorHandler(): void {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -41,7 +41,11 @@ export function outputError(error: unknown): void {
   if (isVerboseEnabled()) {
     try {
       const cause = extractCauseChain(error);
-      if (cause) process.stderr.write(`[verbose] cause: ${cause}\n`);
+      if (cause) {
+        // Sanitize before writing — `cause` interpolates raw error text and
+        // a pathological CliError message could carry a seed/mnemonic.
+        process.stderr.write(`[verbose] cause: ${sanitizeErrorMessage(cause)}\n`);
+      }
     } catch {
       // best-effort
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { output, outputNdjson, verbose, setOutputOptions } from './output';
-export { CliError, errorMessage, outputError, formatError, classifyProgramError, installGlobalErrorHandler } from './errors';
+export { CliError, errorMessage, outputError, formatError, classifyProgramError, classifyTransportError, installGlobalErrorHandler, type TransportReason, type TransportContext } from './errors';
 export { varaToMinimal, minimalToVara, toMinimalUnits, resolveAmount, validateUnits, type UnitsFlag } from './units';
 export { addressToHex } from './address';
 export { textToHex, tryHexToText, resolvePayload } from './payload';

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -38,6 +38,10 @@ export function verbose(message: string): void {
   process.stderr.write(chalk.gray(`[verbose] ${message}\n`));
 }
 
+export function isVerboseEnabled(): boolean {
+  return Boolean(globalOptions.verbose) && !globalOptions.quiet;
+}
+
 function bigintReplacer(_key: string, value: unknown): unknown {
   if (typeof value === 'bigint') {
     return value.toString();


### PR DESCRIPTION
## Summary

Closes #58. Transport-layer failures (DNS, WS handshake, RPC disconnect, TLS, timeout) now surface as `code: "TRANSPORT_ERROR"` with a structured `reason` subcode instead of the historical opaque `{"error":"{}","code":"UNKNOWN_ERROR"}`. Companion to #35's `PROGRAM_ERROR` work at the layer below.

**Reason taxonomy (8 subcodes):** `dns_failure`, `connection_refused`, `timeout`, `ws_close_abnormal`, `protocol_mismatch`, `unreachable`, `tls_failure`, `unknown`. Each error carries `meta.endpoint`, plus `meta.host` (DNS) or `meta.cause` (raw upstream message) for triage.

**Surfaces covered:** WS via explicit `WsProvider` + `on('error')` listener (api.ts), and `--light` via `fetchChainSpec` + smoldot `connect()` (light-client.ts).

**`--verbose` cause echo:** writes `[verbose] cause: code=<x>, message=<y>` to stderr before the structured JSON. EPIPE-safe.

## Design notes

- **Node 22+ built-in WebSocket sanitizes underlying error codes** to `"Received network error or non-101 status code"`. Both the connect rejection and the `on('error')` listener get this generic string — `.code` is unavailable. To compensate, the failure path runs a post-mortem `dns.lookup()` on the endpoint host: if DNS fails, the root cause was DNS (→ `dns_failure`); if DNS resolves, it was handshake/protocol (→ `protocol_mismatch`). **Only fires on the failure path** — zero cost on the success path.
- **Extraction chain:** `err.code → err.error?.code → err.cause?.code → message regex → ctx.cause` (covers Node net errors, `ws` library wraps, Node fetch `cause`, message-only signals, and listener-captured rejections).
- **Legacy code migration:** WS-side `CONNECTION_TIMEOUT` → `TRANSPORT_ERROR { reason: 'timeout' }`. Program-path `classifyProgramError` consumers (`call`/`program`/`dex`/`vft`/`message`) that previously emitted bare `TIMEOUT` / `CONNECTION_FAILED` now route through `TRANSPORT_ERROR` + reason. Faucet HTTP `CONNECTION_FAILED` unchanged (separate consumer surface).

## Breaking changes

Agent scripts that grep for `"code":"TIMEOUT"` or `"code":"CONNECTION_FAILED"` from the WS surface (any `vara-wallet --ws` invocation that previously hit those codes) must switch to `"code":"TRANSPORT_ERROR"` + `"reason":"timeout" | "connection_refused"`. Documented in CHANGELOG.

## Acceptance — repro outputs verbatim

Repro 1 — DNS failure:
~~~json
{"reason":"dns_failure","endpoint":"wss://nonexistent-host-12345.example.invalid","host":"nonexistent-host-12345.example.invalid","cause":"Received network error or non-101 status code. getaddrinfo ENOTFOUND nonexistent-host-12345.example.invalid","error":"Cannot resolve host nonexistent-host-12345.example.invalid","code":"TRANSPORT_ERROR"}
~~~

Repro 2 — protocol mismatch (`wss://example.com`):
~~~json
{"reason":"protocol_mismatch","endpoint":"wss://example.com","cause":"...","error":"Endpoint wss://***.com does not speak WebSocket","code":"TRANSPORT_ERROR"}
~~~

Repro 3 — `--verbose` emits cause before JSON:
~~~
[verbose] Connecting to wss://nonexistent-host-12345.example.invalid
[verbose] cause: code=dns_failure, message=Received network error or non-101 status code. getaddrinfo ENOTFOUND nonexistent-host-12345.example.invalid
{"reason":"dns_failure",...,"code":"TRANSPORT_ERROR"}
~~~

Repro 4 — light client with bad chainspec URL (scope expansion):
~~~json
{"reason":"dns_failure","endpoint":"https://nonexistent.example.invalid","host":"nonexistent.example.invalid",...,"code":"TRANSPORT_ERROR"}
~~~

## Test plan

- [x] `npm test` — 630/630 pass (54 suites)
- [x] `npx tsc --noEmit` — clean
- [x] Issue #58 repros 1–3 produce acceptance-criteria output verbatim against the built CLI
- [x] Light-client repro produces `dns_failure` against `VARA_CHAIN_SPEC_RPC=https://nonexistent.example.invalid`
- [x] Happy path against real testnet program `0x99ba7698...` (vara-agent-network Registry): `discover`, `Registry/Discover`, `node info`, `balance` all return identical output to pre-change behavior
- [x] Regression contracts hold: `INVALID_ADDRESS`, `PROGRAM_ERROR / reason:unreachable` (wrong PID), `METHOD_NOT_FOUND`, `INTERNAL_ERROR` (codec rejection) all classify correctly — no false-positive transport claims

## Files

- `src/utils/errors.ts` — `classifyTransportError` + reason taxonomy + `formatError` fallback + verbose echo
- `src/services/api.ts` — explicit `WsProvider` + listener + post-mortem DNS probe
- `src/services/light-client.ts` — chainspec fetch + smoldot connect classification, `VARA_CHAIN_SPEC_RPC` env override
- `src/utils/output.ts` — `isVerboseEnabled()` getter
- `src/__tests__/errors.test.ts` — full classifier coverage + transport-fallback regressions
- `src/__tests__/api-timeout.test.ts` — `CONNECTION_TIMEOUT` migration tests
- `src/__tests__/verbose-cause.test.ts` (new) — verbose echo + EPIPE safety
- `src/__tests__/light-client-transport.test.ts` (new) — DNS / protocol_mismatch / connection_refused
- `CHANGELOG.md` — Unreleased section

## Commits

1. `fix: classify transport-layer failures with TRANSPORT_ERROR + reason subcodes (#58)` — main implementation
2. `docs: flag program-path TIMEOUT migration in CHANGELOG (#58 followup)` — CHANGELOG clarification
3. `refactor: simplify transport classifier — direct import, listener reset, drop task references` — post-review polish

Safe to squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)