### PR TITLE
v0.18.0 chore: upgrade sails-js to beta.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,10 +152,9 @@ vara-wallet discover 0x1234... --idl ./program.idl
 # Returns: all services, functions, queries, events with argument types
 ```
 
-If the program's IDL is registered in meta-storage, you can omit `--idl`:
+For v2 programs with an embedded `sails:idl` WASM section, you can omit `--idl`:
 
 ```bash
-export VARA_META_STORAGE=https://idea.gear-tech.io/api
 vara-wallet discover 0x1234...
 ```
 
@@ -490,7 +489,7 @@ echo $RESULT | jq '.events[] | select(.section == "balances" and .method == "Tra
 
 3. **Sails queries vs functions.** `call` auto-detects whether a method is a query (read-only, free) or function (state-changing, needs gas). You don't need to specify.
 
-4. **IDL resolution.** The `call`, `discover`, and `vft` commands need a Sails IDL. Provide `--idl <path>` or set `VARA_META_STORAGE` for remote fetch by program codeId.
+4. **IDL resolution.** The `call`, `discover`, and `vft` commands need a Sails IDL. For v2 programs, vara-wallet auto-extracts the embedded `sails:idl` section from on-chain WASM and caches it locally. For v1 programs or overrides, provide `--idl <path>` or import the IDL with `vara-wallet idl import`.
 
 5. **Hex strings for byte arrays.** When a Sails method expects `vec u8` or `[u8; N]`, you can pass hex strings like `"0xabcdef..."` in `--args` and they'll be auto-converted to byte arrays. No need to manually convert hex to number arrays.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded `sails-js` to the `js/v1.0.0-beta.2` release tarball and moved v2 type lookups onto the public beta.2 resolver APIs. The CLI preserves existing output shapes while accepting beta.2's `kind: "generic"` type nodes and stricter v2 reply-header validation.
+- `sails:idl` extraction now uses Sails-JS's public extractor for beta.2 enveloped sections, with a raw UTF-8 section fallback for older beta.1-style programs.
+
 ## [0.17.0] - 2026-05-12
 
 One theme since 0.16.0: **transport-error classification** (PR #59, closes #58). The companion to v0.16.0's `PROGRAM_ERROR` + `reason` work at the layer below — every transport-layer failure (DNS, WS handshake, RPC disconnect, TLS, timeout) now surfaces as a structured `TRANSPORT_ERROR` with a `reason` subcode, replacing the historical opaque `{"error":"{}","code":"UNKNOWN_ERROR"}` payload that hid network failures from agent retry logic. **Breaking for grep-based consumers:** WS-path `CONNECTION_TIMEOUT` and program-path `TIMEOUT` / `CONNECTION_FAILED` are migrated to `TRANSPORT_ERROR` + `reason` subcode (faucet HTTP `CONNECTION_FAILED` unchanged) — see *Changed* below for details. Unblocks #60 (auto-retry on transient transport errors) and #61 (`vara-wallet doctor` health-check subcommand). Field-validated against the 2026-05-12 evidence pass that triggered the original issue (flaky `wss://testnet.vara.network` during a real testnet deploy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-15
+
 ### Changed
 
 - Upgraded `sails-js` to the `js/v1.0.0-beta.2` release tarball and moved v2 type lookups onto the public beta.2 resolver APIs. The CLI preserves existing output shapes while accepting beta.2's `kind: "generic"` type nodes and stricter v2 reply-header validation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ npx jest src/__tests__/units.test.ts
    - `wallet-store.ts` — Encrypted wallet files at `~/.vara-wallet/wallets/` (xsalsa20-poly1305, file mode 0o600)
    - `tx-executor.ts` — Sign, submit, wait for block inclusion, extract events (60s timeout)
    - `event-store.ts` — SQLite persistence via better-sqlite3 (`~/.vara-wallet/events.db`, WAL mode, 7-day auto-prune)
-   - `sails.ts` — IDL loading (local file or meta-storage URL) and typed Sails method invocation
+   - `sails.ts` — IDL loading (local file, on-chain WASM `sails:idl` extraction, or local cache) and typed Sails method invocation
    - `light-client.ts` — SmoldotProvider implementing PolkadotJS ProviderInterface
    - `config.ts` — `~/.vara-wallet/config.json` management
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ For v2 programs (sails ≥ 1.0.0-beta.1) the IDL is auto-resolved from the progr
 
 The JSON response from a real submission includes an `events: [...]` field with any decoded Sails events emitted by the call, phase-correlated to the submitting extrinsic (cross-transaction events from the same block are excluded). Nested numeric leaves (`U256`, `u128`) inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user types are recursively decoded to decimal strings to match the declared IDL return type.
 
+With Sails v2 beta.2 programs, function replies and emitted events are decoded through the header-aware `sails-js` reply/event decoders before vara-wallet normalizes the JSON shape. Older beta.1-style embedded IDL sections still load through the raw `sails:idl` fallback, so existing deployed programs remain readable.
+
 ### `discover` (Sails)
 
 Introspect a Sails program's services, functions, queries, and events.

--- a/SKILL.md
+++ b/SKILL.md
@@ -79,7 +79,7 @@ The passphrase is stored at `~/.vara-wallet/.passphrase` (0600). The agent never
 | `$VW message send <dest> [--payload <hex>] [--value <v>]` | Send message to any actor (program, user, wallet) — also usable for VARA transfers with custom payload |
 | `$VW message reply <mid> [--payload <hex>]` | Reply to a message |
 | `$VW mailbox claim <messageId>` | Claim value from mailbox message |
-| `$VW call <pid> Service/Function --args '[...]' --value <v> --units vara\|raw --idl <path>` | Sails state-changing call |
+| `$VW call <pid> Service/Function --args '[...]' --value <v> --units human\|raw --idl <path>` | Sails state-changing call |
 | `$VW call <pid> Service/Function --estimate --idl <path>` | Estimate gas cost without sending |
 | `$VW vft transfer <token> <to> <amount> --idl <path>` | Transfer fungible tokens |
 | `$VW vft approve <token> <spender> <amount> --idl <path>` | Approve token spender |
@@ -204,12 +204,13 @@ $VW vft transfer $TOKEN $TO 1000 --voucher $VOUCHER_ID
 
 ## IDL Resolution
 
-Sails commands (`call`, `discover`, `vft`) require an IDL. Currently:
+Sails commands (`call`, `discover`, `vft`) require an IDL. Current resolution:
 
 - **`--idl <path>`** — local file, always works
-- **`VARA_META_STORAGE`** — remote fetch by program codeId (no public registry yet)
+- **Embedded v2 `sails:idl` section** — auto-extracted from on-chain WASM and cached by code ID
+- **`vara-wallet idl import`** — seeds the cache for v1 programs or out-of-band IDLs
 
-For now, always provide `--idl <path>`. Public IDL registry is planned for a future release.
+For v2 programs, `call` and `discover` can usually omit `--idl`. For v1 programs, provide `--idl <path>` for one-off use or import the IDL once.
 
 ## Output Parsing
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -20,33 +20,12 @@ content based on detected type, with `--format` flags for output control.
 and `tryHexToText`, and IDL-based constructor encoding via `--idl`/`--init`/`--args`
 on `program upload`/`deploy` (added in v0.8.0). The remaining scope is SCALE decoding
 of program responses with IDL context, which would let agents read structured replies
-without external tooling.
+without external tooling. Sails-JS v1.0.0-beta.2 exposes high-level v2 decoders
+(`decodeCall`, `decodeReply`, `decodeError`, `decodeEvent`, `decodeCtor`) that should
+be evaluated as the foundation for this feature instead of hand-rolling payload
+routing.
 
 **Depends on:** ASCII payload support (completed). Constructor encoding (completed v0.8.0).
-
-## vft balance / vft allowance decoder wiring
-**Priority:** P2 | **Effort:** S (human ~1 day / CC ~15 min)
-
-The `vft balance` and `vft allowance` subcommands currently call
-`BigInt(result)`/`String(result)` directly on the raw sails-js reply
-(`src/commands/vft.ts:288-289` and `:326-327`). This works for top-level
-`u256` return types (the common `Vft.BalanceOf` case) but crashes with
-`BigInt(null)` if the call resolves against `VftExtension.BalanceOf`
-(declared as `opt u256`) and the account has no balance row.
-
-`findVftService` iterates services in IDL-declaration order, so which
-service wins depends on how the IDL was authored. Brittle.
-
-**Fix:** route these two sites through `decodeSailsResult` (already
-available in `src/utils/decode-sails-result.ts`) and then handle the
-`null` case explicitly before `BigInt`/`String` coercion. Roughly four
-lines per site.
-
-**Context:** Surfaced during pre-landing review of PR #40 (issue #32
-decoder fix). Not in scope for #32 because it needs its own None-path
-design — the decoder alone is not enough.
-
-**Depends on:** `decodeSailsResult` (landed in #40).
 
 ## Voucher auto-discovery
 **Priority:** P3 | **Effort:** S (human ~1 day / CC ~15 min)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vara-wallet",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "commander": "^14.0.3",
         "esbuild": "^0.24.2",
         "jest": "^30.2.0",
-        "sails-js": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.1/sails-js.tgz",
+        "sails-js": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.2/sails-js.tgz",
         "sails-js-parser": "^0.5.1",
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.0",
@@ -5533,8 +5533,8 @@
     },
     "node_modules/sails-js": {
       "version": "0.5.1",
-      "resolved": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.1/sails-js.tgz",
-      "integrity": "sha512-Hny07M8B3GPq3gbjT4al6V2SPDCFjdWNL+gz1qa1d5AlkNXZM+eHfwj/1I5xYuaLjz4ZrH9eGvzxDsIARpjGfg==",
+      "resolved": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.2/sails-js.tgz",
+      "integrity": "sha512-smq/wSBkp14Fxc9Lt0Yq8II+5BN0bornIkMT8ArybVKQzm46mlWze+p8TE1aHZoPMpnCIyp40GI+8dIGQrK8rQ==",
       "dev": true,
       "license": "GPL-3.0",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "commander": "^14.0.3",
     "esbuild": "^0.24.2",
     "jest": "^30.2.0",
-    "sails-js": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.1/sails-js.tgz",
+    "sails-js": "https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.2/sails-js.tgz",
     "sails-js-parser": "^0.5.1",
     "ts-jest": "^29.4.5",
     "ts-node": "^10.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/src/__tests__/decode-sails-result.test.ts
+++ b/src/__tests__/decode-sails-result.test.ts
@@ -313,4 +313,19 @@ describe('decodeSailsResult (v2 — Nums fixture)', () => {
     expect(decodeSailsResult(program, td, { id: 7, payload: '0x2a' }, 'Gen'))
       .toEqual({ id: 7, payload: '42' });
   });
+
+  it('normalizes values decoded from beta.2 raw reply payloads', async () => {
+    const program = await parseIdlFileV2(V2_GENERICS_FIXTURE) as SailsProgram;
+    const query = program.services.Gen.queries.ReadAmount;
+    const header = query.encodePayload();
+    const body = program.services.Gen.registry.createType(
+      query.returnType,
+      { id: 7, payload: 42n },
+    ).toHex();
+    const reply = program.decodeReply(`${header}${body.slice(2)}`);
+    if (reply.kind !== 'reply') throw new Error(`decodeReply failed: ${reply.reason}`);
+
+    expect(decodeSailsResult(program, query.returnTypeDef, reply.result, 'Gen'))
+      .toEqual({ id: 7, payload: '42' });
+  });
 });

--- a/src/__tests__/decode-sails-result.test.ts
+++ b/src/__tests__/decode-sails-result.test.ts
@@ -6,6 +6,7 @@ import { decodeSailsResult } from '../utils/decode-sails-result';
 import { BUNDLED_VFT_IDLS } from '../idl/bundled-idls';
 
 const V2_FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-numeric.idl');
