### PR TITLE
[codex] Fix embedded Sails v1 IDL assumptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ vara-wallet discover 0x1234... --idl ./program.idl
 # Returns: all services, functions, queries, events with argument types
 ```
 
-For v2 programs with an embedded `sails:idl` WASM section, you can omit `--idl`:
+For programs with an embedded `sails:idl` WASM section, including Sails 0.10.4 IDL v1 programs, you can omit `--idl`:
 
 ```bash
 vara-wallet discover 0x1234...
@@ -368,7 +368,7 @@ over regex matching on `.error`.
 | `INVALID_ADDRESS` | Wrong shape for `actor_id` field | Pass a hex string (`0x` + 64 chars), SS58 address, or 32-byte array. Field name is in the message: `Invalid ActorId for "<field>": ...`. |
 | `TX_TIMEOUT` | Transaction didn't land in 60s | Retry — network may be congested |
 | `TX_FAILED` | On-chain failure | Check events in output for details |
-| `IDL_NOT_FOUND` | No Sails IDL available | If error says "This is a v1 contract": `vara-wallet idl import <path.idl> --program <id>`. Otherwise pass `--idl <path>` for one-off use. |
+| `IDL_NOT_FOUND` | No Sails IDL available | If the error says the WASM has no `sails:idl` custom section, run `vara-wallet idl import <path.idl> --program <id>`. Otherwise pass `--idl <path>` for one-off use. |
 | `PROGRAM_ERROR` | Program execution failed (panic/error variant) | Read `meta.programMessage` for the contract-level cause. State problems (e.g. `BetTokenTransferFromFailed`) are not gas problems — fix the state, do not increase `--gas-limit`. |
 
 ## Addresses
@@ -489,7 +489,7 @@ echo $RESULT | jq '.events[] | select(.section == "balances" and .method == "Tra
 
 3. **Sails queries vs functions.** `call` auto-detects whether a method is a query (read-only, free) or function (state-changing, needs gas). You don't need to specify.
 
-4. **IDL resolution.** The `call`, `discover`, and `vft` commands need a Sails IDL. For v2 programs, vara-wallet auto-extracts the embedded `sails:idl` section from on-chain WASM and caches it locally. For v1 programs or overrides, provide `--idl <path>` or import the IDL with `vara-wallet idl import`.
+4. **IDL resolution.** The `call`, `discover`, and `vft` commands need a Sails IDL. For programs with an embedded `sails:idl` section, vara-wallet auto-extracts the IDL from on-chain WASM and caches it locally; this includes plain-text Sails IDL v1 (for example Sails 0.10.4) and v2 envelope formats. For programs without a usable embedded IDL, or for overrides, provide `--idl <path>` or import the IDL with `vara-wallet idl import`.
 
 5. **Hex strings for byte arrays.** When a Sails method expects `vec u8` or `[u8; N]`, you can pass hex strings like `"0xabcdef..."` in `--args` and they'll be auto-converted to byte arrays. No need to manually convert hex to number arrays.
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ High-level method invocation on Sails programs. Auto-detects queries vs function
 vara-wallet call <programId> <Service/Method> [--args <json> | --args-file <path>] [--value <v>] [--units human|raw] [--gas-limit <n>] [--idl <path>] [--voucher <id>] [--estimate] [--dry-run]
 ```
 
-For v2 programs (sails ≥ 1.0.0-beta.1) the IDL is auto-resolved from the program's on-chain WASM — `--idl` is only needed for v1 programs (use `idl import`) or when overriding with a local file. Resolved IDLs are cached under `~/.vara-wallet/idl-cache/` so subsequent calls skip the fetch. Inspect or evict the cache with `vara-wallet idl list/remove/clear`.
+For programs that embed a `sails:idl` custom section, the IDL is auto-resolved from the program's on-chain WASM. This includes plain-text Sails IDL v1 (for example Sails 0.10.4) and v2 envelope formats. `--idl` is only needed when a program has no usable embedded IDL, or when overriding with a local file. Resolved IDLs are cached under `~/.vara-wallet/idl-cache/` so subsequent calls skip the fetch. Inspect or evict the cache with `vara-wallet idl list/remove/clear`.
 
 `--args-file <path>` reads the JSON args from a file instead of the `--args` string; use `-` for stdin (`echo '[...]' | vara-wallet call ... --args-file -`). Eliminates shell-escape failures with nested JSON containing hex actor IDs or 64-byte `vec u8` signatures. Mutually exclusive with `--args` (`INVALID_ARGS_SOURCE`).
 
@@ -217,7 +217,7 @@ For v2 programs (sails ≥ 1.0.0-beta.1) the IDL is auto-resolved from the progr
 
 The JSON response from a real submission includes an `events: [...]` field with any decoded Sails events emitted by the call, phase-correlated to the submitting extrinsic (cross-transaction events from the same block are excluded). Nested numeric leaves (`U256`, `u128`) inside `Option`, `Vec`, tuples, structs, enums, `Result`, or user types are recursively decoded to decimal strings to match the declared IDL return type.
 
-With Sails v2 beta.2 programs, function replies and emitted events are decoded through the header-aware `sails-js` reply/event decoders before vara-wallet normalizes the JSON shape. Older beta.1-style embedded IDL sections still load through the raw `sails:idl` fallback, so existing deployed programs remain readable.
+With Sails v2 beta.2 programs, function replies and emitted events are decoded through the header-aware `sails-js` reply/event decoders before vara-wallet normalizes the JSON shape. Plain-text embedded IDLs, including Sails IDL v1 and older beta.1-style v2 sections, still load through the raw `sails:idl` fallback, so existing deployed programs remain readable.
 
 ### `discover` (Sails)
 
@@ -231,7 +231,7 @@ Same auto-resolution as `call`.
 
 ### `idl` (Sails IDL cache)
 
-Manage the local IDL cache at `~/.vara-wallet/idl-cache/`. The cache is populated automatically when v2 programs auto-resolve their IDL from on-chain WASM, or manually via `idl import` for v1 programs (no embedded IDL section).
+Manage the local IDL cache at `~/.vara-wallet/idl-cache/`. The cache is populated automatically when programs auto-resolve their IDL from on-chain WASM, or manually via `idl import` for programs without a usable embedded IDL section.
 
 ```bash
 vara-wallet idl import <path.idl> (--code-id <hex> | --program <hex|ss58>)
