### PR TITLE
[codex] fix npm global install packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.2] - 2026-06-15
+
+### Fixed
+
+- Bundle the Vara.eth runtime peers `viem` and `kzg-wasm` with the packed CLI so global npm installs can resolve `viem/utils` and `kzg-wasm` at startup.
+- Extend the packed-install smoke check to assert those runtime peer imports from the installed tarball before publish.
+
 ## [0.20.1] - 2026-05-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "bundleDependencies": [
-        "@vara-eth/api"
+        "@vara-eth/api",
+        "viem",
+        "kzg-wasm"
       ],
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {
@@ -10,7 +10,9 @@
     "dist"
   ],
   "bundledDependencies": [
-    "@vara-eth/api"
+    "@vara-eth/api",
+    "viem",
+    "kzg-wasm"
   ],
   "engines": {
     "node": ">=22"

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 
 const repoRoot = process.cwd();
 const packageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
@@ -24,17 +25,34 @@ function run(command, args, options = {}) {
   }
 }
 
-try {
-  const pack = spawnSync(npmCmd, [...npmBaseArgs, 'pack', '--pack-destination', tmp, '--json'], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    env: process.env,
-  });
-  if (pack.status !== 0) {
-    process.stdout.write(pack.stdout);
-    process.stderr.write(pack.stderr);
-    throw new Error(`${npmCmd} pack exited with ${pack.status}`);
+function assertInstalledResolve(prefix, request) {
+  const globalRoots = process.platform === 'win32'
+    ? [join(prefix, 'node_modules')]
+    : [join(prefix, 'lib', 'node_modules'), join(prefix, 'node_modules')];
+
+  let packageJsonPath;
+  for (const root of globalRoots) {
+    try {
+      packageJsonPath = createRequire(join(root, 'resolve.cjs')).resolve('vara-wallet/package.json');
+      break;
+    } catch {
+      // Try the next npm global layout.
+    }
   }
+
+  if (!packageJsonPath) {
+    throw new Error(`Packed install did not expose vara-wallet/package.json under ${prefix}`);
+  }
+
+  try {
+    createRequire(packageJsonPath).resolve(request);
+  } catch (error) {
+    throw new Error(`Packed install cannot resolve ${request}: ${error.message}`);
+  }
+}
+
+try {
+  run(npmCmd, [...npmBaseArgs, 'pack', '--pack-destination', tmp]);
 
   const tarball = join(tmp, `vara-wallet-${packageJson.version}.tgz`);
   const prefix = join(tmp, 'prefix');
@@ -45,6 +63,8 @@ try {
     : join(prefix, 'bin', 'vara-wallet');
 
   run(bin, ['--version'], { cwd: tmp });
+  assertInstalledResolve(prefix, 'viem/utils');
+  assertInstalledResolve(prefix, 'kzg-wasm');
 } finally {
   await rm(tmp, { recursive: true, force: true });
 }

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -33,7 +33,7 @@ function assertInstalledResolve(prefix, request) {
   let packageJsonPath;
   for (const root of globalRoots) {
     try {
-      packageJsonPath = createRequire(join(root, 'resolve.cjs')).resolve('vara-wallet/package.json');
+      packageJsonPath = createRequire(root).resolve('vara-wallet/package.json');
       break;
     } catch {
       // Try the next npm global layout.


### PR DESCRIPTION
## Summary

Fixes the published global-install startup path for `vara-wallet` by bundling the Vara.eth runtime peers required by the vendored `@vara-eth/api` package.

## Changes

- Bumps the package version to `0.20.2`.
- Bundles `viem` and `kzg-wasm` alongside `@vara-eth/api` so installed tarballs can resolve `viem/utils` and `kzg-wasm` at runtime.
- Strengthens `scripts/pack-smoke.mjs` to validate those imports from the packed global install.
- Adds a `0.20.2` changelog entry.

## Root Cause

`vara-wallet@0.20.1` bundled the vendored `@vara-eth/api` package, but left its runtime peers (`viem`, `kzg-wasm`) to npm resolution. In a global install from the registry, npm produced empty/malformed peer package roots, so the CLI crashed before startup with `Cannot find module 'viem/utils'`.

## Validation

- `npm run build`
- `npm test -- --runInBand` (`80` suites / `863` tests passed)
- `npm run test:pack-smoke`
- Manual tarball check confirmed these files are included:
  - `package/node_modules/viem/package.json`
  - `package/node_modules/viem/_cjs/utils/index.js`
  - `package/node_modules/kzg-wasm/package.json`
  - `package/node_modules/@vara-eth/api/package.json`