+const V2_GENERICS_FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-generics.idl');
 
 /**
  * We pin one VFT bundled IDL that has the exact shapes the issue reports:
@@ -304,5 +305,12 @@ describe('decodeSailsResult (v2 — Nums fixture)', () => {
     it('snake_case message_id also passes hex through', () => {
       expect(decodeSailsResult(sails, 'message_id', hex32, 'Nums')).toBe(hex32);
     });
+  });
+
+  it('decodes generic user types through the scoped beta.2 resolver', async () => {
+    const program = await parseIdlFileV2(V2_GENERICS_FIXTURE) as SailsProgram;
+    const td = program.services.Gen.queries.ReadAmount.returnTypeDef;
+    expect(decodeSailsResult(program, td, { id: 7, payload: '0x2a' }, 'Gen'))
+      .toEqual({ id: 7, payload: '42' });
   });
 });

--- a/src/__tests__/dry-run.test.ts
+++ b/src/__tests__/dry-run.test.ts
@@ -1,4 +1,15 @@
-import { buildFunctionDryRun, buildQueryDryRun, _resolveDryRunPayloadForTests } from '../commands/call';
+import * as path from 'path';
+import type { SailsProgram } from 'sails-js';
+import {
+  buildFunctionDryRun,
+  buildQueryDryRun,
+  _decodeFunctionReplyForTests,
+  _listServiceMethodsForTests,
+  _resolveDryRunPayloadForTests,
+} from '../commands/call';
+import { parseIdlFileV2 } from '../services/sails';
+
+const V2_GENERICS_FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-generics.idl');
 
 describe('buildFunctionDryRun', () => {
   it('returns the documented dry-run shape with required fields', () => {
@@ -173,6 +184,47 @@ describe('B2 regression: _resolveDryRunPayloadForTests', () => {
     const result = _resolveDryRunPayloadForTests(func, txBuilder, []);
     expect(result.destination).toBe(txBuilder.programId);
     expect(result.encodedPayload).not.toBe(result.destination);
+  });
+});
+
+describe('call command helpers', () => {
+  it('lists available methods directly from the loaded service', () => {
+    const service = {
+      functions: { Transfer: {}, Approve: {} },
+      queries: { BalanceOf: {} },
+    };
+
+    expect(_listServiceMethodsForTests('Vft', service)).toEqual([
+      'Vft/Transfer (function)',
+      'Vft/Approve (function)',
+      'Vft/BalanceOf (query)',
+    ]);
+  });
+
+  it('decodes beta.2 raw function replies through SailsProgram.decodeReply', async () => {
+    const program = await parseIdlFileV2(V2_GENERICS_FIXTURE) as SailsProgram;
+    const query = program.services.Gen.queries.ReadAmount;
+    const header = query.encodePayload();
+    const body = program.services.Gen.registry.createType(
+      query.returnType,
+      { id: 7, payload: 42n },
+    ).toHex();
+    const rawReply = `${header}${body.slice(2)}`;
+    const response = jest.fn(async (rawResult?: boolean) => {
+      if (rawResult) return rawReply;
+      throw new Error('builder decode fallback should not run');
+    });
+
+    const decoded = await _decodeFunctionReplyForTests(
+      { response },
+      program,
+      { returnTypeDef: 'u32' },
+      'FallbackService',
+    );
+
+    expect(decoded).toEqual({ id: 7, payload: '42' });
+    expect(response).toHaveBeenCalledWith(true);
+    expect(response).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/__tests__/event-render-v2.test.ts
+++ b/src/__tests__/event-render-v2.test.ts
@@ -27,6 +27,7 @@ describe('describeSailsProgram — v2 event payload rendering', () => {
     // wallet normalizes it back to the existing compact struct-style output.
     expect(events.Walked.type).toMatch(/from:\s*\(i32,\s*i32\),\s*to:\s*\(i32,\s*i32\)/);
     expect(events.Walked.type).not.toBe('unknown');
+    expect(events.BalanceChanged.type).toBe('{ amount: U256 }');
 
     // Doc strings propagated for all three.
     expect(events.Stopped.docs).toContain('Unit variant');

--- a/src/__tests__/event-render-v2.test.ts
+++ b/src/__tests__/event-render-v2.test.ts
@@ -23,7 +23,8 @@ describe('describeSailsProgram — v2 event payload rendering', () => {
     // Single unnamed payload — pre-rendered by TypeResolver.
     expect(events.StepCount.type).toBe('u32');
 
-    // Named-field event — our custom renderer handles this.
+    // Named-field event — beta.2 may expose this as a JSON string; the
+    // wallet normalizes it back to the existing compact struct-style output.
     expect(events.Walked.type).toMatch(/from:\s*\(i32,\s*i32\),\s*to:\s*\(i32,\s*i32\)/);
     expect(events.Walked.type).not.toBe('unknown');
 

--- a/src/__tests__/fixtures/sample-v2-events.idl
+++ b/src/__tests__/fixtures/sample-v2-events.idl
@@ -1,10 +1,8 @@
 
 !@sails: 1.0.0-beta.1
 
-// Event-shapes fixture: exercises the three v2 event payload shapes
-// (unit variant, single unnamed payload, named-field struct) in
-// describeSailsProgram's event renderer (see Finding C in the PR
-// review).
+// Event-shapes fixture: exercises unit, single unnamed, named-field,
+// and wide-integer v2 event payloads.
 
 service Walker@0x4b67043b3eb7ea42 {
     events {
@@ -12,7 +10,7 @@ service Walker@0x4b67043b3eb7ea42 {
         Stopped,
         /// Single unnamed payload.
         StepCount(u32),
-        /// Named-field event — Finding C regression.
+        /// Named-field event.
         Walked {
             from: (i32, i32),
             to: (i32, i32),

--- a/src/__tests__/fixtures/sample-v2-events.idl
+++ b/src/__tests__/fixtures/sample-v2-events.idl
@@ -6,7 +6,7 @@
 // describeSailsProgram's event renderer (see Finding C in the PR
 // review).
 
-service Walker@0x8b8f80fc72de9b90 {
+service Walker@0x4b67043b3eb7ea42 {
     events {
         /// Unit variant event.
         Stopped,
@@ -17,6 +17,10 @@ service Walker@0x8b8f80fc72de9b90 {
             from: (i32, i32),
             to: (i32, i32),
         },
+        /// Named-field event with a wide integer leaf.
+        BalanceChanged {
+            amount: u256,
+        },
     }
     functions {
         Walk(dx: i32, dy: i32);
@@ -26,6 +30,6 @@ service Walker@0x8b8f80fc72de9b90 {
 program Demo {
     constructors { Default(); }
     services {
-        Walker@0x8b8f80fc72de9b90,
+        Walker@0x4b67043b3eb7ea42,
     }
 }

--- a/src/__tests__/fixtures/sample-v2-generics.idl
+++ b/src/__tests__/fixtures/sample-v2-generics.idl
@@ -8,10 +8,12 @@
 // walker would leave hex strings uncoerced because it'd recurse into
 // the literal type_param `T` rather than the caller's chosen type.
 
-service Gen@0xd80c9eabb287b035 {
+service Gen@0xdf750cb5462f5a1b {
     functions {
         SetPayload(p: Envelope<[u8]>);
         SetFixed(p: Envelope<[u8; 8]>);
+        @query
+        ReadAmount() -> Envelope<u256>;
     }
     types {
         struct Envelope<T> {
@@ -24,6 +26,6 @@ service Gen@0xd80c9eabb287b035 {
 program Demo {
     constructors { Default(); }
     services {
-        Gen@0xd80c9eabb287b035,
+        Gen@0xdf750cb5462f5a1b,
     }
 }

--- a/src/__tests__/hex-bytes-v2-generics.test.ts
+++ b/src/__tests__/hex-bytes-v2-generics.test.ts
@@ -52,23 +52,17 @@ describe('v2 generic substitution', () => {
     ).toThrow(/\[u8; 8\]/);
   });
 
-  it('substitutes type_params directly via the walker', async () => {
-    // Minimal direct test: simulate a call site handing a generic
-    // reference {name:'T'} with a substitution map. This documents the
-    // one-level lookup semantics that the broader substitution walk
-    // builds on.
-    const typeMap = new Map<string, unknown>();
-    const subs = new Map<string, unknown>([['T', { kind: 'slice', item: 'u8' }]]);
+  it('uses beta.2 TypeResolver concrete generic definitions directly', async () => {
+    const program = await parseIdlFileV2(FIXTURE);
+    const setPayload = program.services.Gen.functions.SetPayload;
     const out = coerceHexToBytesV2(
-      '0xabcd',
+      { id: 1, payload: '0xabcd' },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { kind: 'named', name: 'T' } as any,
+      (setPayload.args[0] as any).typeDef,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      typeMap as any,
-      undefined,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      subs as any,
-    );
-    expect(out).toEqual([0xab, 0xcd]);
+      program.services.Gen.typeResolver as any,
+      'p',
+    ) as { payload: number[] };
+    expect(out.payload).toEqual([0xab, 0xcd]);
   });
 });

--- a/src/__tests__/hex-bytes-v2.test.ts
+++ b/src/__tests__/hex-bytes-v2.test.ts
@@ -1,25 +1,13 @@
 import * as path from 'path';
 import { parseIdlFileV2 } from '../services/sails';
 import { coerceHexToBytesV2, coerceArgsV2, coerceArgsAuto } from '../utils/hex-bytes';
-import type { SailsProgram } from 'sails-js';
+import { TypeResolver, type SailsProgram } from 'sails-js';
 
 const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-v2.idl');
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type V2TypeMap = Map<string, any>;
-
 async function setupProgram() {
   const program = await parseIdlFileV2(FIXTURE_PATH);
-  // Types in v2 live per-service (doc.services[i].types) plus optional
-  // ambient types on doc.program.types. Merge both into a single map.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const doc = (program as any)._doc;
-  const typeMap: V2TypeMap = new Map();
-  for (const t of doc?.program?.types ?? []) typeMap.set(t.name, t);
-  for (const svc of doc?.services ?? []) {
-    for (const t of svc.types ?? []) typeMap.set(t.name, t);
-  }
-  return { program, typeMap };
+  return { program, resolver: program.services.Demo.typeResolver };
 }
 
 // Get the TypeDecl for a specific arg of a specific method.
@@ -30,7 +18,7 @@ function argType(program: SailsProgram, service: string, method: string, argInde
 }
 
 describe('coerceHexToBytesV2', () => {
-  const EMPTY_MAP: V2TypeMap = new Map();
+  const EMPTY_RESOLVER = new TypeResolver([]);
 
   describe('Vec<u8> slice', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,23 +29,23 @@ describe('coerceHexToBytesV2', () => {
     });
 
     it('converts hex string to byte array', () => {
-      expect(coerceHexToBytesV2('0xabcdef', dataType, EMPTY_MAP)).toEqual([0xab, 0xcd, 0xef]);
+      expect(coerceHexToBytesV2('0xabcdef', dataType, EMPTY_RESOLVER)).toEqual([0xab, 0xcd, 0xef]);
     });
 
     it('passes through 0x with no hex digits', () => {
-      expect(coerceHexToBytesV2('0x', dataType, EMPTY_MAP)).toBe('0x');
+      expect(coerceHexToBytesV2('0x', dataType, EMPTY_RESOLVER)).toBe('0x');
     });
 
     it('throws on odd-length hex', () => {
-      expect(() => coerceHexToBytesV2('0xabc', dataType, EMPTY_MAP)).toThrow(/Odd-length/);
+      expect(() => coerceHexToBytesV2('0xabc', dataType, EMPTY_RESOLVER)).toThrow(/Odd-length/);
     });
 
     it('throws on invalid hex characters', () => {
-      expect(() => coerceHexToBytesV2('0xzz', dataType, EMPTY_MAP)).toThrow(/Invalid hex/);
+      expect(() => coerceHexToBytesV2('0xzz', dataType, EMPTY_RESOLVER)).toThrow(/Invalid hex/);
     });
 
     it('passes through non-string values unchanged', () => {
-      expect(coerceHexToBytesV2([1, 2, 3], dataType, EMPTY_MAP)).toEqual([1, 2, 3]);
+      expect(coerceHexToBytesV2([1, 2, 3], dataType, EMPTY_RESOLVER)).toEqual([1, 2, 3]);
     });
   });
 
@@ -71,29 +59,29 @@ describe('coerceHexToBytesV2', () => {
 
     it('converts correct-length hex to bytes', () => {
       const hex = '0x' + '11'.repeat(32);
-      const bytes = coerceHexToBytesV2(hex, hashType, EMPTY_MAP) as number[];
+      const bytes = coerceHexToBytesV2(hex, hashType, EMPTY_RESOLVER) as number[];
       expect(bytes).toHaveLength(32);
       expect(bytes[0]).toBe(0x11);
     });
 
     it('throws on wrong-length hex', () => {
-      expect(() => coerceHexToBytesV2('0xaa', hashType, EMPTY_MAP)).toThrow(/\[u8; 32\]/);
+      expect(() => coerceHexToBytesV2('0xaa', hashType, EMPTY_RESOLVER)).toThrow(/\[u8; 32\]/);
     });
   });
 
   describe('struct with byte fields', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let packetType: any;
-    let typeMap: V2TypeMap;
+    let resolver: TypeResolver;
     beforeAll(async () => {
       const setup = await setupProgram();
-      typeMap = setup.typeMap;
+      resolver = setup.resolver;
       packetType = argType(setup.program, 'Demo', 'SetPacket', 0);
     });
 
     it('recurses into named struct and coerces byte fields', () => {
       const input = { id: 42, payload: '0xabcd', tag: '0x' + '77'.repeat(8) };
-      const out = coerceHexToBytesV2(input, packetType, typeMap) as {
+      const out = coerceHexToBytesV2(input, packetType, resolver) as {
         id: number;
         payload: number[];
         tag: number[];
@@ -105,50 +93,50 @@ describe('coerceHexToBytesV2', () => {
 
     it('throws with field name hint when tag length is wrong', () => {
       const input = { id: 1, payload: '0x', tag: '0xff' };
-      expect(() => coerceHexToBytesV2(input, packetType, typeMap)).toThrow(/"tag"/);
+      expect(() => coerceHexToBytesV2(input, packetType, resolver)).toThrow(/"tag"/);
     });
   });
 
   describe('Option<Packet>', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let maybeType: any;
-    let typeMap: V2TypeMap;
+    let resolver: TypeResolver;
     beforeAll(async () => {
       const setup = await setupProgram();
-      typeMap = setup.typeMap;
+      resolver = setup.resolver;
       maybeType = argType(setup.program, 'Demo', 'SetMaybe', 0);
     });
 
     it('recurses into Option<T> payload', () => {
       const input = { id: 1, payload: '0xaa', tag: '0x' + '00'.repeat(8) };
-      const out = coerceHexToBytesV2(input, maybeType, typeMap) as {
+      const out = coerceHexToBytesV2(input, maybeType, resolver) as {
         payload: number[];
       };
       expect(out.payload).toEqual([0xaa]);
     });
 
     it('passes through null without error', () => {
-      expect(coerceHexToBytesV2(null, maybeType, typeMap)).toBeNull();
+      expect(coerceHexToBytesV2(null, maybeType, resolver)).toBeNull();
     });
   });
 
   describe('enum variant recursion', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let actionType: any;
-    let typeMap: V2TypeMap;
+    let resolver: TypeResolver;
     beforeAll(async () => {
       const setup = await setupProgram();
-      typeMap = setup.typeMap;
+      resolver = setup.resolver;
       actionType = argType(setup.program, 'Demo', 'SetAction', 0);
     });
 
     it('unit variant passes through unchanged', () => {
       const input = { Noop: null };
-      expect(coerceHexToBytesV2(input, actionType, typeMap)).toEqual(input);
+      expect(coerceHexToBytesV2(input, actionType, resolver)).toEqual(input);
     });
 
     it('variant with unnamed [u8; 4] payload coerces hex', () => {
-      const out = coerceHexToBytesV2({ Tag: '0xdeadbeef' }, actionType, typeMap) as { Tag: number[] };
+      const out = coerceHexToBytesV2({ Tag: '0xdeadbeef' }, actionType, resolver) as { Tag: number[] };
       expect(out.Tag).toEqual([0xde, 0xad, 0xbe, 0xef]);
     });
 
@@ -156,7 +144,7 @@ describe('coerceHexToBytesV2', () => {
       const out = coerceHexToBytesV2(
         { Store: { key: 'foo', value: '0x0102' } },
         actionType,
-        typeMap,
+        resolver,
       ) as { Store: { key: string; value: number[] } };
       expect(out.Store.key).toBe('foo');
       expect(out.Store.value).toEqual([0x01, 0x02]);
@@ -166,13 +154,13 @@ describe('coerceHexToBytesV2', () => {
   describe('primitive passthrough', () => {
     it('u32 primitive passes through', () => {
       // Build a synthetic primitive TypeDecl (string literal in v2).
-      expect(coerceHexToBytesV2(42, 'u32', EMPTY_MAP)).toBe(42);
-      expect(coerceHexToBytesV2('hi', 'String', EMPTY_MAP)).toBe('hi');
+      expect(coerceHexToBytesV2(42, 'u32', EMPTY_RESOLVER)).toBe(42);
+      expect(coerceHexToBytesV2('hi', 'String', EMPTY_RESOLVER)).toBe('hi');
     });
 
     it('null/undefined pass through', () => {
-      expect(coerceHexToBytesV2(null, 'u32', EMPTY_MAP)).toBeNull();
-      expect(coerceHexToBytesV2(undefined, 'u32', EMPTY_MAP)).toBeUndefined();
+      expect(coerceHexToBytesV2(null, 'u32', EMPTY_RESOLVER)).toBeNull();
+      expect(coerceHexToBytesV2(undefined, 'u32', EMPTY_RESOLVER)).toBeUndefined();
     });
   });
 });
@@ -180,48 +168,43 @@ describe('coerceHexToBytesV2', () => {
 describe('ActorId primitive', () => {
   const ALICE_SS58 = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
   const ALICE_HEX = '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
-  const EMPTY_MAP: V2TypeMap = new Map();
+  const EMPTY_RESOLVER = new TypeResolver([]);
 
   it('accepts canonical hex unchanged', () => {
-    expect(coerceHexToBytesV2(ALICE_HEX, 'ActorId', EMPTY_MAP)).toBe(ALICE_HEX);
+    expect(coerceHexToBytesV2(ALICE_HEX, 'ActorId', EMPTY_RESOLVER)).toBe(ALICE_HEX);
   });
 
   it('converts SS58 to canonical hex', () => {
-    expect(coerceHexToBytesV2(ALICE_SS58, 'ActorId', EMPTY_MAP)).toBe(ALICE_HEX);
+    expect(coerceHexToBytesV2(ALICE_SS58, 'ActorId', EMPTY_RESOLVER)).toBe(ALICE_HEX);
   });
 
   it('throws on garbage string', () => {
-    expect(() => coerceHexToBytesV2('not-an-address', 'ActorId', EMPTY_MAP)).toThrow(/Invalid ActorId/);
+    expect(() => coerceHexToBytesV2('not-an-address', 'ActorId', EMPTY_RESOLVER)).toThrow(/Invalid ActorId/);
   });
 
   it('throws on wrong-length hex (20-byte Ethereum-style)', () => {
-    expect(() => coerceHexToBytesV2('0x1234567890123456789012345678901234567890', 'ActorId', EMPTY_MAP))
+    expect(() => coerceHexToBytesV2('0x1234567890123456789012345678901234567890', 'ActorId', EMPTY_RESOLVER))
       .toThrow(/Invalid ActorId/);
   });
 
   it('passes through non-string unchanged', () => {
     const preDecoded = Array.from({ length: 32 }, (_, i) => i);
-    expect(coerceHexToBytesV2(preDecoded, 'ActorId', EMPTY_MAP)).toBe(preDecoded);
+    expect(coerceHexToBytesV2(preDecoded, 'ActorId', EMPTY_RESOLVER)).toBe(preDecoded);
   });
 
   it('coerces SS58 inside a struct field (walker recursion)', () => {
-    const typeMap: V2TypeMap = new Map([
-      [
-        'Transfer',
-        {
-          kind: 'struct',
-          name: 'Transfer',
-          fields: [
-            { name: 'to', type: 'ActorId' },
-            { name: 'amount', type: 'u128' },
-          ],
-        },
+    const resolver = new TypeResolver([{
+      kind: 'struct',
+      name: 'Transfer',
+      fields: [
+        { name: 'to', type: 'ActorId' },
+        { name: 'amount', type: 'u128' },
       ],
-    ]);
+    }]);
     const result = coerceHexToBytesV2(
       { to: ALICE_SS58, amount: 100 },
       { kind: 'named', name: 'Transfer' },
-      typeMap,
+      resolver,
     );
     expect(result).toEqual({ to: ALICE_HEX, amount: 100 });
   });

--- a/src/__tests__/hex-bytes-v2.test.ts
+++ b/src/__tests__/hex-bytes-v2.test.ts
@@ -224,7 +224,7 @@ describe('coerceArgsV2', () => {
     expect((args[1] as number[]).length).toBe(32);
   });
 
-  it('returns args unchanged when types map is missing', () => {
+  it('returns args unchanged when resolver lookup fails', () => {
     const fakeProgram = {} as SailsProgram;
     const args = coerceArgsV2(['foo'], [{ name: 'x', typeDef: 'String' }], fakeProgram);
     expect(args).toEqual(['foo']);

--- a/src/__tests__/idl-v2.test.ts
+++ b/src/__tests__/idl-v2.test.ts
@@ -12,6 +12,15 @@ import * as fs from 'fs';
 const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-v2.idl');
 
 describe('IDL v2 façade', () => {
+  it('pins sails-js to the beta.2 release tarball', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8'));
+    const lock = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package-lock.json'), 'utf-8'));
+    const expected = 'https://github.com/gear-tech/sails/releases/download/js%2Fv1.0.0-beta.2/sails-js.tgz';
+    expect(pkg.devDependencies['sails-js']).toBe(expected);
+    expect(lock.packages[''].devDependencies['sails-js']).toBe(expected);
+    expect(lock.packages['node_modules/sails-js'].resolved).toBe(expected);
+  });
+
   it('parses the v2 fixture via parseIdlFileV2', async () => {
     const program = await parseIdlFileV2(FIXTURE_PATH);
     expect(isSailsV2(program)).toBe(true);
@@ -95,5 +104,12 @@ describe('IDL v2 façade', () => {
     expect(payload).toMatch(/^0x[0-9a-fA-F]+$/);
     // Header-only payload: exactly 16 bytes hex-encoded.
     expect(payload).toHaveLength(2 + 16 * 2);
+  });
+
+  it('rejects headerless v2 reply bytes in decodeResult', async () => {
+    const program = await parseIdlFileV2(FIXTURE_PATH);
+    if (!isSailsV2(program)) throw new Error('Expected v2');
+    const query = program.services.Demo.queries.GetPacket;
+    expect(() => query.decodeResult('0x00')).toThrow(/Invalid Sails header/);
   });
 });

--- a/src/__tests__/sails-events-decode.test.ts
+++ b/src/__tests__/sails-events-decode.test.ts
@@ -1,24 +1,10 @@
 /**
  * End-to-end decode tests for `decodeSailsEvent`.
  *
- * Builds a synthetic `UserMessageSent`-shaped object whose payload is a
- * properly-encoded Sails message: 16-byte header (magic / version / hlen
- * / 8-byte interface_id / entry_id u16 LE / route_idx u8 / reserved u8)
- * followed by the SCALE-encoded event payload. The event is decoded
- * against the loaded IDL and the decoded `data` is asserted.
- *
- * Header layout (from sails-js parser-idl-v2/lib/header.js):
- *
- *     bytes 0-1   magic 0x47 0x4D ('GM')
- *     byte  2     version (must be 1)
- *     byte  3     hlen (must be >= 16)
- *     bytes 4-11  interfaceId (8 bytes, big-endian as written by the
- *                 sails-js encoder — the exact byte order is preserved
- *                 in the comparison `interfaceId.asU64() ==
- *                 service.interface_id.asU64()`)
- *     bytes 12-13 entryId u16 little-endian
- *     byte  14    routeIdx
- *     byte  15    reserved (must be 0)
+ * Builds a synthetic `UserMessageSent`-shaped object whose payload uses
+ * beta.2's Sails message header helper followed by a SCALE-encoded event
+ * payload. The event is decoded against the loaded IDL and the decoded
+ * `data` is asserted.
  *
  * `service.interface_id` in the v2 IDL header is `0x...` (8 bytes) and
  * is computed from the service signature; we read it back from the
@@ -27,34 +13,16 @@
  */
 import * as path from 'path';
 import { SailsProgram } from 'sails-js';
