### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-12
+
+One theme since 0.16.0: **transport-error classification** (PR #59, closes #58). The companion to v0.16.0's `PROGRAM_ERROR` + `reason` work at the layer below — every transport-layer failure (DNS, WS handshake, RPC disconnect, TLS, timeout) now surfaces as a structured `TRANSPORT_ERROR` with a `reason` subcode, replacing the historical opaque `{"error":"{}","code":"UNKNOWN_ERROR"}` payload that hid network failures from agent retry logic. Unblocks #60 (auto-retry on transient transport errors) and #61 (`vara-wallet doctor` health-check subcommand). Field-validated against the 2026-05-12 evidence pass that triggered the original issue (flaky `wss://testnet.vara.network` during a real testnet deploy).
+
 ### Added
 
 - **`TRANSPORT_ERROR` code with `reason` subcodes** (issue #58). Transport-layer failures (DNS lookup, WS handshake, RPC disconnect, TLS, timeout) now surface as `code: "TRANSPORT_ERROR"` with a structured `reason` field instead of the historical opaque `{"error":"{}","code":"UNKNOWN_ERROR"}`. Reason taxonomy: `dns_failure`, `connection_refused`, `timeout`, `ws_close_abnormal`, `protocol_mismatch`, `unreachable`, `tls_failure`, `unknown`. Each error carries `meta.endpoint` and, for DNS, `meta.host`; `meta.cause` preserves the raw underlying message for triage. Agents can switch on `.reason` to distinguish transient (retry) from permanent (don't retry) failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.17.0] - 2026-05-12
 
-One theme since 0.16.0: **transport-error classification** (PR #59, closes #58). The companion to v0.16.0's `PROGRAM_ERROR` + `reason` work at the layer below — every transport-layer failure (DNS, WS handshake, RPC disconnect, TLS, timeout) now surfaces as a structured `TRANSPORT_ERROR` with a `reason` subcode, replacing the historical opaque `{"error":"{}","code":"UNKNOWN_ERROR"}` payload that hid network failures from agent retry logic. Unblocks #60 (auto-retry on transient transport errors) and #61 (`vara-wallet doctor` health-check subcommand). Field-validated against the 2026-05-12 evidence pass that triggered the original issue (flaky `wss://testnet.vara.network` during a real testnet deploy).
+One theme since 0.16.0: **transport-error classification** (PR #59, closes #58). The companion to v0.16.0's `PROGRAM_ERROR` + `reason` work at the layer below — every transport-layer failure (DNS, WS handshake, RPC disconnect, TLS, timeout) now surfaces as a structured `TRANSPORT_ERROR` with a `reason` subcode, replacing the historical opaque `{"error":"{}","code":"UNKNOWN_ERROR"}` payload that hid network failures from agent retry logic. **Breaking for grep-based consumers:** WS-path `CONNECTION_TIMEOUT` and program-path `TIMEOUT` / `CONNECTION_FAILED` are migrated to `TRANSPORT_ERROR` + `reason` subcode (faucet HTTP `CONNECTION_FAILED` unchanged) — see *Changed* below for details. Unblocks #60 (auto-retry on transient transport errors) and #61 (`vara-wallet doctor` health-check subcommand). Field-validated against the 2026-05-12 evidence pass that triggered the original issue (flaky `wss://testnet.vara.network` during a real testnet deploy).
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vara-wallet",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.17.0. One theme since 0.16.0: **transport-error classification** (PR #59, closes #58).

The companion to v0.16.0's `PROGRAM_ERROR` + `reason` work at the layer below. Every transport-layer failure (DNS, WS handshake, RPC disconnect, TLS, timeout) now surfaces as `TRANSPORT_ERROR` with a structured `reason` subcode, replacing the `{"error":"{}","code":"UNKNOWN_ERROR"}` opacity that hid network failures from agent retry logic.

## Breaking changes

WS-path `CONNECTION_TIMEOUT` and program-path `TIMEOUT` / `CONNECTION_FAILED` are migrated to `TRANSPORT_ERROR` + `reason` subcode. Agent scripts grepping for `"code":"TIMEOUT"` / `"code":"CONNECTION_FAILED"` from WS surfaces must switch to `"code":"TRANSPORT_ERROR"` + `"reason":"timeout" | "connection_refused"`. Faucet HTTP `CONNECTION_FAILED` is unchanged.

## Unblocks

- #60 — auto-retry on transient `TRANSPORT_ERROR { reason: 'timeout' | 'ws_close_abnormal' }`
- #61 — `vara-wallet doctor` health-check subcommand
- Downstream `gear-foundation/vara-agent-network` PR #37 docs can drop the "Recovering from transient `UNKNOWN_ERROR`" workaround prose

## Test plan

- [x] `npm test` — 630/630 pass (54 suites)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Field-validated against real testnet program `0x99ba7698...`: happy-path discover/query/node info/balance all unchanged; issue #58 repros 1–4 produce acceptance-criteria output verbatim
- [x] CHANGELOG `[0.17.0]` section in place with date 2026-05-12
- [x] `package.json` + `package-lock.json` bumped to 0.17.0

## After merge

Push the `v0.17.0` tag to trigger the npm publish workflow:

\`\`\`
git checkout main && git pull
git tag -a v0.17.0 -m "v0.17.0"
git push origin v0.17.0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)