@@ -437,7 +437,7 @@ The `--hex` flag treats input as 0x-prefixed hex bytes (strict validation: even-
 | `NO_ACCOUNT` | No account configured |
 | `TX_TIMEOUT` | Transaction not included in 60s |
 | `TX_FAILED` | On-chain extrinsic failure |
-| `IDL_NOT_FOUND` | No Sails IDL available. Distinguishes v1 contracts (no `sails:idl` WASM section — import manually) from chain-unavailable cases (RPC down, no program) |
+| `IDL_NOT_FOUND` | No Sails IDL available. Distinguishes readable WASM with no `sails:idl` section from chain-unavailable cases (RPC down, no program) |
 | `INVALID_ARGS_FORMAT` | `--args` shape mismatch. Sails methods take positional args; pass as JSON array. 1-arg struct methods also accept bare `{...}` (wrapped automatically) |
 | `INVALID_ADDRESS` | `actor_id` field received a non-string non-array value. Message names the offending field: `Invalid ActorId for "<name>": ...` |
 | `METHOD_NOT_FOUND` | Method not in Sails IDL |

--- a/src/__tests__/resolve-idl.test.ts
+++ b/src/__tests__/resolve-idl.test.ts
@@ -236,7 +236,7 @@ describe('resolveIdl :: stage 3 (chain WASM)', () => {
     const api = makeApi({ originalCodeStorage: async () => makeSome(WASM_HEADER) });
     try {
       await _resolveIdlForTests(apiArg(api), { programId: PROGRAM_ID }, null);
-      fail('expected throw');
+      throw new Error('expected _resolveIdlForTests to throw');
     } catch (err: unknown) {
       expect(err).toMatchObject({ code: 'IDL_NOT_FOUND' });
       const msg = (err as Error).message;

--- a/src/__tests__/resolve-idl.test.ts
+++ b/src/__tests__/resolve-idl.test.ts
@@ -8,7 +8,13 @@ const testDir = path.join(os.tmpdir(), `vara-resolve-idl-test-${Date.now()}-${pr
 process.env.VARA_WALLET_DIR = testDir;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import { _resolveIdlForTests, _resetParserCache } from '../services/sails';
+import {
+  _resolveIdlForTests,
+  _resetParserCache,
+  describeSailsProgram,
+  getSailsVersion,
+  loadSailsAuto,
+} from '../services/sails';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import { evictCachedIdl, writeCachedIdl, readCachedIdl } from '../services/idl-cache';
 import { SailsIdlParser as V1Parser } from 'sails-js-parser';
@@ -195,6 +201,30 @@ describe('resolveIdl :: stage 3 (chain WASM)', () => {
     expect(cached?.meta.version).toBe('v2');
   });
 
+  it('loads embedded v1 IDL from chain through the auto/discover path', async () => {
+    const wasm = buildWasmWithSailsIdl(TEST_IDL_V1);
+    const api = makeApi({ originalCodeStorage: async () => makeSome(wasm) });
+
+    const sails = await loadSailsAuto(apiArg(api), { programId: PROGRAM_ID });
+    expect(getSailsVersion(sails)).toBe('v1');
+    expect(describeSailsProgram(sails)).toMatchObject({
+      Counter: {
+        queries: {
+          Value: {
+            args: [],
+            returnType: 'u32',
+            docs: null,
+          },
+        },
+      },
+    });
+
+    const cached = readCachedIdl(CODE_ID);
+    expect(cached?.idl).toBe(TEST_IDL_V1);
+    expect(cached?.meta.source).toBe('chain');
+    expect(cached?.meta.version).toBe('unknown');
+  });
+
   it('falls through when originalCodeStorage returns None', async () => {
     const api = makeApi({ originalCodeStorage: async () => makeNone() });
     await expect(_resolveIdlForTests(apiArg(api), { programId: PROGRAM_ID }, null))
@@ -202,10 +232,17 @@ describe('resolveIdl :: stage 3 (chain WASM)', () => {
     expect(readCachedIdl(CODE_ID)).toBeNull();
   });
 
-  it('falls through when WASM has no sails:idl section (v1 program)', async () => {
+  it('falls through when WASM has no sails:idl section', async () => {
     const api = makeApi({ originalCodeStorage: async () => makeSome(WASM_HEADER) });
-    await expect(_resolveIdlForTests(apiArg(api), { programId: PROGRAM_ID }, null))
-      .rejects.toMatchObject({ code: 'IDL_NOT_FOUND' });
+    try {
+      await _resolveIdlForTests(apiArg(api), { programId: PROGRAM_ID }, null);
+      fail('expected throw');
+    } catch (err: unknown) {
+      expect(err).toMatchObject({ code: 'IDL_NOT_FOUND' });
+      const msg = (err as Error).message;
+      expect(msg).toContain('has no `sails:idl` custom section');
+      expect(msg).not.toContain('v1 contract');
+    }
     expect(readCachedIdl(CODE_ID)).toBeNull();
   });
 

--- a/src/__tests__/sails-extract-from-chain.test.ts
+++ b/src/__tests__/sails-extract-from-chain.test.ts
@@ -98,7 +98,7 @@ const FAKE_CODE_ID = '0x' + '11'.repeat(32);
 describe('tryExtractFromChain (B1 regression)', () => {
   const encoder = new TextEncoder();
 
-  it('returns the IDL string when WASM has a sails:idl section', async () => {
+  it('returns plain-text v1 IDL when WASM has a sails:idl section', async () => {
     const idl = 'service Counter { query Value : () -> u32; };';
     const wasm = buildWasm([{ name: 'sails:idl', payload: encoder.encode(idl) }]);
     const codec = makeBytesCodec(wasm);

--- a/src/commands/idl.ts
+++ b/src/commands/idl.ts
@@ -19,7 +19,7 @@ const CODE_ID_HEX_RE = /^(0x)?[0-9a-fA-F]{64}$/;
  * `vara-wallet idl import <path.idl> (--code-id <hex> | --program <hex|ss58>)`
  *
  * Seed the local IDL cache for a program whose IDL is not auto-discoverable
- * from the chain (v1 programs, or programs built with sails < 1.0.0-beta.1).
+ * from the chain because its WASM has no usable `sails:idl` custom section.
  * Once imported, `vara-wallet call/discover/vft/dex` can reach the IDL
  * without any further flags.
  *

--- a/src/services/sails.ts
+++ b/src/services/sails.ts
@@ -279,9 +279,9 @@ async function resolveIdl(
   }
 
   // (3) Chain WASM.
-  // Track whether the chain probe deterministically identified this as a
-  // v1 contract (WASM exists but has no sails:idl section). Used below
-  // to render a precise error instead of hedging "v1 or v2".
+  // Track whether the chain probe deterministically found no embedded IDL:
+  // the WASM exists and is readable, but has no sails:idl section. This is a
+  // capability signal, not an IDL-version signal.
   let chainProbeReason: ExtractFromChainResult['reason'] | undefined;
   if (codeId) {
     const extracted = await tryExtractFromChain(api, codeId);
@@ -326,20 +326,20 @@ async function resolveIdl(
 
   // (5) All sources exhausted. Render an error keyed off the chain probe:
   // - 'no-section' is deterministic — the WASM was readable and has no
-  //   sails:idl section. That's a v1 contract; tell the user precisely.
-  // - 'unavailable' / undefined: we couldn't read the WASM, so we can't
-  //   tell v1 from v2. Hedge in that case only.
-  const isV1Contract = chainProbeReason === 'no-section';
-  const errMsg = isV1Contract
+  //   sails:idl section, so the user must provide an IDL out of band.
+  // - 'unavailable' / undefined: we couldn't read the WASM, so we cannot
+  //   tell whether embedded IDL exists.
+  const hasNoEmbeddedIdl = chainProbeReason === 'no-section';
+  const errMsg = hasNoEmbeddedIdl
     ? `No IDL available for program ${options.programId}.\n` +
-      `This is a v1 contract — the on-chain WASM has no \`sails:idl\` custom section.\n` +
+      `The on-chain WASM is readable, but it has no \`sails:idl\` custom section.\n` +
       `Import the IDL manually:\n` +
       `    vara-wallet idl import <path.idl> --program ${options.programId}\n` +
       `IDLs are typically shipped in the project's GitHub repo. Or use --idl <path.idl> for a one-off.`
     : `No IDL source available for program ${options.programId}.\n` +
-      `- v2 programs: the IDL is read from the on-chain WASM's \`sails:idl\` section.\n` +
+      `- Programs with embedded IDL: the IDL is read from the on-chain WASM's \`sails:idl\` section.\n` +
       `  Could not reach the chain or the program code is unavailable.\n` +
-      `- v1 programs: import the IDL manually:\n` +
+      `- Programs without embedded IDL: import the IDL manually:\n` +
       `    vara-wallet idl import <path.idl> --program ${options.programId}\n` +
       `  (IDLs are typically shipped in the project's GitHub repo.)\n` +
       `- One-off: pass --idl <path.idl>.\n` +
@@ -362,12 +362,12 @@ export async function _tryExtractFromChainForTests(
 }
 
 /** Outcome of an on-chain WASM IDL extraction.
- *  - `ok`: WASM had a sails:idl custom section (v2 contract).
+ *  - `ok`: WASM had a sails:idl custom section (plain-text v1 or v2 envelope).
  *  - `no-section`: WASM exists and was readable but had no sails:idl section.
- *    This is the deterministic v1-contract signal — caller can render an
- *    accurate "this is a v1 contract" message instead of hedging.
+ *    This is the deterministic "no embedded IDL" signal; it does not identify
+ *    the program's Sails version.
  *  - `unavailable`: couldn't read the WASM at all (no entry, RPC error,
- *    too large). Caller cannot infer v1 vs v2 from this.
+ *    too large). Caller cannot infer whether an embedded IDL exists.
  */
 type ExtractFromChainResult =
   | { idl: string; reason: 'ok' }

--- a/src/services/wasm-section.ts
+++ b/src/services/wasm-section.ts
@@ -1,10 +1,10 @@
 /**
  * Extract the `sails:idl` custom section from a Gear program's WASM blob.
  *
- * Sails-JS owns the v2 IDL envelope format, so this module routes through its
- * public extractor first. The small raw-section fallback keeps older beta.1
- * programs readable because they embedded plain UTF-8 text directly in the
- * same custom section before the beta.2 envelope was introduced.
+ * Sails-JS owns the newer IDL envelope format, so this module routes through
+ * its public extractor first. The small raw-section fallback keeps plain-text
+ * embedded IDLs readable, including Sails IDL v1 and older beta.1-style v2
+ * sections that stored UTF-8 text directly in the same custom section.
  */
 import { extractIdlFromWasm } from 'sails-js/parser';
 
@@ -12,7 +12,7 @@ const SECTION_NAME = 'sails:idl';
 
 /**
  * Returns the UTF-8 decoded IDL text from the `sails:idl` custom section,
- * or `null` if the section is absent (e.g. v1 program, or sails < 1.0.0-beta.1).
+ * or `null` if the section is absent.
  *
  * Throws when:
  * - the bytes are not a valid WASM module/envelope.


### PR DESCRIPTION
## What changed

- Corrected IDL resolution docs and internal comments so embedded IDL support is described as capability-based, not tied to Sails v2.
- Updated `IDL_NOT_FOUND` wording to distinguish readable WASM without a `sails:idl` section from chain-unavailable cases, without misclassifying the program as v1.
- Added regression coverage proving plain-text Sails IDL v1 embedded in WASM loads through `loadSailsAuto`, reaches the discover-description path, and caches as a chain-sourced IDL.

## Why

Sails 0.10.4 / IDL v1 programs can also embed IDL in a `sails:idl` WASM section. The implementation already supported the happy path, but docs, comments, and error text still implied v1 required manual import.

## Validation

- `npm test -- --runTestsByPath src/__tests__/wasm-section.test.ts src/__tests__/sails-extract-from-chain.test.ts src/__tests__/resolve-idl.test.ts`
- `npm run build`
- `npm test`