### PR TITLE
fix: bundle wallet crypto for global installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+      - run: npm run test:pack-smoke
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.1] - 2026-05-27
+
+### Fixed
+
+- Bundle the HD-wallet crypto modules used by the CLI startup path so global npm installs do not fail with `Cannot find module '@noble/curves/ed25519'`.
+- Add a packed-install smoke check to the release workflow. It installs the generated tarball into a clean global prefix and runs `vara-wallet --version` before publishing.
+
 ## [0.20.0] - 2026-05-19
 
 One theme: **the wallet now drives Vara.eth as a first-class chain**. The substrate rail (`vara-wallet --chain vara`) is untouched. A parallel `vara-wallet --chain vara-eth` rail ships with read paths verified on mainnet + Hoodi, L1 write path verified on Hoodi, and an injected-tx persistence layer that survives kill/restart for terminal outcomes. Typed errors from `@vara-eth/api@0.5.0-rc.1` now surface as `MESSAGE_REVERTED` / `PROMISE_TIMEOUT` / `CHAIN_ID_MISMATCH` (etc.) directly in JSON output. Diagnostics flag `--no-validate-signature` lets operators bypass the validator-signature check on injected-path replies when triaging recovery failures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "bundleDependencies": [
         "@vara-eth/api"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {
@@ -21,6 +21,7 @@
     "dev": "ts-node --transpile-only src/app.ts",
     "test": "jest",
     "test:smoke": "npm run build && node scripts/smoke.mjs",
+    "test:pack-smoke": "npm run build && node scripts/pack-smoke.mjs",
     "test:vara-eth-sails:e2e": "node scripts/vara-eth-sails-e2e.mjs",
     "clean": "rm -rf dist",
     "dev:link:vara-eth": "node scripts/dev-link-vara-eth.mjs",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -17,6 +17,8 @@ await build({
   // resolution can pick the CJS entry via the `main` field. Bundling them
   // followed the ESM `exports.import` path, which dragged in kzg-wasm's ESM
   // build that uses `import.meta.url` — unsupported in our CJS bundle.
+  // Keep HD-wallet crypto bundled: npm can install bundled scoped packages in
+  // a shape that leaves sibling scoped packages unavailable at global runtime.
   external: [
     'better-sqlite3',
     'smoldot',
@@ -24,10 +26,7 @@ await build({
     'viem',
     'kzg-wasm',
     '@noble/ciphers',
-    '@noble/curves',
     '@noble/hashes',
-    '@scure/bip32',
-    '@scure/bip39',
   ],
   define: {
     'process.env.VARA_WALLET_VERSION': JSON.stringify(pkg.version),

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -1,0 +1,50 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = process.cwd();
+const packageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+const tmp = await mkdtemp(join(tmpdir(), 'vara-wallet-pack-smoke-'));
+const npmCli = process.env.npm_execpath;
+const npmCmd = npmCli ? process.execPath : 'npm';
+const npmBaseArgs = npmCli ? [npmCli] : [];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: process.env,
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} exited with ${result.status}`);
+  }
+}
+
+try {
+  const pack = spawnSync(npmCmd, [...npmBaseArgs, 'pack', '--pack-destination', tmp, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: process.env,
+  });
+  if (pack.status !== 0) {
+    process.stdout.write(pack.stdout);
+    process.stderr.write(pack.stderr);
+    throw new Error(`${npmCmd} pack exited with ${pack.status}`);
+  }
+
+  const tarball = join(tmp, `vara-wallet-${packageJson.version}.tgz`);
+  const prefix = join(tmp, 'prefix');
+  run(npmCmd, [...npmBaseArgs, 'install', '--prefix', prefix, '-g', tarball]);
+
+  const bin = process.platform === 'win32'
+    ? join(prefix, 'vara-wallet.cmd')
+    : join(prefix, 'bin', 'vara-wallet');
+
+  run(bin, ['--version'], { cwd: tmp });
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- bump to v0.20.1 for the global-install hotfix
- bundle the HD-wallet crypto modules that were previously left as runtime externals
- add a packed global-install smoke check to the release workflow before npm publish

## Verification
- npm test -- --runInBand
- npm run test:smoke
- npm run test:pack-smoke