+import { InterfaceId, SailsMessageHeader } from 'sails-js/parser';
 import { parseIdlFileV2 } from '../services/sails';
 import { decodeSailsEvent } from '../services/sails-events';
 
 const EVENTS_FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-events.idl');
 const EXTENDS_FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-extends.idl');
 
-const MAGIC = [0x47, 0x4D];
-
 function buildHeader(interfaceIdLike: unknown, entryId: number, routeIdx: number): Uint8Array {
-  const bytes = new Uint8Array(16);
-  bytes[0] = MAGIC[0];
-  bytes[1] = MAGIC[1];
-  bytes[2] = 1; // version
-  bytes[3] = 16; // hlen
-  // interface_id is exposed as an InterfaceId class instance with a `.bytes`
-  // Uint8Array property (see node_modules/sails-js/.../interface-id.js).
-  // The sails-js encoder writes those 8 bytes verbatim into header[4..12],
-  // and tryReadBytes reads them back the same way; we mirror exactly.
-  const idObj = interfaceIdLike as { bytes?: Uint8Array };
-  if (!idObj?.bytes || idObj.bytes.length !== 8) {
-    throw new Error(`expected interface_id with .bytes (length 8), got ${typeof interfaceIdLike}`);
-  }
-  bytes.set(idObj.bytes, 4);
-  bytes[12] = entryId & 0xff;
-  bytes[13] = (entryId >> 8) & 0xff;
-  bytes[14] = routeIdx & 0xff;
-  bytes[15] = 0;
-  return bytes;
+  const interfaceId = InterfaceId.from(interfaceIdLike as Parameters<typeof InterfaceId.from>[0]);
+  return SailsMessageHeader.v1(interfaceId, entryId, routeIdx).toBytes();
 }
 
 function toHex(bytes: Uint8Array): string {

--- a/src/__tests__/sails-events-decode.test.ts
+++ b/src/__tests__/sails-events-decode.test.ts
@@ -145,6 +145,28 @@ describe('decodeSailsEvent — happy paths', () => {
     expect(decoded!.data).toBeNull();
   });
 
+  it('decodes a v2 event through SailsProgram.decodeEvent and normalizes nested u256', async () => {
+    const sails = await parseIdlFileV2(EVENTS_FIXTURE) as SailsProgram;
+    const svc = getServiceWire(sails, 'Walker');
+    const balanceIdx = (svc.events ?? []).findIndex((e) => e.name === 'BalanceChanged');
+    expect(balanceIdx).toBeGreaterThanOrEqual(0);
+    const entryId = svc.events![balanceIdx].entry_id ?? balanceIdx;
+    const header = buildHeader(svc.interface_id!, entryId, getRouteIdx(sails, 'Walker'));
+
+    const amount = new Uint8Array(32);
+    amount[0] = 42;
+    const fullPayload = concat(header, amount);
+
+    const ums = buildUserMessageSent(fullPayload, '0x' + '00'.repeat(32));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const decoded = decodeSailsEvent(sails, ums as any);
+    expect(decoded).toEqual({
+      service: 'Walker',
+      event: 'BalanceChanged',
+      data: { amount: '42' },
+    });
+  });
+
   it('decodes an event from an inherited service via extends (v2)', async () => {
     const sails = await parseIdlFileV2(EXTENDS_FIXTURE) as SailsProgram;
     const baseSvc = getServiceWire(sails, 'Base');

--- a/src/__tests__/sails-events.test.ts
+++ b/src/__tests__/sails-events.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for `services/sails-events.ts`:
  *
- * - listEventNames flattens v2 service.extends recursively (Codex finding #7)
+ * - listEventNames flattens v2 service.extends recursively
  * - resolveEventName accepts Service/Event and bare-name forms
  * - resolveEventName throws AMBIGUOUS_EVENT for multi-service bare names
  * - decodeSailsEvent returns null when no event matches the payload prefix
@@ -34,14 +34,8 @@ describe('listEventNames', () => {
   it('flattens v2 service.extends recursively', async () => {
     const sails: LoadedSails = await parseIdlFileV2(EXTENDS_FIXTURE);
     const names = listEventNames(sails).map((x) => `${x.service}/${x.event}`).sort();
-    // `Composite` extends `Base`, so `BaseEvent` should appear under both
-    // its own declaration AND through Composite's extends chain.
     expect(names).toContain('Base/BaseEvent');
     expect(names).toContain('Composite/OwnEvent');
-    expect(names).toContain('Base/BaseEvent'); // base direct
-    // Walker extends propagation: when traversed via Composite, Base's
-    // events show up under Base's own service name (sails-js wires it
-    // that way in `service.extends`).
   });
 });
 

--- a/src/__tests__/sails-events.test.ts
+++ b/src/__tests__/sails-events.test.ts
@@ -28,7 +28,7 @@ describe('listEventNames', () => {
   it('lists every event in a flat single-service IDL', async () => {
     const sails: LoadedSails = await parseIdlFileV2(EVENTS_FIXTURE);
     const names = listEventNames(sails).map((x) => `${x.service}/${x.event}`).sort();
-    expect(names).toEqual(['Walker/Stopped', 'Walker/StepCount', 'Walker/Walked'].sort());
+    expect(names).toEqual(['Walker/BalanceChanged', 'Walker/Stopped', 'Walker/StepCount', 'Walker/Walked'].sort());
   });
 
   it('flattens v2 service.extends recursively', async () => {

--- a/src/__tests__/type-scoping-v2.test.ts
+++ b/src/__tests__/type-scoping-v2.test.ts
@@ -1,28 +1,30 @@
 /**
  * Two services declaring same-named user types must not collide in arg
- * coercion. Scoping via `serviceName` narrows the type map to the
- * caller's service plus program-level types.
+ * coercion. Scoping via `serviceName` selects the beta.2 service
+ * TypeResolver for the caller's service.
  */
 import * as path from 'path';
-import { parseIdlFileV2, getRegistryTypes } from '../services/sails';
+import { getV2TypeResolver, parseIdlFileV2 } from '../services/sails';
 import { coerceArgsV2 } from '../utils/hex-bytes';
 
 const FIXTURE = path.join(__dirname, 'fixtures', 'sample-v2-collision.idl');
 
 describe('v2 type scoping across services', () => {
-  it('getRegistryTypes with a service name returns only that service\'s types', async () => {
+  it('service TypeResolvers resolve only that service\'s scoped type shape', async () => {
     const program = await parseIdlFileV2(FIXTURE);
 
-    const aMap = getRegistryTypes(program, 'A');
-    const bMap = getRegistryTypes(program, 'B');
-    const flat = getRegistryTypes(program);
+    const aSet = program.services.A.functions.Set;
+    const bSet = program.services.B.functions.Set;
+    const aResolver = getV2TypeResolver(program, 'A');
+    const bResolver = getV2TypeResolver(program, 'B');
 
-    // Each scoped map has its own Packet definition.
-    const aPacket = aMap.get('Packet');
-    const bPacket = bMap.get('Packet');
+    // Each scoped resolver has its own Packet definition.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const aPacket = aResolver.resolveNamed((aSet.args[0] as any).typeDef) as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bPacket = bResolver.resolveNamed((bSet.args[0] as any).typeDef) as any;
     expect(aPacket).toBeDefined();
     expect(bPacket).toBeDefined();
-    expect(aPacket).not.toBe(bPacket);
 
     // Service A's Packet has [u8; 4], service B's has [u8; 8].
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,8 +34,9 @@ describe('v2 type scoping across services', () => {
     expect(aLen).toBe(4);
     expect(bLen).toBe(8);
 
-    // Un-scoped flat map collides — last-service-iterated wins.
-    expect(flat.get('Packet')).toBeDefined();
+    // Program-level resolver intentionally does not see service-local Packet.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(program.typeResolver.resolveNamed((aSet.args[0] as any).typeDef)).toBeUndefined();
   });
 
   it('coerceArgsV2 with service name uses that service\'s type shape', async () => {
@@ -62,15 +65,5 @@ describe('v2 type scoping across services', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       coerceArgsV2([{ payload: '0x01020304' }], bSet.args as any, program, 'B'),
     ).toThrow(/\[u8; 8\]/);
-  });
-
-  it('getRegistryTypes memoizes results per (instance, scope) pair', async () => {
-    const program = await parseIdlFileV2(FIXTURE);
-    const first = getRegistryTypes(program, 'A');
-    const second = getRegistryTypes(program, 'A');
-    // Same Map reference on second call — cached.
-    expect(first).toBe(second);
-    // Different scope, different Map.
-    expect(getRegistryTypes(program, 'B')).not.toBe(first);
   });
 });

--- a/src/__tests__/wasm-section.test.ts
+++ b/src/__tests__/wasm-section.test.ts
@@ -44,6 +44,13 @@ describe('extractSailsIdl', () => {
     await expect(extractSailsIdl(wasm)).resolves.toBe(idl);
   });
 
+  it('returns the beta.2 enveloped IDL before raw-section fallback', async () => {
+    const idl = '!@sails: 1.0.0-beta.2\nservice Counter@0x1234567890abcdef {}';
+    const envelope = new Uint8Array([0x01, 0x00, ...encoder.encode(idl)]);
+    const wasm = buildWasm([{ name: 'sails:idl', payload: envelope }]);
+    await expect(extractSailsIdl(wasm)).resolves.toBe(idl);
+  });
+
   it('returns null when no custom sections are present', async () => {
     await expect(extractSailsIdl(WASM_HEADER)).resolves.toBeNull();
   });

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
-import { loadSailsAuto, describeSailsProgram, suggestMethod, suggestService, type LoadedSails } from '../services/sails';
+import { loadSailsAuto, describeSailsProgram, suggestMethod, suggestService, isSailsV2, type LoadedSails } from '../services/sails';
 import { collectDecodedEvents } from '../services/sails-events';
 import { resolveBlockNumber } from '../services/tx-executor';
 import { validateVoucher } from '../services/voucher-validator';
@@ -359,15 +359,13 @@ async function executeFunction(
   }
 
   const result = await txBuilder.signAndSend();
-  let response;
+  let decoded;
   try {
-    response = await result.response();
+    decoded = await decodeFunctionReply(result, sails, func, serviceName);
   } catch (err) {
     throw classifyProgramError(err);
   }
   const blockNumber = await resolveBlockNumber(api, result.blockHash);
-
-  const decoded = decodeSailsResult(sails, func.returnTypeDef, response, serviceName);
 
   // Phase-correlated block-event scan (#37). Walks system.events() at the
   // inclusion block, restricting to records emitted by OUR extrinsic
@@ -395,4 +393,32 @@ async function executeFunction(
     result: decoded,
     events,
   });
+}
+
+async function decodeFunctionReply(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  result: { response: (rawResult?: boolean) => Promise<any> },
+  sails: LoadedSails,
+  func: { returnTypeDef: unknown },
+  serviceName: string,
+): Promise<unknown> {
+  if (isSailsV2(sails)) {
+    const rawPayload = await result.response(true);
+    const reply = sails.decodeReply(rawPayload);
+    if (reply.kind === 'reply') {
+      const entry = reply.entry as { service: string; fn: string };
+      const replyFunc = sails.services[entry.service]?.functions[entry.fn]
+        ?? sails.services[entry.service]?.queries[entry.fn];
+      return decodeSailsResult(
+        sails,
+        replyFunc?.returnTypeDef ?? func.returnTypeDef,
+        reply.result,
+        entry.service,
+      );
+    }
+    verbose(`decodeFunctionReply: v2 decodeReply returned ${reply.reason}; falling back to builder decode`);
+  }
+
+  const response = await result.response();
+  return decodeSailsResult(sails, func.returnTypeDef, response, serviceName);
 }

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -82,10 +82,7 @@ export function registerCallCommand(program: Command): void {
       const isFunction = methodName in service.functions;
 
       if (!isQuery && !isFunction) {
-        const allMethods = [
-          ...Object.keys(service.functions || {}).map((m) => `${serviceName}/${m} (function)`),
-          ...Object.keys(service.queries || {}).map((m) => `${serviceName}/${m} (query)`),
-        ];
+        const allMethods = listServiceMethods(serviceName, service);
         const hint = suggestMethod(sails, serviceName, methodName);
         const prefix = hint ? `Did you mean: ${hint}? ` : '';
         throw new CliError(
@@ -142,6 +139,18 @@ export function _resolveDryRunPayloadForTests(
     destination: txBuilder.programId,
   };
 }
+
+function listServiceMethods(
+  serviceName: string,
+  service: { functions?: Record<string, unknown>; queries?: Record<string, unknown> },
+): string[] {
+  return [
+    ...Object.keys(service.functions || {}).map((method) => `${serviceName}/${method} (function)`),
+    ...Object.keys(service.queries || {}).map((method) => `${serviceName}/${method} (query)`),
+  ];
+}
+
+export const _listServiceMethodsForTests = listServiceMethods;
 
 /**
  * Build the dry-run output object for a function call.
@@ -419,3 +428,5 @@ async function decodeFunctionReply(
   const response = await result.response();
   return decodeSailsResult(sails, func.returnTypeDef, response, serviceName);
 }
+
+export const _decodeFunctionReplyForTests = decodeFunctionReply;

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { getApi } from '../services/api';
 import { resolveAccount, resolveAddress, AccountOptions } from '../services/account';
-import { loadSailsAuto, describeSailsProgram, suggestMethod, suggestService, isSailsV2, type LoadedSails } from '../services/sails';
+import { loadSailsAuto, suggestMethod, suggestService, isSailsV2, type LoadedSails } from '../services/sails';
 import { collectDecodedEvents } from '../services/sails-events';
 import { resolveBlockNumber } from '../services/tx-executor';
 import { validateVoucher } from '../services/voucher-validator';
@@ -82,11 +82,9 @@ export function registerCallCommand(program: Command): void {
       const isFunction = methodName in service.functions;
 
       if (!isQuery && !isFunction) {
-        const description = describeSailsProgram(sails);
-        const serviceDesc = description[serviceName] as Record<string, Record<string, unknown>>;
         const allMethods = [
-          ...Object.keys(serviceDesc.functions || {}).map((m) => `${serviceName}/${m} (function)`),
-          ...Object.keys(serviceDesc.queries || {}).map((m) => `${serviceName}/${m} (query)`),
+          ...Object.keys(service.functions || {}).map((m) => `${serviceName}/${m} (function)`),
+          ...Object.keys(service.queries || {}).map((m) => `${serviceName}/${m} (query)`),
         ];
         const hint = suggestMethod(sails, serviceName, methodName);
         const prefix = hint ? `Did you mean: ${hint}? ` : '';
@@ -107,7 +105,7 @@ export function registerCallCommand(program: Command): void {
             'VOUCHER_ON_QUERY',
           );
         }
-        await executeQuery(api, sails, serviceName, methodName, args, opts, !!options.dryRun);
+        await executeQuery(sails, serviceName, methodName, args, opts, !!options.dryRun);
       } else {
         await executeFunction(api, sails, serviceName, methodName, args, options, opts, programId);
       }
@@ -210,7 +208,6 @@ export function buildQueryDryRun(input: {
 }
 
 async function executeQuery(
-  _api: unknown,
   sails: LoadedSails,
   serviceName: string,
   methodName: string,
@@ -276,14 +273,13 @@ async function executeFunction(
   //   both together  : encode payload AND compute gas, account required.
   //   neither        : real submission (further down).
   //
-  // _resolveDryRunPayloadForTests is the canonical encoder seam (also
-  // exported as a regression hook). The dry-run+estimate path falls
-  // through to gas calc, which mutates txBuilder via
-  // withAccount/withValue/calculateGas — same instance, no rebuild.
+  // The dry-run+estimate path falls through to gas calc, which mutates
+  // txBuilder via withAccount/withValue/calculateGas — same instance,
+  // no rebuild.
   const txBuilder = func(...args);
-  const { encodedPayload, destination } = _resolveDryRunPayloadForTests(func, txBuilder, args);
 
   if (options.dryRun && !options.estimate) {
+    const { encodedPayload, destination } = _resolveDryRunPayloadForTests(func, txBuilder, args);
     output(buildFunctionDryRun({
       service: serviceName,
       method: methodName,
@@ -324,10 +320,12 @@ async function executeFunction(
   }
 
   if (options.estimate) {
-    const gasLimitStr = (txBuilder.gasInfo as any)?.limit?.toString() ?? txBuilder.gasInfo?.min_limit?.toString() ?? null;
-    const minLimitStr = txBuilder.gasInfo?.min_limit?.toString() ?? null;
+    const gasInfo = txBuilder.gasInfo as { limit?: { toString(): string }; min_limit?: { toString(): string } } | undefined;
+    const gasLimitStr = gasInfo?.limit?.toString() ?? gasInfo?.min_limit?.toString() ?? null;
+    const minLimitStr = gasInfo?.min_limit?.toString() ?? null;
 
     if (options.dryRun) {
+      const { encodedPayload, destination } = _resolveDryRunPayloadForTests(func, txBuilder, args);
       // Composition: dry-run shape with estimateGas appended.
       output(buildFunctionDryRun({
         service: serviceName,
@@ -367,11 +365,10 @@ async function executeFunction(
   }
   const blockNumber = await resolveBlockNumber(api, result.blockHash);
 
-  // Phase-correlated block-event scan (#37). Walks system.events() at the
-  // inclusion block, restricting to records emitted by OUR extrinsic
-  // (via phase index match) and our programId, then runs each through
-  // decodeSailsEvent. Always-on, additive — `events` is a new key, never
-  // replaces or renames anything in the existing reply shape.
+  // Walk system.events() at the inclusion block, restricting to records
+  // emitted by our extrinsic and programId, then decode matching Sails
+  // events. Always-on, additive — `events` is a new key, never replaces or
+  // renames anything in the existing reply shape.
   // sails-js `IMethodReturnType` declares blockHash/txHash as `HexString`
   // (= `0x${string}`) and the runtime (`transaction-builder.js`) returns them
   // already converted via `.toHex()`. No cast needed; pass straight through.

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -172,7 +172,7 @@ export function registerEncodeCommand(program: Command): void {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           // v2 decodeResult expects a 16-byte SailsMessageHeader prefix at the
-          // start of the bytes (see sails-js v1.0.0-beta.1 sails-idl-v2.ts).
+          // start of the bytes.
           // Surface the hint only when we know the IDL is v2 — v1 users
           // would find the header reference misleading.
           const hint = isSailsV2(sails)

--- a/src/services/sails-events.ts
+++ b/src/services/sails-events.ts
@@ -1,10 +1,10 @@
 /**
  * IDL-aware Sails event decoding.
  *
- * Wraps the per-service `events[E].is(...)` / `events[E].decode(...)` surface
- * exposed by both v1 `Sails` and v2 `SailsProgram`. The shapes are identical
- * across versions; the only v2-specific wrinkle is `service.extends`, which
- * pulls in events from inherited services and must be walked recursively.
+ * v2 events prefer `SailsProgram.decodeEvent`, which owns the header routing
+ * and event dispatch table. v1 keeps the per-service `events[E].is(...)` /
+ * `events[E].decode(...)` scan; v2 also falls back to that scan for inherited
+ * service events that are reachable through `service.extends`.
  *
  * Critical invariant the caller MUST honor: sails-js's `events[E].is()` only
  * checks `destination === ZERO_ADDRESS` and the payload prefix — it does NOT
@@ -25,6 +25,8 @@ import { CliError, errorMessage, verbose } from '../utils';
 import { decodeEventData } from '../utils/decode-sails-result';
 import { isSailsV2, type LoadedSails } from './sails';
 
+const ZERO_ADDRESS = '0x' + '00'.repeat(32);
+
 export interface DecodedSailsEvent {
   service: string;
   event: string;
@@ -40,6 +42,38 @@ export interface DecodedSailsEvent {
  * equals the program ID this `sails` instance was bound to.
  */
 export function decodeSailsEvent(
+  sails: LoadedSails,
+  userMessageSent: UserMessageSent,
+): DecodedSailsEvent | null {
+  if (isSailsV2(sails)) {
+    if (!isZeroDestination(userMessageSent)) return null;
+    const payloadHex = userMessageSent.data.message.payload.toHex();
+    const decoded = sails.decodeEvent(payloadHex);
+    if (decoded.kind === 'event') {
+      const entry = decoded.entry as { service: string; event: string };
+      const serviceName = entry.service;
+      const eventName = entry.event;
+      const event = sails.services[serviceName]?.events[eventName];
+      const data = event
+        ? decodeEventData(sails, event.typeDef, decoded.data, serviceName)
+        : decoded.data;
+      return { service: serviceName, event: eventName, data };
+    }
+  }
+
+  return decodeSailsEventViaServices(sails, userMessageSent);
+}
+
+function isZeroDestination(userMessageSent: UserMessageSent): boolean {
+  const destination = userMessageSent.data.message.destination as unknown as {
+    eq?: (other: unknown) => boolean;
+    toHex?: () => string;
+  } | undefined;
+  if (!destination) return false;
+  return destination.eq?.(ZERO_ADDRESS) === true || destination.toHex?.() === ZERO_ADDRESS;
+}
+
+function decodeSailsEventViaServices(
   sails: LoadedSails,
   userMessageSent: UserMessageSent,
 ): DecodedSailsEvent | null {

--- a/src/services/sails-events.ts
+++ b/src/services/sails-events.ts
@@ -13,11 +13,8 @@
  * that check leaks events from other programs that happen to share the same
  * service hash + event id.
  *
- * The decoded payload runs through `decodeEventData` (alias of the shared
- * decode walker in `decode-sails-result.ts`) so that nested `Option<U256>`,
- * `Vec<U256>`, etc. normalize identically to `call` replies — a single
- * source of truth for "decoded JSON shape", per Codex findings #6 + Phase 1
- * issue #32.
+ * The decoded payload runs through `decodeEventData` so nested wide integers
+ * normalize identically to `call` replies.
  */
 import type { GearApi, UserMessageSent, HexString } from '@gear-js/api';
 import type { SailsService } from 'sails-js';
@@ -150,7 +147,7 @@ export function resolveEventName(
 }
 
 /**
- * Phase-correlated block-event scan (Codex finding #1 — high severity).
+ * Phase-correlated block-event scan.
  *
  * Reads `system.events()` at `blockHash`, filters down to records whose
  * `phase.asApplyExtrinsic` matches the index of OUR extrinsic in the

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -788,6 +788,7 @@ function renderEventType(sails: LoadedSails, event: EventLike, serviceName: stri
 }
 
 function renderEventTypeString(type: string): string {
+  if (!type.startsWith('{')) return type;
   try {
     const parsed = JSON.parse(type) as unknown;
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -1,5 +1,5 @@
 import { GearApi } from '@gear-js/api';
-import { Sails, SailsProgram, type SailsService, type Type, type TypeDecl, type TypeResolver } from 'sails-js';
+import { Sails, SailsProgram, type Type, type TypeDecl, type TypeResolver } from 'sails-js';
 import { SailsIdlParser as V1Parser } from 'sails-js-parser';
 import { SailsIdlParser as V2Parser } from 'sails-js/parser';
 import type { Option, Bytes } from '@polkadot/types';
@@ -546,72 +546,31 @@ export function getSailsVersion(sails: LoadedSails): 'v1' | 'v2' {
   return isSailsV2(sails) ? 'v2' : 'v1';
 }
 
-/**
- * Per-instance cache of resolved type maps keyed by service scope.
- * Scoping matters for v2 because same-name types in different services
- * would otherwise collide in a flat global map.
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const registryTypesCache = new WeakMap<LoadedSails, Map<string, Map<string, any>>>();
+const registryTypesCache = new WeakMap<Sails, Map<string, any>>();
 
 /**
- * Get the type-name → user-defined-type map for a loaded Sails instance.
+ * Get the v1 type-name → user-defined-type map for a loaded Sails instance.
  *
- * - v1: reads `sails._program.types` (global flat map; v1 has no service
- *   type scoping). The `serviceName` arg is ignored for v1.
- * - v2: uses beta.2's public `programTypes`, `service.types`, and
- *   `service.extends` accessors. When `serviceName` is provided, the result
- *   includes that service's transitive service-type scope. When omitted, all
- *   program and service types are flattened (caller accepts collision risk).
+ * v2 callers should use beta.2 `TypeResolver` APIs directly, since
+ * service-local type scopes and generics are first-class there. This helper
+ * intentionally remains v1-only.
  *
- * Results are cached per (instance, scope) pair via a WeakMap so subsequent
- * calls are O(1).
- *
- * Returns an empty map if the IDL has no user-defined types.
+ * Returns an empty map if the v1 IDL has no user-defined types.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getRegistryTypes(sails: LoadedSails, serviceName?: string): Map<string, any> {
-  const cacheKey = serviceName ?? '__all__';
-  let scopedCache = registryTypesCache.get(sails);
-  if (!scopedCache) {
-    scopedCache = new Map();
-    registryTypesCache.set(sails, scopedCache);
-  }
-  const cached = scopedCache.get(cacheKey);
+export function getRegistryTypes(sails: Sails): Map<string, any> {
+  const cached = registryTypesCache.get(sails);
   if (cached) return cached;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const map = new Map<string, any>();
-  if (isSailsV2(sails)) {
-    if (serviceName) {
-      const service = sails.services[serviceName];
-      if (service) collectServiceTypes(service, map);
-    } else {
-      for (const t of sails.programTypes.values()) map.set(t.name, t);
-      for (const service of Object.values(sails.services)) collectServiceTypes(service, map);
-    }
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const types = (sails as any)._program?.types as Array<{ name: string; def: unknown }> | undefined;
-    if (types) {
-      for (const t of types) map.set(t.name, t.def);
-    }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const types = (sails as any)._program?.types as Array<{ name: string; def: unknown }> | undefined;
+  if (types) {
+    for (const t of types) map.set(t.name, t.def);
   }
-  scopedCache.set(cacheKey, map);
+  registryTypesCache.set(sails, map);
   return map;
-}
-
-function collectServiceTypes(
-  service: SailsService,
-  map: Map<string, Type>,
-  visited = new WeakSet<object>(),
-): void {
-  if (visited.has(service)) return;
-  visited.add(service);
-  for (const t of service.types.values()) map.set(t.name, t);
-  for (const extended of Object.values(service.extends)) {
-    collectServiceTypes(extended, map, visited);
-  }
 }
 
 export function getV2TypeResolver(sails: SailsProgram, serviceName?: string): TypeResolver {
@@ -628,10 +587,7 @@ export function resolveV2UserType(
   serviceName?: string,
 ): Type | undefined {
   if (serviceName) {
-    const service = sails.services[serviceName];
-    const serviceResolved = service?.typeResolver.resolveNamed(typeDecl);
-    if (serviceResolved) return serviceResolved;
-    return sails.resolveInService(serviceName, typeDecl);
+    return sails.services[serviceName]?.typeResolver.resolveNamed(typeDecl);
   }
   return sails.typeResolver.resolveNamed(typeDecl);
 }

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -870,9 +870,9 @@ export function suggestMethod(
   const exactHits: string[] = [];
   for (const [svcName, svc] of Object.entries(allServices)) {
     const methodNames = new Set([...Object.keys(svc.functions), ...Object.keys(svc.queries)]);
-    for (const m of methodNames) {
-      if (m.toLowerCase() === lowerMethod && !(svcName === serviceName && m === methodName)) {
-        exactHits.push(`${svcName}/${m}`);
+    for (const candidateMethod of methodNames) {
+      if (candidateMethod.toLowerCase() === lowerMethod && !(svcName === serviceName && candidateMethod === methodName)) {
+        exactHits.push(`${svcName}/${candidateMethod}`);
       }
     }
   }
@@ -886,17 +886,17 @@ export function suggestMethod(
   let bestMatches: string[] = [];
   for (const [svcName, svc] of Object.entries(allServices)) {
     const methodNames = new Set([...Object.keys(svc.functions), ...Object.keys(svc.queries)]);
-    for (const m of methodNames) {
+    for (const candidateMethod of methodNames) {
       // Skip identity (shouldn't happen — caller already checked the
       // method is missing — but defensive).
-      if (svcName === serviceName && m === methodName) continue;
-      const d = levenshtein(methodName, m, cap);
-      if (d > cap) continue;
-      if (d < bestDist) {
-        bestDist = d;
-        bestMatches = [`${svcName}/${m}`];
-      } else if (d === bestDist) {
-        bestMatches.push(`${svcName}/${m}`);
+      if (svcName === serviceName && candidateMethod === methodName) continue;
+      const distance = levenshtein(methodName, candidateMethod, cap);
+      if (distance > cap) continue;
+      if (distance < bestDist) {
+        bestDist = distance;
+        bestMatches = [`${svcName}/${candidateMethod}`];
+      } else if (distance === bestDist) {
+        bestMatches.push(`${svcName}/${candidateMethod}`);
       }
     }
   }
@@ -925,15 +925,15 @@ export function suggestService(sails: LoadedSails, serviceName: string): string 
   const cap = 2;
   let bestDist = cap + 1;
   let bestMatches: string[] = [];
-  for (const s of services) {
-    if (s === serviceName) continue;
-    const d = levenshtein(serviceName, s, cap);
-    if (d > cap) continue;
-    if (d < bestDist) {
-      bestDist = d;
-      bestMatches = [s];
-    } else if (d === bestDist) {
-      bestMatches.push(s);
+  for (const candidateService of services) {
+    if (candidateService === serviceName) continue;
+    const distance = levenshtein(serviceName, candidateService, cap);
+    if (distance > cap) continue;
+    if (distance < bestDist) {
+      bestDist = distance;
+      bestMatches = [candidateService];
+    } else if (distance === bestDist) {
+      bestMatches.push(candidateService);
     }
   }
   if (bestMatches.length === 1) return bestMatches[0];

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -1,5 +1,5 @@
 import { GearApi } from '@gear-js/api';
-import { Sails, SailsProgram } from 'sails-js';
+import { Sails, SailsProgram, type SailsService, type Type, type TypeDecl, type TypeResolver } from 'sails-js';
 import { SailsIdlParser as V1Parser } from 'sails-js-parser';
 import { SailsIdlParser as V2Parser } from 'sails-js/parser';
 import type { Option, Bytes } from '@polkadot/types';
@@ -559,18 +559,13 @@ const registryTypesCache = new WeakMap<LoadedSails, Map<string, Map<string, any>
  *
  * - v1: reads `sails._program.types` (global flat map; v1 has no service
  *   type scoping). The `serviceName` arg is ignored for v1.
- * - v2: types live on `_doc.program.types` (program-level, rare) and on
- *   `_doc.services[i].types` (per-service, the common case). When
- *   `serviceName` is provided, the result includes program-level types
- *   PLUS only that service's types — this avoids cross-service
- *   collisions when two services declare the same-named struct/enum.
- *   When `serviceName` is omitted, all service types are flattened
- *   (caller accepts the collision risk; useful for global lookups like
- *   describeSailsProgram iteration).
+ * - v2: uses beta.2's public `programTypes`, `service.types`, and
+ *   `service.extends` accessors. When `serviceName` is provided, the result
+ *   includes that service's transitive service-type scope. When omitted, all
+ *   program and service types are flattened (caller accepts collision risk).
  *
- * Both branches reach into private fields — stable within the
- * 1.0.0-beta line and mirrors v1's access pattern. Results are cached
- * per (instance, scope) pair via a WeakMap so subsequent calls are O(1).
+ * Results are cached per (instance, scope) pair via a WeakMap so subsequent
+ * calls are O(1).
  *
  * Returns an empty map if the IDL has no user-defined types.
  */
@@ -588,22 +583,12 @@ export function getRegistryTypes(sails: LoadedSails, serviceName?: string): Map<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const map = new Map<string, any>();
   if (isSailsV2(sails)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = (sails as any)._doc;
-    // Program-level types (ambient — visible to every service + ctors).
-    const programTypes = doc?.program?.types as Array<{ name: string }> | undefined;
-    if (programTypes) for (const t of programTypes) map.set(t.name, t);
-    // Service-local types.
-    const services = doc?.services as Array<{ name?: string; types?: Array<{ name: string }> }> | undefined;
-    if (services) {
-      if (serviceName) {
-        const target = services.find((s) => s.name === serviceName);
-        if (target?.types) for (const t of target.types) map.set(t.name, t);
-      } else {
-        for (const svc of services) {
-          if (svc.types) for (const t of svc.types) map.set(t.name, t);
-        }
-      }
+    if (serviceName) {
+      const service = sails.services[serviceName];
+      if (service) collectServiceTypes(service, map);
+    } else {
+      for (const t of sails.programTypes.values()) map.set(t.name, t);
+      for (const service of Object.values(sails.services)) collectServiceTypes(service, map);
     }
   } else {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -616,6 +601,41 @@ export function getRegistryTypes(sails: LoadedSails, serviceName?: string): Map<
   return map;
 }
 
+function collectServiceTypes(
+  service: SailsService,
+  map: Map<string, Type>,
+  visited = new WeakSet<object>(),
+): void {
+  if (visited.has(service)) return;
+  visited.add(service);
+  for (const t of service.types.values()) map.set(t.name, t);
+  for (const extended of Object.values(service.extends)) {
+    collectServiceTypes(extended, map, visited);
+  }
+}
+
+export function getV2TypeResolver(sails: SailsProgram, serviceName?: string): TypeResolver {
+  if (serviceName) {
+    const service = sails.services[serviceName];
+    if (service) return service.typeResolver;
+  }
+  return sails.typeResolver;
+}
+
+export function resolveV2UserType(
+  sails: SailsProgram,
+  typeDecl: TypeDecl,
+  serviceName?: string,
+): Type | undefined {
+  if (serviceName) {
+    const service = sails.services[serviceName];
+    const serviceResolved = service?.typeResolver.resolveNamed(typeDecl);
+    if (serviceResolved) return serviceResolved;
+    return sails.resolveInService(serviceName, typeDecl);
+  }
+  return sails.typeResolver.resolveNamed(typeDecl);
+}
+
 /**
  * Describe a Sails type definition as a human-readable string.
  *
@@ -623,12 +643,20 @@ export function getRegistryTypes(sails: LoadedSails, serviceName?: string): Map<
  * v2 delegates to SailsProgram.typeResolver.getTypeDeclString which already
  * produces a canonical string representation (e.g. "Option<Vec<u8>>").
  */
-export function describeType(sails: LoadedSails, typeDef: unknown): string {
+export function describeType(sails: LoadedSails, typeDef: unknown, serviceName?: string): string {
   if (isSailsV2(sails)) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return sails.typeResolver.getTypeDeclString(typeDef as any);
+      return getV2TypeResolver(sails, serviceName).getTypeDeclString(typeDef as TypeDecl);
     } catch {
+      if (!serviceName) {
+        for (const service of Object.values(sails.services)) {
+          try {
+            return service.typeResolver.getTypeDeclString(typeDef as TypeDecl);
+          } catch {
+            // Try the next service scope before falling through.
+          }
+        }
+      }
       return 'unknown';
     }
   }
@@ -726,9 +754,9 @@ interface EventLike {
  * v1 events have no `.type` field; the v1 walker handles them via
  * `describeType(sails, event.typeDef)`.
  */
-function renderEventType(sails: LoadedSails, event: EventLike): string {
+function renderEventType(sails: LoadedSails, event: EventLike, serviceName: string): string {
   // v2: fast path when the library already stringified the type.
-  if (typeof event.type === 'string') return event.type;
+  if (typeof event.type === 'string') return renderEventTypeString(event.type);
 
   // v2 named-field case: typeDef is IServiceEvent with a `fields` array.
   if (isSailsV2(sails)) {
@@ -737,16 +765,16 @@ function renderEventType(sails: LoadedSails, event: EventLike): string {
     if (Array.isArray(fields) && fields.length > 0) {
       // All fields named: render as struct.
       if (fields.every((f) => typeof f.name === 'string' && f.name.length > 0)) {
-        const parts = fields.map((f) => `${f.name}: ${describeType(sails, f.type)}`);
+        const parts = fields.map((f) => `${f.name}: ${describeType(sails, f.type, serviceName)}`);
         return `{ ${parts.join(', ')} }`;
       }
       // All fields unnamed: render as tuple.
       if (fields.every((f) => !f.name)) {
-        const parts = fields.map((f) => describeType(sails, f.type));
+        const parts = fields.map((f) => describeType(sails, f.type, serviceName));
         return parts.length === 1 ? parts[0] : `(${parts.join(', ')})`;
       }
       // Mixed: fall back to struct form, skipping unnamed slots.
-      const parts = fields.map((f, i) => `${f.name ?? `_${i}`}: ${describeType(sails, f.type)}`);
+      const parts = fields.map((f, i) => `${f.name ?? `_${i}`}: ${describeType(sails, f.type, serviceName)}`);
       return `{ ${parts.join(', ')} }`;
     }
     // Empty fields on a v2 event means unit variant; library usually
@@ -756,7 +784,22 @@ function renderEventType(sails: LoadedSails, event: EventLike): string {
   }
 
   // v1 fallback: walk the v1 TypeDef accessor shape.
-  return describeType(sails, event.typeDef);
+  return describeType(sails, event.typeDef, serviceName);
+}
+
+function renderEventTypeString(type: string): string {
+  try {
+    const parsed = JSON.parse(type) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const entries = Object.entries(parsed as Record<string, unknown>);
+      if (entries.length > 0 && entries.every(([, value]) => typeof value === 'string')) {
+        return `{ ${entries.map(([key, value]) => `${key}: ${value}`).join(', ')} }`;
+      }
+    }
+  } catch {
+    // Non-JSON type strings like "Null", "u32", and "Option<u32>" pass through.
+  }
+  return type;
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -914,9 +957,9 @@ export function describeSailsProgram(sails: LoadedSails): Record<string, unknown
       functions[funcName] = {
         args: func.args.map((a) => ({
           name: a.name,
-          type: describeType(sails, a.typeDef),
+          type: describeType(sails, a.typeDef, serviceName),
         })),
-        returnType: describeType(sails, func.returnTypeDef),
+        returnType: describeType(sails, func.returnTypeDef, serviceName),
         docs: func.docs || null,
       };
     }
@@ -925,16 +968,16 @@ export function describeSailsProgram(sails: LoadedSails): Record<string, unknown
       queries[queryName] = {
         args: query.args.map((a) => ({
           name: a.name,
-          type: describeType(sails, a.typeDef),
+          type: describeType(sails, a.typeDef, serviceName),
         })),
-        returnType: describeType(sails, query.returnTypeDef),
+        returnType: describeType(sails, query.returnTypeDef, serviceName),
         docs: query.docs || null,
       };
     }
 
     for (const [eventName, event] of Object.entries(service.events)) {
       events[eventName] = {
-        type: renderEventType(sails, event),
+        type: renderEventType(sails, event, serviceName),
         docs: event.docs || null,
       };
     }

--- a/src/services/wasm-section.ts
+++ b/src/services/wasm-section.ts
@@ -1,17 +1,12 @@
 /**
  * Extract the `sails:idl` custom section from a Gear program's WASM blob.
  *
- * sails-js >= 1.0.0-beta.1 embeds the IDL as a WASM custom section named
- * `sails:idl` (see sails/rs/idl-embed/src/lib.rs). For any v2 program whose
- * code is on-chain, this gives a deterministic IDL source without needing
- * a registry or out-of-band file.
- *
- * Uses `WebAssembly.compile()` — the async variant that offloads compilation
- * to a worker thread. The sync `new WebAssembly.Module()` would block the
- * event loop for tens to low-hundreds of milliseconds on typical hundreds-
- * of-KB WASMs; with a 10MB size cap upstream, that could reach ~1s in the
- * worst case. Async is strictly better.
+ * Sails-JS owns the v2 IDL envelope format, so this module routes through its
+ * public extractor first. The small raw-section fallback keeps older beta.1
+ * programs readable because they embedded plain UTF-8 text directly in the
+ * same custom section before the beta.2 envelope was introduced.
  */
+import { extractIdlFromWasm } from 'sails-js/parser';
 
 const SECTION_NAME = 'sails:idl';
 
@@ -20,18 +15,19 @@ const SECTION_NAME = 'sails:idl';
  * or `null` if the section is absent (e.g. v1 program, or sails < 1.0.0-beta.1).
  *
  * Throws when:
- * - `WebAssembly.compile` rejects the bytes as not a valid WASM module.
- * - The `sails:idl` payload is not valid UTF-8 (fatal TextDecoder) —
- *   a corrupt section is a real bug worth surfacing, not silent fallback.
+ * - the bytes are not a valid WASM module/envelope.
+ * - the `sails:idl` payload is not valid UTF-8.
  */
 export async function extractSailsIdl(wasm: Uint8Array): Promise<string | null> {
-  // Copy into a fresh ArrayBuffer-backed view so `WebAssembly.compile` is
-  // happy regardless of whether the caller's buffer is ArrayBuffer or
-  // SharedArrayBuffer (TS's BufferSource type only accepts the former).
+  const enveloped = await extractIdlFromWasm(wasm);
+  if (enveloped !== null) return enveloped;
+  return extractRawSailsIdl(wasm);
+}
+
+async function extractRawSailsIdl(wasm: Uint8Array): Promise<string | null> {
   const bytes = new Uint8Array(wasm);
   const mod = await WebAssembly.compile(bytes);
   const sections = WebAssembly.Module.customSections(mod, SECTION_NAME);
   if (sections.length === 0) return null;
-  const decoder = new TextDecoder('utf-8', { fatal: true });
-  return decoder.decode(sections[0]);
+  return new TextDecoder('utf-8', { fatal: true }).decode(sections[0]);
 }

--- a/src/types/sails-js-parser.d.ts
+++ b/src/types/sails-js-parser.d.ts
@@ -1,6 +1,6 @@
 // Type shim for the `sails-js/parser` subpath export.
 //
-// sails-js 1.0.0-beta.1 publishes the v2 IDL parser under the `exports` field
+// sails-js 1.0.0-beta.x publishes the v2 IDL parser under the `exports` field
 // at "./parser". With `moduleResolution: "node"` TypeScript does not respect
 // package `exports`, so we redirect it here.
 //

--- a/src/utils/decode-sails-result.ts
+++ b/src/utils/decode-sails-result.ts
@@ -20,20 +20,22 @@
  *     isStruct, asStruct, isEnum, asEnum, isResult, asResult, isMap, asMap,
  *     isFixedSizeArray, asFixedSizeArray, isUserDefined, asUserDefined }
  *
- * V2 typeDef shape (verified against sails-js 1.0.0-beta.1 parser output):
+ * V2 typeDef shape (sails-js 1.0.0-beta.2 parser output):
  *   Node = string | { kind, ... }
  *   - bare string      → primitive name, e.g. "u32", "String", "u256"
+ *   - {kind:"generic"} → { name } — type parameter leaf inside raw generic definitions
  *   - {kind:"named"}   → { name, generics?: Node[] } — Option / Result / user-defined
  *   - {kind:"tuple"}   → { types: Node[] }
  *   - {kind:"slice"}   → { item: Node }            — `vec T`
  *   - {kind:"array"}   → { item: Node, len: number } — `[T; N]`
- *   User-defined types (_doc.services[i].types):
+ *   User-defined types (resolved through beta.2 TypeResolver):
  *     { name, kind:"struct", fields: [{name, type}] }
  *     { name, kind:"enum",   variants: [{name, fields: [{name?, type}]}] }
  */
 
-import { LoadedSails, isSailsV2, getRegistryTypes, describeType } from '../services/sails';
+import { LoadedSails, isSailsV2, getRegistryTypes, describeType, resolveV2UserType } from '../services/sails';
 import { verbose } from './output';
+import type { SailsProgram, Type, TypeDecl } from 'sails-js';
 
 type V2Node = string | { kind: string; [k: string]: unknown };
 
@@ -181,7 +183,7 @@ function v1VariantIsUnit(def: V1TypeDef): boolean {
 // V2 walker — object form (kind-discriminated)
 // ────────────────────────────────────────────────────────────────────────
 
-function walkV2(sails: LoadedSails, node: V2Node, value: unknown, serviceName: string): unknown {
+function walkV2(sails: SailsProgram, node: V2Node, value: unknown, serviceName: string): unknown {
   if (typeof node === 'string') return decodePrimitive(normalizePrimV2(node), value);
 
   switch (node.kind) {
@@ -204,6 +206,9 @@ function walkV2(sails: LoadedSails, node: V2Node, value: unknown, serviceName: s
       return items.map((t, i) => walkV2(sails, t, value[i], serviceName));
     }
 
+    case 'generic':
+      return value;
+
     case 'named': {
       const name = node.name as string;
       const generics = (node.generics as V2Node[] | undefined) ?? [];
@@ -217,10 +222,9 @@ function walkV2(sails: LoadedSails, node: V2Node, value: unknown, serviceName: s
           (err) => walkV2(sails, generics[1], err, serviceName),
         );
       }
-      // User-defined type — resolve from registry, then recurse on its body.
-      const resolved = getRegistryTypes(sails, serviceName).get(name) as
-        | { kind?: string; fields?: Array<{ name?: string; type: V2Node }>; variants?: Array<{ name: string; fields?: Array<{ name?: string; type: V2Node }> }> }
-        | undefined;
+      // User-defined type — resolve through the scoped beta.2 resolver so
+      // same-named service types do not collide and generics are concrete.
+      const resolved = resolveV2UserType(sails, node as unknown as TypeDecl, serviceName) as V2UserType | undefined;
       if (!resolved) return fallback(sails, node, value, `user-defined type "${name}" not in registry`);
       return walkV2UserType(sails, resolved, value, serviceName);
     }
@@ -231,8 +235,8 @@ function walkV2(sails: LoadedSails, node: V2Node, value: unknown, serviceName: s
 }
 
 function walkV2UserType(
-  sails: LoadedSails,
-  udt: { kind?: string; fields?: Array<{ name?: string; type: V2Node }>; variants?: Array<{ name: string; fields?: Array<{ name?: string; type: V2Node }> }> },
+  sails: SailsProgram,
+  udt: V2UserType,
   value: unknown,
   serviceName: string,
 ): unknown {
@@ -241,7 +245,7 @@ function walkV2UserType(
     const isTuple = fields.length > 0 && fields.every((f) => !f.name);
     if (isTuple) {
       if (!Array.isArray(value)) return fallback(sails, udt, value, 'expected tuple-struct value to be an array');
-      return fields.map((f, i) => walkV2(sails, f.type, value[i], serviceName));
+      return fields.map((f, i) => walkV2(sails, f.type as V2Node, value[i], serviceName));
     }
     if (value == null || typeof value !== 'object' || Array.isArray(value)) {
       return fallback(sails, udt, value, 'expected struct value to be an object');
@@ -267,7 +271,7 @@ function walkV2UserType(
 }
 
 function walkV2EnumPayload(
-  sails: LoadedSails,
+  sails: SailsProgram,
   variant: { fields?: Array<{ name?: string; type: V2Node }> },
   payload: unknown,
   serviceName: string,
@@ -291,8 +295,13 @@ function walkV2EnumPayload(
   }
   // Mixed — tuple-like.
   if (!Array.isArray(payload)) return fallback(sails, variant, payload, 'expected tuple-shaped enum payload to be an array');
-  return fields.map((f, i) => walkV2(sails, f.type, payload[i], serviceName));
+  return fields.map((f, i) => walkV2(sails, f.type as V2Node, payload[i], serviceName));
 }
+
+type V2UserType = Type & {
+  fields?: Array<{ name?: string; type: V2Node }>;
+  variants?: Array<{ name: string; fields?: Array<{ name?: string; type: V2Node }> }>;
+};
 
 function normalizePrimV2(s: string): string {
   // Lowercase then strip underscores so snake_case ("actor_id") and

--- a/src/utils/decode-sails-result.ts
+++ b/src/utils/decode-sails-result.ts
@@ -8,8 +8,7 @@
  * for any codec wider than JSON numbers can hold (U256, u128, u64 in some
  * configurations). The result: top-level U256 gets a decimal string, but the
  * same U256 nested inside Option / Vec / struct stays as raw hex. Agents
- * wrapping the CLI have to re-parse those hex blobs, which is the bug
- * reported in issue #32.
+ * wrapping the CLI would otherwise have to re-parse those hex blobs.
  *
  * This does not replace sails-js decoding. It walks the declared return type
  * against an already-decoded JS value and rewrites numeric leaves (hex string

--- a/src/utils/decode-sails-result.ts
+++ b/src/utils/decode-sails-result.ts
@@ -1,5 +1,6 @@
 /**
- * Post-process a sails-js query/function reply into a fully-decoded JSON tree.
+ * Normalize a sails-js decoded value into the stable JSON shape exposed by
+ * vara-wallet.
  *
  * Motivation: sails-js decodes the top-level codec with toBigInt/toString for a
  * handful of primitives and with .toJSON() for everything else. Polkadot's
@@ -10,10 +11,9 @@
  * wrapping the CLI have to re-parse those hex blobs, which is the bug
  * reported in issue #32.
  *
- * Fix: walk the declared return type (ISailsTypeDef) against the already-
- * decoded JS value and rewrite numeric leaves (hex string OR bigint) to a
- * decimal string. The walker is type-driven, not value-driven, so we never
- * confuse an ActorId hex with a numeric hex.
+ * This does not replace sails-js decoding. It walks the declared return type
+ * against an already-decoded JS value and rewrites numeric leaves (hex string
+ * OR bigint) to decimal strings.
  *
  * V1 typeDef shape (from sails-js-types 0.5.1 accessor interface):
  *   { isPrimitive, asPrimitive, isOptional, asOptional, isVec, asVec,
@@ -28,6 +28,7 @@
  *   - {kind:"tuple"}   → { types: Node[] }
  *   - {kind:"slice"}   → { item: Node }            — `vec T`
  *   - {kind:"array"}   → { item: Node, len: number } — `[T; N]`
+ *   - {fields:[...]}   → service event payload wrapper
  *   User-defined types (resolved through beta.2 TypeResolver):
  *     { name, kind:"struct", fields: [{name, type}] }
  *     { name, kind:"enum",   variants: [{name, fields: [{name?, type}]}] }
@@ -36,7 +37,7 @@
 import { isSailsV2, getRegistryTypes, describeType, resolveV2UserType } from '../services/sails';
 import { verbose } from './output';
 import type { LoadedSails } from '../services/sails';
-import type { SailsProgram, Type, TypeDecl } from 'sails-js';
+import type { Sails, SailsProgram, Type, TypeDecl } from 'sails-js';
 
 type V2Node = string | { kind: string; [k: string]: unknown };
 
@@ -76,7 +77,7 @@ function walk(sails: LoadedSails, typeDef: unknown, value: unknown, serviceName:
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type V1TypeDef = any;
 
-function walkV1(sails: LoadedSails, td: V1TypeDef, value: unknown, serviceName: string): unknown {
+function walkV1(sails: Sails, td: V1TypeDef, value: unknown, serviceName: string): unknown {
   if (td.isPrimitive) return decodePrimitive(primitiveV1Name(td.asPrimitive), value);
 
   if (td.isOptional) return decodeOption(value, (inner) => walkV1(sails, td.asOptional.def, inner, serviceName));
@@ -138,7 +139,7 @@ function walkV1(sails: LoadedSails, td: V1TypeDef, value: unknown, serviceName: 
   }
 
   if (td.isUserDefined) {
-    const resolved = getRegistryTypes(sails, serviceName).get(td.asUserDefined.name);
+    const resolved = getRegistryTypes(sails).get(td.asUserDefined.name);
     if (!resolved) return fallback(sails, td, value, `user-defined type "${td.asUserDefined.name}" not in registry`);
     return walkV1(sails, resolved, value, serviceName);
   }
@@ -186,6 +187,9 @@ function v1VariantIsUnit(def: V1TypeDef): boolean {
 
 function walkV2(sails: SailsProgram, node: V2Node, value: unknown, serviceName: string): unknown {
   if (typeof node === 'string') return decodePrimitive(normalizePrimV2(node), value);
+  if (Array.isArray(node.fields)) {
+    return walkV2EventFields(sails, node as { fields?: Array<{ name?: string; type: V2Node }> }, value, serviceName);
+  }
 
   switch (node.kind) {
     case 'slice': {
@@ -233,6 +237,31 @@ function walkV2(sails: SailsProgram, node: V2Node, value: unknown, serviceName: 
     default:
       return fallback(sails, node, value, `unrecognized v2 node kind "${node.kind}"`);
   }
+}
+
+function walkV2EventFields(
+  sails: SailsProgram,
+  event: { fields?: Array<{ name?: string; type: V2Node }> },
+  value: unknown,
+  serviceName: string,
+): unknown {
+  const fields = event.fields ?? [];
+  if (fields.length === 0) return null;
+  if (fields.length === 1 && !fields[0].name) {
+    return walkV2(sails, fields[0].type, value, serviceName);
+  }
+  if (fields.every((f) => !!f.name)) {
+    if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+      return fallback(sails, event, value, 'expected event payload to be an object');
+    }
+    return decodeStructFields(
+      fields.map((f) => ({ name: f.name as string, def: f.type as unknown })),
+      value as Record<string, unknown>,
+      (fdef, fvalue) => walkV2(sails, fdef as V2Node, fvalue, serviceName),
+    );
+  }
+  if (!Array.isArray(value)) return fallback(sails, event, value, 'expected tuple-shaped event payload to be an array');
+  return fields.map((f, i) => walkV2(sails, f.type, value[i], serviceName));
 }
 
 function walkV2UserType(

--- a/src/utils/decode-sails-result.ts
+++ b/src/utils/decode-sails-result.ts
@@ -33,8 +33,9 @@
  *     { name, kind:"enum",   variants: [{name, fields: [{name?, type}]}] }
  */
 
-import { LoadedSails, isSailsV2, getRegistryTypes, describeType, resolveV2UserType } from '../services/sails';
+import { isSailsV2, getRegistryTypes, describeType, resolveV2UserType } from '../services/sails';
 import { verbose } from './output';
+import type { LoadedSails } from '../services/sails';
 import type { SailsProgram, Type, TypeDecl } from 'sails-js';
 
 type V2Node = string | { kind: string; [k: string]: unknown };
@@ -318,8 +319,8 @@ function normalizePrimV2(s: string): string {
   if (lower === 'char') return 'char';
   if (lower === 'null' || lower === '()') return 'null';
   // ints — u8..u256, i8..i128, nonzero-*
-  const m = lower.match(/^(?:nonzero)?(u|i)(\d+)$/);
-  if (m) return `${m[1]}${m[2]}`;
+  const intMatch = lower.match(/^(?:nonzero)?(u|i)(\d+)$/);
+  if (intMatch) return `${intMatch[1]}${intMatch[2]}`;
   return lower;
 }
 
@@ -369,14 +370,12 @@ function decodeOption(value: unknown, decodeInner: (v: unknown) => unknown): unk
   if (value == null) return null;
   // Belt-and-suspenders: unwrap {Some: x} / {None: null} if polkadot ever emits
   // the non-flattened shape (it usually doesn't).
-  if (typeof value === 'object' && !Array.isArray(value)) {
-    const obj = value as Record<string, unknown>;
-    const keys = Object.keys(obj);
-    if (keys.length === 1) {
-      const k = keys[0].toLowerCase();
-      if (k === 'none') return null;
-      if (k === 'some') return decodeInner(obj[keys[0]]);
-    }
+  const entry = singleObjectEntry(value);
+  if (entry) {
+    const [key, inner] = entry;
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === 'none') return null;
+    if (lowerKey === 'some') return decodeInner(inner);
   }
   return decodeInner(value);
 }
@@ -386,14 +385,12 @@ function decodeResult(
   decodeOk: (v: unknown) => unknown,
   decodeErr: (v: unknown) => unknown,
 ): unknown {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    const obj = value as Record<string, unknown>;
-    const keys = Object.keys(obj);
-    if (keys.length === 1) {
-      const k = keys[0].toLowerCase();
-      if (k === 'ok') return { kind: 'Ok', value: decodeOk(obj[keys[0]]) };
-      if (k === 'err') return { kind: 'Err', value: decodeErr(obj[keys[0]]) };
-    }
+  const entry = singleObjectEntry(value);
+  if (entry) {
+    const [key, payload] = entry;
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === 'ok') return { kind: 'Ok', value: decodeOk(payload) };
+    if (lowerKey === 'err') return { kind: 'Err', value: decodeErr(payload) };
   }
   return value;
 }
@@ -419,26 +416,31 @@ function decodeEnum(
 ): unknown {
   // Unit variant emitted as a bare string.
   if (typeof value === 'string') {
-    const match = variants.find((v) => v.name.toLowerCase() === value.toLowerCase());
+    const lowerValue = value.toLowerCase();
+    const match = variants.find((v) => v.name.toLowerCase() === lowerValue);
     if (match) return { kind: match.name };
     return value;
   }
   // Payload variant emitted as {variantName: payload}.
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    const keys = Object.keys(value as Record<string, unknown>);
-    if (keys.length === 1) {
-      const jsonKey = keys[0];
-      const match = variants.find((v) => v.name.toLowerCase() === jsonKey.toLowerCase()
-        || lowerFirst(v.name) === jsonKey);
-      if (match) {
-        const payload = (value as Record<string, unknown>)[jsonKey];
-        if (isUnit(match.def)) return { kind: match.name };
-        const decoded = decodeVariant(match.def, payload);
-        return decoded === undefined ? { kind: match.name } : { kind: match.name, value: decoded };
-      }
+  const entry = singleObjectEntry(value);
+  if (entry) {
+    const [jsonKey, payload] = entry;
+    const lowerJsonKey = jsonKey.toLowerCase();
+    const match = variants.find((v) => v.name.toLowerCase() === lowerJsonKey || lowerFirst(v.name) === jsonKey);
+    if (match) {
+      if (isUnit(match.def)) return { kind: match.name };
+      const decoded = decodeVariant(match.def, payload);
+      return decoded === undefined ? { kind: match.name } : { kind: match.name, value: decoded };
     }
   }
   return value;
+}
+
+function singleObjectEntry(value: unknown): [string, unknown] | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  return keys.length === 1 ? [keys[0], obj[keys[0]]] : null;
 }
 
 function findKeyCaseInsensitiveFirst(obj: Record<string, unknown>, declared: string): string | undefined {

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -6,6 +6,8 @@ import { getRegistryTypes, getV2TypeResolver } from '../services/sails';
 const HEX_RE = /^0x[0-9a-fA-F]+$/;
 const ACTOR_ID_HEX_RE = /^0x[0-9a-fA-F]{64}$/;
 
+type FixedU8ArrayMatch = { match: true; len: number } | { match: false };
+
 /**
  * Check if a typeDef represents `vec u8`.
  */
@@ -22,7 +24,7 @@ function isVecU8(typeDef: any): boolean {
  * Check if a typeDef represents `[u8; N]`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isFixedU8Array(typeDef: any): { match: boolean; len?: number } {
+function isFixedU8Array(typeDef: any): FixedU8ArrayMatch {
   if (
     typeDef.isFixedSizeArray &&
     typeDef.asFixedSizeArray.def.isPrimitive &&
@@ -63,13 +65,6 @@ function hexToBytes(value: string, fieldHint?: string): number[] {
   return Array.from(Buffer.from(hex, 'hex'));
 }
 
-/**
- * If `value` is a `0x`-prefixed hex string, convert it to a byte array.
- * When `expectedLen` is provided, throw if the decoded length doesn't
- * match — used by `[u8; N]` and fixed-width array branches. Returns
- * the value unchanged if it isn't a hex string (so downstream encoders
- * can accept pre-decoded bytes).
- */
 /**
  * Coerce an ActorId arg: accept canonical 32-byte hex as-is (byte-identical
  * with pre-ActorId-SS58 behavior), or SS58 via `addressToHex`. Non-string
@@ -116,6 +111,13 @@ function tryActorIdToHex(value: unknown, fieldHint?: string): unknown {
   }
 }
 
+/**
+ * If `value` is a `0x`-prefixed hex string, convert it to a byte array.
+ * When `expectedLen` is provided, throw if the decoded length doesn't
+ * match — used by `[u8; N]` and fixed-width array branches. Returns
+ * the value unchanged if it isn't a hex string (so downstream encoders
+ * can accept pre-decoded bytes).
+ */
 function tryHexToBytes(value: unknown, fieldHint?: string, expectedLen?: number): unknown {
   if (!isNonEmptyHex(value)) return value;
   const bytes = hexToBytes(value, fieldHint);
@@ -161,12 +163,6 @@ export function coerceHexToBytes(value: unknown, typeDef: any, typeMap: TypeMap,
   // Struct: recurse into each field
   if (typeDef.isStruct && typeof value === 'object' && !Array.isArray(value)) {
     const struct = typeDef.asStruct;
-    if (struct.isTuple && Array.isArray(value)) {
-      // Tuple struct: recurse by index
-      return struct.fields.map((f: { def: unknown }, i: number) =>
-        coerceHexToBytes((value as unknown[])[i], f.def, typeMap, fieldHint),
-      );
-    }
     const result: Record<string, unknown> = { ...(value as Record<string, unknown>) };
     for (const field of struct.fields) {
       if (field.name in result) {
@@ -210,7 +206,7 @@ export function coerceHexToBytes(value: unknown, typeDef: any, typeMap: TypeMap,
 
   // Vec (non-u8): recurse into elements
   if (typeDef.isVec && Array.isArray(value)) {
-    return value.map((item, i) => coerceHexToBytes(item, typeDef.asVec.def, typeMap, fieldHint));
+    return value.map((item) => coerceHexToBytes(item, typeDef.asVec.def, typeMap, fieldHint));
   }
 
   // Map: recurse into values
@@ -302,7 +298,7 @@ function isV2SliceU8(typeDecl: V2TypeDecl): boolean {
   return typeof typeDecl === 'object' && typeDecl.kind === 'slice' && isV2PrimitiveU8(typeDecl.item);
 }
 
-function isV2ArrayU8(typeDecl: V2TypeDecl): { match: boolean; len?: number } {
+function isV2ArrayU8(typeDecl: V2TypeDecl): FixedU8ArrayMatch {
   if (typeof typeDecl === 'object' && typeDecl.kind === 'array' && isV2PrimitiveU8(typeDecl.item)) {
     return { match: true, len: typeDecl.len };
   }
@@ -336,7 +332,7 @@ export function coerceHexToBytesV2(
 
   // Fixed array of u8 → bytes with length validation
   const fixed = isV2ArrayU8(typeDecl);
-  if (fixed.match && fixed.len !== undefined) return tryHexToBytes(value, fieldHint, fixed.len);
+  if (fixed.match) return tryHexToBytes(value, fieldHint, fixed.len);
 
   // PrimitiveType (string literal): no byte fields to coerce
   if (typeof typeDecl === 'string') return value;

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -279,15 +279,9 @@ type V2TypeDecl =
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type V2Type = any; // struct | enum | alias — loose to avoid deep type churn
 
-type V2TypeMap = Map<string, V2Type>;
-type V2TypeLookup = V2TypeMap | TypeResolver;
-
-function resolveV2UserType(typeDecl: V2TypeDecl, typeLookup: V2TypeLookup): V2Type | undefined {
+function resolveV2UserType(typeDecl: V2TypeDecl, typeResolver: TypeResolver): V2Type | undefined {
   if (typeof typeDecl === 'string' || typeDecl.kind !== 'named') return undefined;
-  if ('resolveNamed' in typeLookup) {
-    return typeLookup.resolveNamed(typeDecl as TypeDecl);
-  }
-  return typeLookup.get(typeDecl.name);
+  return typeResolver.resolveNamed(typeDecl as TypeDecl);
 }
 
 function isV2PrimitiveU8(typeDecl: V2TypeDecl): boolean {
@@ -316,7 +310,7 @@ function isV2ArrayU8(typeDecl: V2TypeDecl): FixedU8ArrayMatch {
 export function coerceHexToBytesV2(
   value: unknown,
   typeDecl: V2TypeDecl,
-  typeLookup: V2TypeLookup,
+  typeResolver: TypeResolver,
   fieldHint?: string,
 ): unknown {
   if (value === null || value === undefined) return value;
@@ -340,7 +334,7 @@ export function coerceHexToBytesV2(
   // Slice (non-u8): recurse elements
   if (typeDecl.kind === 'slice') {
     if (Array.isArray(value)) {
-      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeLookup, fieldHint));
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeResolver, fieldHint));
     }
     return value;
   }
@@ -348,7 +342,7 @@ export function coerceHexToBytesV2(
   // Array (non-u8): recurse elements
   if (typeDecl.kind === 'array') {
     if (Array.isArray(value)) {
-      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeLookup, fieldHint));
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeResolver, fieldHint));
     }
     return value;
   }
@@ -356,7 +350,7 @@ export function coerceHexToBytesV2(
   // Tuple: recurse by index
   if (typeDecl.kind === 'tuple') {
     if (Array.isArray(value)) {
-      return typeDecl.types.map((t, i) => coerceHexToBytesV2((value as unknown[])[i], t, typeLookup, fieldHint));
+      return typeDecl.types.map((t, i) => coerceHexToBytesV2((value as unknown[])[i], t, typeResolver, fieldHint));
     }
     return value;
   }
@@ -371,12 +365,12 @@ export function coerceHexToBytesV2(
 
     // Well-known wrappers.
     if (name === 'Option' && generics && generics.length === 1) {
-      return coerceHexToBytesV2(value, generics[0], typeLookup, fieldHint);
+      return coerceHexToBytesV2(value, generics[0], typeResolver, fieldHint);
     }
     if (name === 'Result' && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
       const obj = value as Record<string, unknown>;
-      if ('ok' in obj) return { ok: coerceHexToBytesV2(obj.ok, generics[0], typeLookup, 'ok') };
-      if ('err' in obj) return { err: coerceHexToBytesV2(obj.err, generics[1], typeLookup, 'err') };
+      if ('ok' in obj) return { ok: coerceHexToBytesV2(obj.ok, generics[0], typeResolver, 'ok') };
+      if ('err' in obj) return { err: coerceHexToBytesV2(obj.err, generics[1], typeResolver, 'err') };
       return value;
     }
     if (name === 'Vec' && generics && generics.length === 1) {
@@ -384,25 +378,25 @@ export function coerceHexToBytesV2(
       // Vec<u8> → bytes via hex coercion
       if (isV2PrimitiveU8(inner)) return tryHexToBytes(value, fieldHint);
       if (Array.isArray(value)) {
-        return value.map((item) => coerceHexToBytesV2(item, inner, typeLookup, fieldHint));
+        return value.map((item) => coerceHexToBytesV2(item, inner, typeResolver, fieldHint));
       }
       return value;
     }
     if ((name === 'Map' || name === 'BTreeMap' || name === 'HashMap') && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
       const result: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-        result[k] = coerceHexToBytesV2(v, generics[1], typeLookup, k);
+        result[k] = coerceHexToBytesV2(v, generics[1], typeResolver, k);
       }
       return result;
     }
 
-    // User-defined type: look up in type resolver/map and recurse.
-    const userType = resolveV2UserType(typeDecl, typeLookup);
+    // User-defined type: look up in the scoped beta.2 resolver and recurse.
+    const userType = resolveV2UserType(typeDecl, typeResolver);
     if (!userType) return value; // Unknown type, pass through
 
     // Alias: recurse into target.
     if (userType.kind === 'alias' && userType.target) {
-      return coerceHexToBytesV2(value, userType.target, typeLookup, fieldHint);
+      return coerceHexToBytesV2(value, userType.target, typeResolver, fieldHint);
     }
 
     // Struct: recurse into fields
@@ -411,7 +405,7 @@ export function coerceHexToBytesV2(
       const result: Record<string, unknown> = { ...(value as Record<string, unknown>) };
       for (const field of fields) {
         if (field.name && field.name in result) {
-          result[field.name] = coerceHexToBytesV2(result[field.name], field.type, typeLookup, field.name);
+          result[field.name] = coerceHexToBytesV2(result[field.name], field.type, typeResolver, field.name);
         }
       }
       return result;
@@ -420,7 +414,7 @@ export function coerceHexToBytesV2(
     // Struct (tuple-shaped — all fields unnamed): recurse by index
     if (userType.kind === 'struct' && userType.fields && Array.isArray(value)) {
       const fields = userType.fields as Array<{ name?: string; type: V2TypeDecl }>;
-      return fields.map((f, i) => coerceHexToBytesV2((value as unknown[])[i], f.type, typeLookup, f.name));
+      return fields.map((f, i) => coerceHexToBytesV2((value as unknown[])[i], f.type, typeResolver, f.name));
     }
 
     // Enum: match variant and recurse into payload fields
@@ -435,21 +429,21 @@ export function coerceHexToBytesV2(
           const payload = obj[variant.name];
           if (variant.fields.length === 1 && !variant.fields[0].name) {
             // Single unnamed field: payload is the raw value
-            return { [variant.name]: coerceHexToBytesV2(payload, variant.fields[0].type, typeLookup, variant.name) };
+            return { [variant.name]: coerceHexToBytesV2(payload, variant.fields[0].type, typeResolver, variant.name) };
           }
           // Struct-shaped variant payload
           if (typeof payload === 'object' && payload !== null && !Array.isArray(payload)) {
             const result: Record<string, unknown> = { ...(payload as Record<string, unknown>) };
             for (const f of variant.fields) {
               if (f.name && f.name in result) {
-                result[f.name] = coerceHexToBytesV2(result[f.name], f.type, typeLookup, f.name);
+                result[f.name] = coerceHexToBytesV2(result[f.name], f.type, typeResolver, f.name);
               }
             }
             return { [variant.name]: result };
           }
           // Tuple-shaped variant payload (array)
           if (Array.isArray(payload)) {
-            return { [variant.name]: variant.fields.map((f, i) => coerceHexToBytesV2((payload as unknown[])[i], f.type, typeLookup, f.name)) };
+            return { [variant.name]: variant.fields.map((f, i) => coerceHexToBytesV2((payload as unknown[])[i], f.type, typeResolver, f.name)) };
           }
           return value;
         }
@@ -479,16 +473,16 @@ export function coerceArgsV2(
 ): unknown[] {
   if (args.length === 0) return args;
 
-  let typeLookup: V2TypeLookup;
+  let typeResolver: TypeResolver;
   try {
-    typeLookup = getV2TypeResolver(program, serviceName);
+    typeResolver = getV2TypeResolver(program, serviceName);
   } catch {
     return args; // Graceful fallback
   }
 
   return args.map((arg, i) => {
     if (i >= argDefs.length) return arg;
-    return coerceHexToBytesV2(arg, argDefs[i].typeDef, typeLookup, argDefs[i].name);
+    return coerceHexToBytesV2(arg, argDefs[i].typeDef, typeResolver, argDefs[i].name);
   });
 }
 

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -279,11 +279,6 @@ type V2TypeDecl =
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type V2Type = any; // struct | enum | alias — loose to avoid deep type churn
 
-function resolveV2UserType(typeDecl: V2TypeDecl, typeResolver: TypeResolver): V2Type | undefined {
-  if (typeof typeDecl === 'string' || typeDecl.kind !== 'named') return undefined;
-  return typeResolver.resolveNamed(typeDecl as TypeDecl);
-}
-
 function isV2PrimitiveU8(typeDecl: V2TypeDecl): boolean {
   return typeof typeDecl === 'string' && typeDecl === 'u8';
 }
@@ -391,7 +386,7 @@ export function coerceHexToBytesV2(
     }
 
     // User-defined type: look up in the scoped beta.2 resolver and recurse.
-    const userType = resolveV2UserType(typeDecl, typeResolver);
+    const userType = typeResolver.resolveNamed(typeDecl as TypeDecl) as V2Type | undefined;
     if (!userType) return value; // Unknown type, pass through
 
     // Alias: recurse into target.
@@ -490,9 +485,9 @@ export function coerceArgsV2(
  * Dispatch coerceArgs to the v1 or v2 walker based on the Sails instance type.
  * This is what generic commands (call, encode, program) should call.
  *
- * `serviceName` is v2-only — it narrows the type map to one service's
- * types to avoid cross-service name collisions. Ignored for v1 (which
- * has a single global type namespace).
+ * `serviceName` is v2-only — it selects the service TypeResolver to avoid
+ * cross-service name collisions. Ignored for v1, which has one global type
+ * namespace.
  */
 export function coerceArgsAuto(
   args: unknown[],

--- a/src/utils/hex-bytes.ts
+++ b/src/utils/hex-bytes.ts
@@ -1,7 +1,7 @@
-import { SailsProgram, type Sails } from 'sails-js';
+import { SailsProgram, type Sails, type TypeDecl, type TypeResolver } from 'sails-js';
 import { CliError } from './errors';
 import { addressToHex } from './address';
-import { getRegistryTypes } from '../services/sails';
+import { getRegistryTypes, getV2TypeResolver } from '../services/sails';
 
 const HEX_RE = /^0x[0-9a-fA-F]+$/;
 const ACTOR_ID_HEX_RE = /^0x[0-9a-fA-F]{64}$/;
@@ -244,12 +244,7 @@ export function coerceArgs(
   // Build type map from sails internal program types
   let typeMap: TypeMap;
   try {
-    typeMap = new Map();
-    const types = sails._program?.types;
-    if (!types) return args; // No type info available, pass through
-    for (const t of types) {
-      typeMap.set(t.name, t.def);
-    }
+    typeMap = getRegistryTypes(sails);
   } catch {
     return args; // Graceful fallback
   }
@@ -268,6 +263,7 @@ export function coerceArgs(
 //   - { kind: 'slice',  item: TypeDecl }
 //   - { kind: 'array',  item: TypeDecl, len: number }
 //   - { kind: 'tuple',  types: TypeDecl[] }
+//   - { kind: 'generic', name: string }
 //   - { kind: 'named',  name: string, generics?: TypeDecl[] }
 //
 // User-defined types (from program.types) are separate `Type` entries:
@@ -281,12 +277,22 @@ type V2TypeDecl =
   | { kind: 'slice'; item: V2TypeDecl }
   | { kind: 'array'; item: V2TypeDecl; len: number }
   | { kind: 'tuple'; types: V2TypeDecl[] }
+  | { kind: 'generic'; name: string }
   | { kind: 'named'; name: string; generics?: V2TypeDecl[] };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type V2Type = any; // struct | enum | alias — loose to avoid deep type churn
 
 type V2TypeMap = Map<string, V2Type>;
+type V2TypeLookup = V2TypeMap | TypeResolver;
+
+function resolveV2UserType(typeDecl: V2TypeDecl, typeLookup: V2TypeLookup): V2Type | undefined {
+  if (typeof typeDecl === 'string' || typeDecl.kind !== 'named') return undefined;
+  if ('resolveNamed' in typeLookup) {
+    return typeLookup.resolveNamed(typeDecl as TypeDecl);
+  }
+  return typeLookup.get(typeDecl.name);
+}
 
 function isV2PrimitiveU8(typeDecl: V2TypeDecl): boolean {
   return typeof typeDecl === 'string' && typeDecl === 'u8';
@@ -303,49 +309,21 @@ function isV2ArrayU8(typeDecl: V2TypeDecl): { match: boolean; len?: number } {
   return { match: false };
 }
 
-type V2Substitutions = Map<string, V2TypeDecl>;
-
-/**
- * Resolve a single-level type_param reference. If `typeDecl` is a bare
- * named reference (no generics of its own) and its name matches an entry
- * in `subs`, return the substituted TypeDecl. Otherwise return `typeDecl`
- * unchanged.
- *
- * One-level only: if `subs` maps T → Option<U> and U itself is also a
- * type_param, the consumer recursion resolves U when it walks into the
- * Option's inner type.
- */
-function resolveV2Subs(typeDecl: V2TypeDecl, subs?: V2Substitutions): V2TypeDecl {
-  if (!subs || typeof typeDecl === 'string') return typeDecl;
-  if (typeDecl.kind === 'named' && (!typeDecl.generics || typeDecl.generics.length === 0) && subs.has(typeDecl.name)) {
-    return subs.get(typeDecl.name) as V2TypeDecl;
-  }
-  return typeDecl;
-}
-
 /**
  * v2 equivalent of coerceHexToBytes.
  * Walks a TypeDecl (v2 IDL shape) and converts hex strings to byte arrays
  * for `vec u8` (slice<u8>, Vec<u8>) and `[u8; N]` fields.
  *
- * `substitutions` carries generic type_param bindings down through the
- * recursion. When a user-defined type has `type_params` and the call site
- * supplied matching `generics`, we build a new substitution scope for
- * that type's body. Type-param references inside field/variant types
- * resolve against the scope when the walker recurses.
+ * Generic user-defined types are resolved through the beta.2 TypeResolver,
+ * which returns a concrete copy with `{ kind: 'generic' }` leaves substituted.
  */
 export function coerceHexToBytesV2(
   value: unknown,
   typeDecl: V2TypeDecl,
-  typeMap: V2TypeMap,
+  typeLookup: V2TypeLookup,
   fieldHint?: string,
-  substitutions?: V2Substitutions,
 ): unknown {
   if (value === null || value === undefined) return value;
-
-  // Resolve type_param references at entry so every branch below works
-  // on the fully-substituted TypeDecl.
-  typeDecl = resolveV2Subs(typeDecl, substitutions);
 
   // ActorId primitive: accept SS58 or canonical hex, normalize to hex.
   // MUST precede the `typeof typeDecl === 'string'` fallthrough below —
@@ -366,7 +344,7 @@ export function coerceHexToBytesV2(
   // Slice (non-u8): recurse elements
   if (typeDecl.kind === 'slice') {
     if (Array.isArray(value)) {
-      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint, substitutions));
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeLookup, fieldHint));
     }
     return value;
   }
@@ -374,7 +352,7 @@ export function coerceHexToBytesV2(
   // Array (non-u8): recurse elements
   if (typeDecl.kind === 'array') {
     if (Array.isArray(value)) {
-      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeMap, fieldHint, substitutions));
+      return value.map((item) => coerceHexToBytesV2(item, typeDecl.item, typeLookup, fieldHint));
     }
     return value;
   }
@@ -382,8 +360,12 @@ export function coerceHexToBytesV2(
   // Tuple: recurse by index
   if (typeDecl.kind === 'tuple') {
     if (Array.isArray(value)) {
-      return typeDecl.types.map((t, i) => coerceHexToBytesV2((value as unknown[])[i], t, typeMap, fieldHint, substitutions));
+      return typeDecl.types.map((t, i) => coerceHexToBytesV2((value as unknown[])[i], t, typeLookup, fieldHint));
     }
+    return value;
+  }
+
+  if (typeDecl.kind === 'generic') {
     return value;
   }
 
@@ -391,54 +373,40 @@ export function coerceHexToBytesV2(
   if (typeDecl.kind === 'named') {
     const { name, generics } = typeDecl;
 
-    // Well-known wrappers — pass current substitutions through.
+    // Well-known wrappers.
     if (name === 'Option' && generics && generics.length === 1) {
-      return coerceHexToBytesV2(value, generics[0], typeMap, fieldHint, substitutions);
+      return coerceHexToBytesV2(value, generics[0], typeLookup, fieldHint);
     }
     if (name === 'Result' && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
       const obj = value as Record<string, unknown>;
-      if ('ok' in obj) return { ok: coerceHexToBytesV2(obj.ok, generics[0], typeMap, 'ok', substitutions) };
-      if ('err' in obj) return { err: coerceHexToBytesV2(obj.err, generics[1], typeMap, 'err', substitutions) };
+      if ('ok' in obj) return { ok: coerceHexToBytesV2(obj.ok, generics[0], typeLookup, 'ok') };
+      if ('err' in obj) return { err: coerceHexToBytesV2(obj.err, generics[1], typeLookup, 'err') };
       return value;
     }
     if (name === 'Vec' && generics && generics.length === 1) {
-      // Resolve once so isV2PrimitiveU8 sees the substituted inner type.
-      const inner = resolveV2Subs(generics[0], substitutions);
+      const inner = generics[0];
       // Vec<u8> → bytes via hex coercion
       if (isV2PrimitiveU8(inner)) return tryHexToBytes(value, fieldHint);
       if (Array.isArray(value)) {
-        return value.map((item) => coerceHexToBytesV2(item, inner, typeMap, fieldHint, substitutions));
+        return value.map((item) => coerceHexToBytesV2(item, inner, typeLookup, fieldHint));
       }
       return value;
     }
     if ((name === 'Map' || name === 'BTreeMap' || name === 'HashMap') && generics && generics.length === 2 && typeof value === 'object' && !Array.isArray(value)) {
       const result: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-        result[k] = coerceHexToBytesV2(v, generics[1], typeMap, k, substitutions);
+        result[k] = coerceHexToBytesV2(v, generics[1], typeLookup, k);
       }
       return result;
     }
 
-    // User-defined type: look up in type map and recurse.
-    const userType = typeMap.get(name);
+    // User-defined type: look up in type resolver/map and recurse.
+    const userType = resolveV2UserType(typeDecl, typeLookup);
     if (!userType) return value; // Unknown type, pass through
 
-    // Build a new substitution scope from this type's type_params. Resolve
-    // each supplied generic through the OUTER substitutions first (so
-    // a caller-side `Foo<T>` where T is an outer type_param binds to the
-    // outer value, not to the literal T).
-    let nextSubs = substitutions;
-    const typeParams = (userType.type_params ?? []) as Array<{ name: string }>;
-    if (typeParams.length > 0 && generics && generics.length === typeParams.length) {
-      nextSubs = new Map();
-      for (let i = 0; i < typeParams.length; i++) {
-        nextSubs.set(typeParams[i].name, resolveV2Subs(generics[i], substitutions));
-      }
-    }
-
-    // Alias: recurse into target with the new substitution scope.
+    // Alias: recurse into target.
     if (userType.kind === 'alias' && userType.target) {
-      return coerceHexToBytesV2(value, userType.target, typeMap, fieldHint, nextSubs);
+      return coerceHexToBytesV2(value, userType.target, typeLookup, fieldHint);
     }
 
     // Struct: recurse into fields
@@ -447,7 +415,7 @@ export function coerceHexToBytesV2(
       const result: Record<string, unknown> = { ...(value as Record<string, unknown>) };
       for (const field of fields) {
         if (field.name && field.name in result) {
-          result[field.name] = coerceHexToBytesV2(result[field.name], field.type, typeMap, field.name, nextSubs);
+          result[field.name] = coerceHexToBytesV2(result[field.name], field.type, typeLookup, field.name);
         }
       }
       return result;
@@ -456,7 +424,7 @@ export function coerceHexToBytesV2(
     // Struct (tuple-shaped — all fields unnamed): recurse by index
     if (userType.kind === 'struct' && userType.fields && Array.isArray(value)) {
       const fields = userType.fields as Array<{ name?: string; type: V2TypeDecl }>;
-      return fields.map((f, i) => coerceHexToBytesV2((value as unknown[])[i], f.type, typeMap, f.name, nextSubs));
+      return fields.map((f, i) => coerceHexToBytesV2((value as unknown[])[i], f.type, typeLookup, f.name));
     }
 
     // Enum: match variant and recurse into payload fields
@@ -471,21 +439,21 @@ export function coerceHexToBytesV2(
           const payload = obj[variant.name];
           if (variant.fields.length === 1 && !variant.fields[0].name) {
             // Single unnamed field: payload is the raw value
-            return { [variant.name]: coerceHexToBytesV2(payload, variant.fields[0].type, typeMap, variant.name, nextSubs) };
+            return { [variant.name]: coerceHexToBytesV2(payload, variant.fields[0].type, typeLookup, variant.name) };
           }
           // Struct-shaped variant payload
           if (typeof payload === 'object' && payload !== null && !Array.isArray(payload)) {
             const result: Record<string, unknown> = { ...(payload as Record<string, unknown>) };
             for (const f of variant.fields) {
               if (f.name && f.name in result) {
-                result[f.name] = coerceHexToBytesV2(result[f.name], f.type, typeMap, f.name, nextSubs);
+                result[f.name] = coerceHexToBytesV2(result[f.name], f.type, typeLookup, f.name);
               }
             }
             return { [variant.name]: result };
           }
           // Tuple-shaped variant payload (array)
           if (Array.isArray(payload)) {
-            return { [variant.name]: variant.fields.map((f, i) => coerceHexToBytesV2((payload as unknown[])[i], f.type, typeMap, f.name, nextSubs)) };
+            return { [variant.name]: variant.fields.map((f, i) => coerceHexToBytesV2((payload as unknown[])[i], f.type, typeLookup, f.name)) };
           }
           return value;
         }
@@ -502,15 +470,10 @@ export function coerceHexToBytesV2(
 /**
  * Coerce args for a Sails v2 method/constructor call.
  *
- * When `serviceName` is provided, the type map is scoped to that
- * service's types + program-level types — avoiding collisions when
- * two services declare the same-named struct. Pass undefined for
- * ctor encoding (ctors are program-level) or when the caller accepts
- * the flatten-all-services semantics.
- *
- * Type lookups route through `getRegistryTypes` (memoized per
- * instance+scope) so the private-`_doc` walk happens in exactly one
- * place in the codebase.
+ * When `serviceName` is provided, type lookup uses that service's beta.2
+ * `TypeResolver`, which resolves service-local generics and avoids collisions
+ * when two services declare the same-named struct. Pass undefined for ctor
+ * encoding, where program-level types are in scope.
  */
 export function coerceArgsV2(
   args: unknown[],
@@ -520,16 +483,16 @@ export function coerceArgsV2(
 ): unknown[] {
   if (args.length === 0) return args;
 
-  let typeMap: V2TypeMap;
+  let typeLookup: V2TypeLookup;
   try {
-    typeMap = getRegistryTypes(program, serviceName);
+    typeLookup = getV2TypeResolver(program, serviceName);
   } catch {
     return args; // Graceful fallback
   }
 
   return args.map((arg, i) => {
     if (i >= argDefs.length) return arg;
-    return coerceHexToBytesV2(arg, argDefs[i].typeDef, typeMap, argDefs[i].name);
+    return coerceHexToBytesV2(arg, argDefs[i].typeDef, typeLookup, argDefs[i].name);
   });
 }
 


### PR DESCRIPTION
## Summary

- Upgrades `vara-wallet` to `@gear-js/api` / `sails-js` `js/v1.0.0-beta.2` and bumps the package release to `v0.18.0`.
- Replaces local Sails WASM IDL section parsing with beta.2 `extractIdlFromWasm`, while preserving the raw beta.1 `sails:idl` fallback for older contracts.
- Moves Sails v2 type coercion onto the public `TypeResolver` APIs, including service-scoped generic user types, so the CLI no longer maintains flattened v2 type maps.
- Uses beta.2 `SailsProgram.decodeReply` and `decodeEvent` for v2 replies/events, with local normalization kept only for CLI JSON output and wide integer rendering.
- Simplifies Sails call/dry-run method handling and removes stale workaround TODOs that beta.2 now covers.
- Updates README, agent docs, and skill docs to match the current embedded-IDL/cache-based flow.

## Test Coverage

Coverage gate: PASS, 100% for the upgrade plan after ship-generated regression tests.

- Baseline: 54 suites / 630 tests on `origin/main`.
- Final: 54 suites / 637 tests at `1670919`.
- Added coverage for v2 submitted-function reply decoding, beta.2 enveloped WASM IDL extraction, and the `METHOD_NOT_FOUND` method-listing path.

## Pre-Landing Review

No blocking code-review findings. The initial coverage review found three concrete Sails beta.2 gaps; all were fixed before landing and covered by tests.

## Design Review

Skipped: no frontend or user-interface files changed.

## Eval Results

Skipped: no prompt, agent-routing, or eval-target files changed.

## Greptile Review

No active Greptile/GitHub review comments were present for this PR head.

## Scope Drift

Clean. The PR stayed within the requested Sails beta.2 upgrade and simplification scope: dependency bump, IDL extraction, resolver usage, reply/event decoding, docs, changelog, and tests.

## Plan Completion

- Replaced the local WASM IDL parser with Sails-JS beta.2 `extractIdlFromWasm`.
- Moved v2 type lookup to public `TypeResolver` APIs and kept v1 maps centralized.
- Added beta.2 regression coverage for IDL extraction, type scoping/generics, reply decoding, and CLI method errors.
- Removed or updated stale Sails workaround TODOs.

## Verification Results

- `rtk npm run build` passed.
- `rtk npm test -- --runInBand` passed: 54 suites, 637 tests.
- `rtk git diff --check` passed.
- GitHub CI passed: 2/2 checks green for `1670919d3e32cc060333a7c483dd51d6bc955d09`.

## TODOs

`TODOS.md` was updated to remove stale beta.1 workaround items and point remaining payload-codec cleanup at the new beta.2 decoder surface. No unrelated TODOs were changed.

## Documentation

- README.md: documented Sails v2 beta.2 header-aware reply/event decoding and the beta.1 raw `sails:idl` fallback.
- CLAUDE.md: updated the Sails service architecture note from stale meta-storage wording to local file, on-chain WASM extraction, and cache-based IDL loading.
- AGENTS.md: replaced removed `VARA_META_STORAGE` guidance with embedded `sails:idl` auto-extraction and `idl import` guidance.
- SKILL.md: corrected Sails call units to `human|raw` and updated IDL resolution to the current embedded-section/cache flow.

### Documentation Debt

- `docs/sails-js-upstream-proposals.md` is still a historical beta.1 upstream-proposal note. It should get a follow-up status pass against beta.2 to mark which resolver/type export proposals are resolved, partially resolved, or still open.
