### PR TITLE
Fix Vara.eth production regressions

### DIFF
--- a/src/__tests__/events-list.test.ts
+++ b/src/__tests__/events-list.test.ts
@@ -1,0 +1,146 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Command } from 'commander';
+
+const mockOutput = jest.fn();
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  output: (data: unknown) => mockOutput(data),
+  verbose: jest.fn(),
+}));
+
+import { registerEventsCommand } from '../commands/events';
+import { closeEventStore, initEventStore, insertEvent } from '../services/event-store';
+import { writeConfig } from '../services/config';
+
+const ETH_PROGRAM = '0xabcdef0000000000000000000000000000000002';
+const NATIVE_PROGRAM = '0x' + '11'.repeat(32);
+
+const savedWalletDir = process.env.VARA_WALLET_DIR;
+let tmpDir: string;
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.option('--chain <name>', 'target chain');
+  registerEventsCommand(program);
+  return program;
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vw-events-list-'));
+  process.env.VARA_WALLET_DIR = tmpDir;
+  mockOutput.mockReset();
+  writeConfig({ defaultChain: 'vara-eth' });
+  initEventStore();
+});
+
+afterEach(() => {
+  closeEventStore();
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (savedWalletDir === undefined) delete process.env.VARA_WALLET_DIR;
+  else process.env.VARA_WALLET_DIR = savedWalletDir;
+});
+
+describe('events list chain filtering', () => {
+  it('lists native and Vara.eth rows by default even when defaultChain is set', async () => {
+    seedEvents();
+
+    await makeProgram().parseAsync(['events', 'list'], { from: 'user' });
+
+    const rows = latestOutputRows();
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ chain: 'vara', label: 'native' }),
+      expect.objectContaining({ chain: 'vara-eth', label: 'eth' }),
+    ]));
+  });
+
+  it('filters explicit native event lists to native and legacy null-chain rows', async () => {
+    seedEvents();
+
+    await makeProgram().parseAsync(['--chain', 'vara', 'events', 'list'], { from: 'user' });
+
+    const rows = latestOutputRows();
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ chain: 'vara', label: 'native' }),
+      expect.objectContaining({ chain: 'vara', label: 'legacy-native' }),
+    ]));
+    expect(rows).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'eth' }),
+    ]));
+  });
+
+  it('filters explicit Vara.eth event lists to Vara.eth rows', async () => {
+    seedEvents();
+
+    await makeProgram().parseAsync(['--chain', 'vara-eth', 'events', 'list'], { from: 'user' });
+
+    const rows = latestOutputRows();
+    expect(rows).toEqual([
+      expect.objectContaining({ chain: 'vara-eth', label: 'eth' }),
+    ]);
+  });
+
+  it('infers program filter normalization from address shape when chain is omitted', async () => {
+    seedEvents();
+
+    await makeProgram().parseAsync(['events', 'list', '--program', ETH_PROGRAM], { from: 'user' });
+    expect(latestOutputRows()).toEqual([
+      expect.objectContaining({ chain: 'vara-eth', label: 'eth' }),
+    ]);
+
+    await makeProgram().parseAsync(['events', 'list', '--program', NATIVE_PROGRAM], { from: 'user' });
+    expect(latestOutputRows()).toEqual([
+      expect.objectContaining({ chain: 'vara', label: 'native' }),
+    ]);
+  });
+});
+
+function seedEvents(): void {
+  insertEvent({
+    type: 'program',
+    chain: 'vara',
+    event_id: 'native',
+    data: { label: 'native' },
+    program_id: NATIVE_PROGRAM,
+  });
+  insertEvent({
+    type: 'program',
+    chain: 'vara-eth',
+    event_id: 'eth',
+    data: { label: 'eth' },
+    program_id: ETH_PROGRAM,
+  });
+  insertLegacyNullChainEvent();
+}
+
+function insertLegacyNullChainEvent(): void {
+  const db = new Database(path.join(tmpDir, 'events.db'));
+  try {
+    db.prepare(`
+      INSERT INTO events (type, chain, network, event_id, data, block_number, block_hash, source, destination, program_id, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'program',
+      null,
+      null,
+      'legacy-native',
+      JSON.stringify({ label: 'legacy-native' }),
+      null,
+      null,
+      null,
+      null,
+      '0x' + '22'.repeat(32),
+      Date.now(),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function latestOutputRows(): Array<Record<string, unknown>> {
+  return mockOutput.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>;
+}

--- a/src/__tests__/vara-eth-actions.test.ts
+++ b/src/__tests__/vara-eth-actions.test.ts
@@ -263,6 +263,22 @@ describe('Vara.eth shared actions', () => {
     expect(mockSendAndWait).not.toHaveBeenCalled();
   });
 
+  it('rejects invalid Vara.eth message send paths before opening the API', async () => {
+    await expect(outputVaraEthMessageSend(TO, {
+      account: 'hoodi-smoke',
+      payload: '0xabcd',
+      via: 'ethe' as any,
+    })).rejects.toMatchObject({
+      code: 'INVALID_VIA',
+      meta: {
+        via: 'ethe',
+      },
+    });
+
+    expect(getEthexeApi).not.toHaveBeenCalled();
+    expect(mockSendAndWait).not.toHaveBeenCalled();
+  });
+
   it('discovers a Vara.eth Sails program from a local IDL without substrate RPC', async () => {
     await outputVaraEthDiscover(TO, { idl: FIXTURE_IDL });
 

--- a/src/__tests__/vara-eth-actions.test.ts
+++ b/src/__tests__/vara-eth-actions.test.ts
@@ -316,6 +316,47 @@ describe('Vara.eth shared actions', () => {
     }));
   });
 
+  it('decodes empty replies for Vara.eth Sails v1 null-return functions', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vara-wallet-v1-null-reply-'));
+    const idl = join(dir, 'program.idl');
+    writeFileSync(idl, [
+      'constructor {',
+      '  Init : ();',
+      '};',
+      '',
+      'service VaraArkanoid {',
+      '  SimulateGame : (num_steps: u32) -> null;',
+      '};',
+    ].join('\n'));
+
+    try {
+      await outputVaraEthSailsCall(TO, 'VaraArkanoid/SimulateGame', {
+        account: 'hoodi-smoke',
+        idl,
+        args: '[10]',
+        value: '0',
+        via: 'eth',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    expect(mockSendAndWait).toHaveBeenCalledWith(TO, expect.stringMatching(/^0x/), {
+      value: 0n,
+      via: 'eth',
+    });
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      chain: 'vara-eth',
+      kind: 'function',
+      service: 'VaraArkanoid',
+      method: 'SimulateGame',
+      result: null,
+      reply: expect.objectContaining({
+        payload: '0x',
+      }),
+    }));
+  });
+
   it('uses zero address for Vara.eth Sails read origins only when no account is configured', async () => {
     resolveEthexeAccountAddress.mockImplementationOnce(() => {
       throw new CliError(

--- a/src/__tests__/vara-eth-actions.test.ts
+++ b/src/__tests__/vara-eth-actions.test.ts
@@ -101,8 +101,10 @@ import {
   outputVaraEthSailsCall,
   outputVaraEthProgramTopUp,
   outputVaraEthWvaraTransfer,
+  _isNullReturnTypeForTests,
 } from '../commands/vara-eth-actions';
 import { CliError } from '../utils/errors';
+import { parseIdlFileV2 } from '../services/sails';
 
 const FIXTURE_IDL = join(__dirname, 'fixtures', 'sample-v2.idl');
 
@@ -371,6 +373,12 @@ describe('Vara.eth shared actions', () => {
         payload: '0x',
       }),
     }));
+  });
+
+  it('recognizes Sails unit return types as empty replies', async () => {
+    const sails = await parseIdlFileV2(FIXTURE_IDL);
+
+    expect(_isNullReturnTypeForTests(sails, { kind: 'tuple', types: [] }, 'Demo')).toBe(true);
   });
 
   it('uses zero address for Vara.eth Sails read origins only when no account is configured', async () => {

--- a/src/__tests__/vara-eth-root-message-routing.test.ts
+++ b/src/__tests__/vara-eth-root-message-routing.test.ts
@@ -1,0 +1,76 @@
+import { Command } from 'commander';
+
+const mockMessageSend = jest.fn();
+
+jest.mock('../commands/vara-eth-actions', () => ({
+  outputVaraEthMessageReply: jest.fn(),
+  outputVaraEthMessageSend: (...args: unknown[]) => mockMessageSend(...args),
+}));
+
+import { registerMessageCommand } from '../commands/message';
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.option('--chain <name>', 'chain');
+  program.option('--account <name>', 'account');
+  program.option('--passphrase <pass>', 'passphrase');
+  registerMessageCommand(program);
+  return program;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMessageSend.mockResolvedValue(undefined);
+});
+
+describe('root --chain vara-eth message routing', () => {
+  it('converts default message send values with native VARA units', async () => {
+    const mirror = '0xabcdef0000000000000000000000000000000002';
+
+    await makeProgram().parseAsync([
+      '--chain', 'vara-eth',
+      '--account', 'alice',
+      'message', 'send', mirror,
+      '--payload', '0xabcd',
+      '--value', '1',
+    ], { from: 'user' });
+
+    expect(mockMessageSend).toHaveBeenCalledWith(mirror, expect.objectContaining({
+      account: 'alice',
+      payload: '0xabcd',
+      value: '1000000000000',
+    }));
+  });
+
+  it('passes raw message send values through when requested', async () => {
+    const mirror = '0xabcdef0000000000000000000000000000000002';
+
+    await makeProgram().parseAsync([
+      '--chain', 'vara-eth',
+      'message', 'send', mirror,
+      '--payload', '0xabcd',
+      '--value', '7',
+      '--units', 'raw',
+    ], { from: 'user' });
+
+    expect(mockMessageSend).toHaveBeenCalledWith(mirror, expect.objectContaining({
+      payload: '0xabcd',
+      value: '7',
+    }));
+  });
+
+  it('still rejects native-only message send options on Vara.eth', async () => {
+    const mirror = '0xabcdef0000000000000000000000000000000002';
+
+    await expect(makeProgram().parseAsync([
+      '--chain', 'vara-eth',
+      'message', 'send', mirror,
+      '--payload-ascii', 'hello',
+    ], { from: 'user' })).rejects.toMatchObject({
+      code: 'UNSUPPORTED_CHAIN_OPTION',
+    });
+
+    expect(mockMessageSend).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -60,7 +60,7 @@ export function registerEventsCommand(program: Command): void {
 function resolveExplicitChainFilter(cmd: Command): Chain | undefined {
   if (!hasCliOptionSource(cmd, 'chain')) return undefined;
   const opts = cmd.optsWithGlobals() as { chain?: string };
-  return resolveChain(opts.chain);
+  return opts.chain ? resolveChain(opts.chain) : undefined;
 }
 
 function hasCliOptionSource(cmd: Command, optionName: string): boolean {

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { initEventStore, queryEvents, pruneEvents } from '../services/event-store';
+import { type Chain, resolveChain } from '../chains/types';
 import { output, verbose, addressToHex } from '../utils';
 import { asAddress } from '../utils/eth-types';
-import { resolveActiveChain } from '../utils/active-chain';
 import { parseDuration } from './subscribe/shared';
 
 export function registerEventsCommand(program: Command): void {
@@ -24,10 +24,8 @@ export function registerEventsCommand(program: Command): void {
 
       const since = options.since ? Date.now() - parseDuration(options.since) : undefined;
       const limit = parseInt(options.limit, 10);
-      const chain = options.chain ?? resolveActiveChain(cmd);
-      const program = options.program
-        ? (chain === 'vara-eth' ? asAddress(options.program, '--program') : addressToHex(options.program))
-        : undefined;
+      const chain = resolveExplicitChainFilter(cmd);
+      const program = normalizeProgramFilter(options.program, chain);
 
       const rows = queryEvents({ type: options.type, since, program, chain, network: options.network, limit });
       const parsed = rows.map((row) => ({
@@ -57,4 +55,30 @@ export function registerEventsCommand(program: Command): void {
 
       output({ pruned: count });
     });
+}
+
+function resolveExplicitChainFilter(cmd: Command): Chain | undefined {
+  if (!hasCliOptionSource(cmd, 'chain')) return undefined;
+  const opts = cmd.optsWithGlobals() as { chain?: string };
+  return resolveChain(opts.chain);
+}
+
+function hasCliOptionSource(cmd: Command, optionName: string): boolean {
+  let current: Command | undefined = cmd;
+  while (current) {
+    if (current.getOptionValueSource(optionName) === 'cli') return true;
+    current = current.parent ?? undefined;
+  }
+  return false;
+}
+
+function normalizeProgramFilter(program: string | undefined, chain: Chain | undefined): string | undefined {
+  if (!program) return undefined;
+  if (chain === 'vara-eth') return asAddress(program, '--program');
+  if (chain === 'vara') return addressToHex(program);
+  return isEthAddress(program) ? asAddress(program, '--program') : addressToHex(program);
+}
+
+function isEthAddress(value: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(value);
 }

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -85,13 +85,14 @@ export function registerMessageCommand(program: Command): void {
     }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       if (resolveActiveChain(program) === 'vara-eth') {
-        if (options.payloadAscii || options.gasLimit || options.metadata || options.voucher || options.units) {
+        if (options.payloadAscii || options.gasLimit || options.metadata || options.voucher) {
           throw new CliError(
-            '--chain vara-eth message send supports --payload, --value, --via, --timeout-ms, --resume, and account options',
+            '--chain vara-eth message send supports --payload, --value, --units, --via, --timeout-ms, --resume, and account options',
             'UNSUPPORTED_CHAIN_OPTION',
           );
         }
-        await outputVaraEthMessageSend(destination, { ...opts, ...options });
+        const value = resolveAmount(options.value, options.units).toString();
+        await outputVaraEthMessageSend(destination, { ...opts, ...options, value });
         return;
       }
 

--- a/src/commands/vara-eth-actions.ts
+++ b/src/commands/vara-eth-actions.ts
@@ -10,6 +10,7 @@ import { insertEvent, initEventStore } from '../services/event-store';
 import { readConfig } from '../services/config';
 import { resolveInitDescriptor, type InitOptions } from '../services/sails-init';
 import {
+  describeType,
   describeSailsProgram,
   getSailsVersion,
   isSailsV2,
@@ -826,8 +827,19 @@ function decodeVaraEthSailsReply(
       verbose(`Vara.eth Sails reply was not an enveloped v2 reply; falling back to method result decode. ${errorMessage(err)}`);
     }
   }
+  if (payload === '0x' && isNullReturnType(sails, method.returnTypeDef, serviceName)) {
+    return null;
+  }
   const decoded = method.decodeResult ? method.decodeResult(payload) : payload;
   return decodeSailsResult(sails, method.returnTypeDef, decoded, serviceName);
+}
+
+function isNullReturnType(sails: LoadedSails, typeDef: unknown, serviceName: string): boolean {
+  try {
+    return describeType(sails, typeDef, serviceName).toLowerCase() === 'null';
+  } catch {
+    return false;
+  }
 }
 
 function resolveVaraEthOrigin(opts: EthexeAccountOptions & { origin?: string }): Address {

--- a/src/commands/vara-eth-actions.ts
+++ b/src/commands/vara-eth-actions.ts
@@ -159,7 +159,7 @@ export async function outputVaraEthMessageSend(mirrorArg: string, opts: VaraEthS
   }
   const payload = asHex(opts.payload, '--payload');
   const value = parseOptionalBigInt(opts.value, '--value');
-  const via: 'eth' | 'injected' = opts.via === 'eth' ? 'eth' : 'injected';
+  const via = resolveVaraEthSendPath(opts.via ?? 'injected');
   const timeoutMs = parseOptionalPositiveInteger(opts.timeoutMs, '--timeout-ms', 'INVALID_TIMEOUT');
 
   const api = await getEthexeApi();

--- a/src/commands/vara-eth-actions.ts
+++ b/src/commands/vara-eth-actions.ts
@@ -836,11 +836,14 @@ function decodeVaraEthSailsReply(
 
 function isNullReturnType(sails: LoadedSails, typeDef: unknown, serviceName: string): boolean {
   try {
-    return describeType(sails, typeDef, serviceName).toLowerCase() === 'null';
+    const typeName = describeType(sails, typeDef, serviceName).toLowerCase();
+    return typeName === 'null' || typeName === '()';
   } catch {
     return false;
   }
 }
+
+export const _isNullReturnTypeForTests = isNullReturnType;
 
 function resolveVaraEthOrigin(opts: EthexeAccountOptions & { origin?: string }): Address {
   if (opts.origin) return asAddress(opts.origin, '--origin');


### PR DESCRIPTION
## Summary
- fix Vara.eth null reply decoding
- validate unsupported Vara.eth message routing options earlier
- preserve Vara.eth value/unit forwarding through the root message command
- default event listing to the selected chain context

## Verification
- npm test -- --runInBand
- npm run build
- npm pack --dry-run