### PR TITLE
chore: bump Node engine to >=22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
       - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "rm -rf dist && node scripts/build.mjs",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,7 +8,7 @@ await build({
   outfile: 'dist/app.js',
   bundle: true,
   platform: 'node',
-  target: 'node20',
+  target: 'node22',
   format: 'cjs',
   minify: false,
   sourcemap: 'linked',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "CommonJS",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

Bumps the Node engine requirement to **>=22** across `package.json`, the CI matrix (`.github/workflows/ci.yml`), and the release workflow (`.github/workflows/release.yml`). Lands as one atomic change.

Required because the upcoming ethexe rail integration (see ${REPO_OWNER:-vara-wallet} PR #N+1, blocked on `@vara-eth/api@0.5.0` reaching npm) depends on `@vara-eth/api` which is already Node 22 only.

## Test plan

- [ ] CI matrix runs Node 22 green
- [ ] Release workflow dry-runs successfully (workflow_dispatch on a fork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)