### PR TITLE
Reduce Vara.eth RPC startup latency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,6 +506,8 @@ vara-wallet --chain vara-eth --network hoodi call 0xMIRROR Service/Query --args 
 
 Vara.eth wallet files are `~/.vara-wallet/wallets/<name>.vara-eth.json`. They appear in unqualified `wallet list` with `chain: "vara-eth"`, but native commands must not treat those files as Substrate wallets. Passphrases resolve from `--passphrase`, named passphrase files, or `VARA_PASSPHRASE` depending on the command path. Typed Vara.eth errors use stable JSON codes such as `MESSAGE_REVERTED`, `PROMISE_TIMEOUT`, `CHAIN_ID_MISMATCH`, and `TRANSPORT_ERROR` with top-level metadata.
 
+Vara.eth opens the validator connection and Ethereum bootstrap concurrently. Built-in presets use an Ethereum HTTP endpoint for one-shot requests, while `vara-eth:subscribe` keeps Ethereum WebSocket transport for event streams. Custom deployments can set `ETHEREUM_HTTP_RPC`; without it, request-mode calls fall back to `ETHEREUM_RPC`.
+
 Direct config setters are preset-aware: `config set varaNetwork <mainnet|testnet|local>` also updates `wsEndpoint`, and `config set varaEthNetwork <mainnet|hoodi|local>` also updates the Vara.eth RPC, Ethereum RPC, and Router fields. For Vara.eth Sails read calls, zero-address origin fallback is only for no selected account; a missing or corrupt selected wallet must fail instead of silently querying as zero address.
 
 For endpoints and canonical Router/WVARA addresses, see `docs/vara-eth-networks.md`. For the manual Sails deploy/discover/call E2E, see `docs/sails-real-program-e2e.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,6 +497,11 @@ vara-wallet --chain vara-eth --network hoodi vara-eth:state read 0xMIRROR
 vara-wallet --chain vara-eth --network hoodi --account agent-eth \
   vara-eth:message send 0xMIRROR --payload 0xfeed --via eth
 
+# Lowest-latency transaction-only path. Returns after RPC acceptance; direct
+# Ethereum output has txHash but no messageId/reply until the receipt is mined.
+vara-wallet --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:message send 0xMIRROR --payload 0xfeed --via eth --wait submitted
+
 # Root Sails flow on Vara.eth
 vara-wallet --chain vara-eth --network hoodi --account agent-eth \
   program upload ./program.opt.wasm --idl ./program.idl --args '[]'
@@ -506,7 +511,9 @@ vara-wallet --chain vara-eth --network hoodi call 0xMIRROR Service/Query --args 
 
 Vara.eth wallet files are `~/.vara-wallet/wallets/<name>.vara-eth.json`. They appear in unqualified `wallet list` with `chain: "vara-eth"`, but native commands must not treat those files as Substrate wallets. Passphrases resolve from `--passphrase`, named passphrase files, or `VARA_PASSPHRASE` depending on the command path. Typed Vara.eth errors use stable JSON codes such as `MESSAGE_REVERTED`, `PROMISE_TIMEOUT`, `CHAIN_ID_MISMATCH`, and `TRANSPORT_ERROR` with top-level metadata.
 
-Vara.eth opens the validator connection and Ethereum bootstrap concurrently. Built-in presets use an Ethereum HTTP endpoint for one-shot requests, while `vara-eth:subscribe` keeps Ethereum WebSocket transport for event streams. Custom deployments can set `ETHEREUM_HTTP_RPC`; without it, request-mode calls fall back to `ETHEREUM_RPC`.
+Vara.eth opens the validator connection and Ethereum bootstrap concurrently when both are required. Direct Ethereum submit-only messages and WVARA writes use an Ethereum-only context and skip the validator connection. Built-in presets use an Ethereum HTTP endpoint for one-shot requests, while `vara-eth:subscribe` keeps Ethereum WebSocket transport for event streams. Custom deployments can set `ETHEREUM_HTTP_RPC`; without it, request-mode calls fall back to `ETHEREUM_RPC`.
+
+Message sends and state-changing Sails calls default to `--wait reply`; WVARA transfers and message replies default to `--wait receipt`. Use `--wait submitted` when an agent only needs RPC acceptance. Direct Ethereum submission returns `messageId: null` because that ID comes from the mined Mirror event. Injected submission returns its locally derived message ID but does not wait for or validate a validator reply. Do not assume `--resume` can follow a submit-only injected transaction: pending-promise reattachment is not yet supported upstream.
 
 Direct config setters are preset-aware: `config set varaNetwork <mainnet|testnet|local>` also updates `wsEndpoint`, and `config set varaEthNetwork <mainnet|hoodi|local>` also updates the Vara.eth RPC, Ethereum RPC, and Router fields. For Vara.eth Sails read calls, zero-address origin fallback is only for no selected account; a missing or corrupt selected wallet must fail instead of silently querying as zero address.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Reduce Vara.eth command startup latency by overlapping validator connection with API bootstrap and using preset Ethereum HTTP endpoints for one-shot requests. Event subscriptions continue to use WebSocket, and custom configurations without `ETHEREUM_HTTP_RPC` retain their existing WebSocket fallback.
+- Add Vara.eth `--wait submitted` for transaction-hash-only message, reply, WVARA, and Sails function workflows while preserving reply/receipt completion defaults. Direct Ethereum submissions skip validator bootstrap when no validator state is needed.
 
 ## [0.20.3] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Reduce Vara.eth command startup latency by overlapping validator connection with API bootstrap and using preset Ethereum HTTP endpoints for one-shot requests. Event subscriptions continue to use WebSocket, and custom configurations without `ETHEREUM_HTTP_RPC` retain their existing WebSocket fallback.
+
 ## [0.20.3] - 2026-06-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ npm link
 | `VARA_DEX_FACTORY` | DEX factory program address | — |
 | `VARA_FAUCET_URL` | Faucet API URL | `https://faucet.gear-tech.io` |
 | `VARA_ETH_RPC` | Vara.eth validator RPC | network preset |
-| `ETHEREUM_RPC` | Ethereum JSON-RPC/WebSocket endpoint for Vara.eth | network preset |
+| `ETHEREUM_RPC` | Ethereum WebSocket endpoint for Vara.eth streams and custom fallback | network preset |
+| `ETHEREUM_HTTP_RPC` | Ethereum HTTP endpoint for one-shot Vara.eth requests | network preset |
 | `VARA_ETH_ROUTER` | Vara.eth Router address | network preset |
+
+Vara.eth starts its validator connection and Ethereum bootstrap concurrently. Built-in network presets use HTTP for one-shot Ethereum reads to avoid a WebSocket handshake; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
 
 ## Account Resolution
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm link
 | `ETHEREUM_HTTP_RPC` | Ethereum HTTP endpoint for one-shot Vara.eth requests | network preset |
 | `VARA_ETH_ROUTER` | Vara.eth Router address | network preset |
 
-Vara.eth starts its validator connection and Ethereum bootstrap concurrently when a command needs both RPCs. Direct low-level message submissions, WVARA writes, and direct Sails submissions with an explicit `--idl` use an Ethereum-only request context and do not open the validator connection. Built-in network presets use HTTP for one-shot Ethereum requests; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
+Vara.eth starts its validator connection and Ethereum bootstrap concurrently when a command needs both RPCs. Direct low-level message submissions, WVARA writes, and direct Sails function submissions with both `--via eth --wait submitted` and an explicit `--idl` use an Ethereum-only request context and do not open the validator connection. Built-in network presets use HTTP for one-shot Ethereum requests; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
 
 ## Account Resolution
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm link
 | `ETHEREUM_HTTP_RPC` | Ethereum HTTP endpoint for one-shot Vara.eth requests | network preset |
 | `VARA_ETH_ROUTER` | Vara.eth Router address | network preset |
 
-Vara.eth starts its validator connection and Ethereum bootstrap concurrently. Built-in network presets use HTTP for one-shot Ethereum reads to avoid a WebSocket handshake; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
+Vara.eth starts its validator connection and Ethereum bootstrap concurrently. Built-in network presets use HTTP for one-shot Ethereum requests to avoid a WebSocket handshake; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
 
 ## Account Resolution
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm link
 | `ETHEREUM_HTTP_RPC` | Ethereum HTTP endpoint for one-shot Vara.eth requests | network preset |
 | `VARA_ETH_ROUTER` | Vara.eth Router address | network preset |
 
-Vara.eth starts its validator connection and Ethereum bootstrap concurrently. Built-in network presets use HTTP for one-shot Ethereum requests to avoid a WebSocket handshake; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
+Vara.eth starts its validator connection and Ethereum bootstrap concurrently when a command needs both RPCs. Direct low-level message submissions, WVARA writes, and direct Sails submissions with an explicit `--idl` use an Ethereum-only request context and do not open the validator connection. Built-in network presets use HTTP for one-shot Ethereum requests; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
 
 ## Account Resolution
 
@@ -182,6 +182,11 @@ vara-wallet --chain vara-eth --network hoodi vara-eth:state read 0xMIRROR
 vara-wallet --chain vara-eth --network hoodi --account alice \
   vara-eth:message send 0xMIRROR --payload 0xfeed --via eth
 
+# Return as soon as the Ethereum RPC accepts the transaction. This output has
+# a txHash but no messageId/reply because those require the L1 receipt/event.
+vara-wallet --chain vara-eth --network hoodi --account alice \
+  vara-eth:message send 0xMIRROR --payload 0xfeed --via eth --wait submitted
+
 # Deploy a Sails program through the root command surface
 vara-wallet --chain vara-eth --network hoodi --account alice \
   program upload ./program.opt.wasm --idl ./program.idl --args '[]'
@@ -199,7 +204,7 @@ vara-wallet --chain vara-eth --network hoodi vara-eth:program top-up 0xMIRROR --
 vara-wallet --chain vara-eth --network hoodi vara-eth:subscribe router
 ```
 
-Injected sends remain available with `--via injected`; use `--no-validate-signature` only for diagnostics when investigating validator-signature recovery. See `docs/vara-eth-networks.md` for endpoints and `docs/sails-real-program-e2e.md` for the full Sails deploy/discover/call smoke.
+Message sends and state-changing Sails calls default to `--wait reply`; use `--wait submitted` when only RPC acceptance and a transaction hash are needed. WVARA transfers and message replies default to `--wait receipt` and also accept `--wait submitted`. Injected sends remain available with `--via injected`; submit-only injected output includes the locally derived `messageId`, but does not validate a validator signature or wait for program execution. Use `--no-validate-signature` only for diagnostics when waiting for injected replies. See `docs/vara-eth-networks.md` for endpoints and `docs/sails-real-program-e2e.md` for the full Sails deploy/discover/call smoke.
 
 ### `node`
 

--- a/docs/sails-real-program-e2e.md
+++ b/docs/sails-real-program-e2e.md
@@ -335,6 +335,7 @@ Acceptance for Vara.eth support:
 - `call --estimate` returns `api.fees.estimate({ type: 'sendMessage' })` data for
   function calls;
 - query calls return decoded Sails results;
-- function calls submit via `--via eth` or `--via injected`, wait for the reply,
-  and return decoded reply/result data;
+- function calls submit via `--via eth` or `--via injected`; the default
+  `--wait reply` returns decoded reply/result data, while `--wait submitted`
+  returns the transaction/message identifiers without decoding a result;
 - errors are typed by stable `code` and `reason`, not by English text.

--- a/docs/vara-eth-followups.md
+++ b/docs/vara-eth-followups.md
@@ -14,6 +14,9 @@ cleanup work.
   diagnostics.
 - The networks guide now covers mainnet, Hoodi, and local as
   `docs/vara-eth-networks.md`.
+- Transaction-only workflows expose `--wait submitted`. Direct Ethereum and
+  WVARA writes avoid the validator connection, while injected submit-only sends
+  call `injected_sendTransaction` without opening a receipt subscription.
 
 ## Remaining Work
 

--- a/docs/vara-eth-integration-report.md
+++ b/docs/vara-eth-integration-report.md
@@ -46,6 +46,10 @@ Rail-specific workflows remain available under `vara-eth:*`:
 - `vara-eth:message send` supports `--via eth` and `--via injected`; prefer
   `--via eth` for production writes until injected-path validator recovery is
   fully triaged.
+- `--wait submitted` returns after RPC acceptance for message sends, Sails
+  functions, WVARA transfers, and message replies. Direct Ethereum submissions
+  skip the validator connection for low-level messages and for Sails calls with
+  an explicit local IDL; completion-oriented defaults are unchanged.
 - `--no-validate-signature` exists only for injected-path diagnostics.
 - `reply.code` output is structured as `{ tag, raw, reason }`.
 - Vara.eth typed errors flow through stable JSON codes such as

--- a/docs/vara-eth-networks.md
+++ b/docs/vara-eth-networks.md
@@ -50,7 +50,7 @@ Use `--wait submitted` for automation that only needs proof the RPC accepted a t
 - WVARA transfers and message replies return their Ethereum `txHash` without waiting for a block receipt.
 - A raw-unit WVARA submit does not perform a decimals read; `amountRaw` is authoritative and the immediate output reports `amount: null` and `decimals: null`.
 
-The compatibility defaults remain completion-oriented: message sends and Sails functions use `--wait reply`; WVARA transfers and message replies use `--wait receipt`. `--timeout-ms` applies to the reply-wait path, not submit-only RPC acceptance. A submit-only injected row remains pending locally; `--resume` cannot reattach to an in-flight validator promise until upstream subscription-by-hash support exists.
+The compatibility defaults remain completion-oriented: message sends and Sails functions use `--wait reply`; WVARA transfers and message replies use `--wait receipt`. `--timeout-ms` applies to the reply-wait path, not submit-only RPC acceptance. Submit-only injected sends are not stored as resumable pending rows; `--resume` only reports terminal outcomes captured by the reply-wait path until upstream subscription-by-hash support exists.
 
 A direct Sails submit can skip validator bootstrap only when `--idl <path>` is supplied. Without a local IDL, the wallet must query Vara.eth for the program code ID and embedded/cached interface before encoding the call.
 

--- a/docs/vara-eth-networks.md
+++ b/docs/vara-eth-networks.md
@@ -5,11 +5,13 @@ How to point vara-wallet at each Vara.eth deployment. Select via
 
 ## Preset registry
 
-| Name | Ethereum RPC | Vara.eth RPC | Router | WVARA | Block time |
-|------|-------------|--------------|--------|-------|------------|
-| `mainnet` | `wss://mainnet-reth-rpc.gear-tech.io/ws` | `wss://validator-1-eth.vara.network` | [`0x9C13FE9242…aA74cb6`](https://etherscan.io/address/0x9C13FE9242dfe2ba2Cd446480A9308279aA74cb6) | [`0xB67010F224…E9d7E5aD`](https://etherscan.io/address/0xB67010F2246814e5c39593ac23A925D9e9d7E5aD) | 12 s |
-| `hoodi`   | `wss://hoodi-reth-rpc.gear-tech.io/ws`   | `wss://vara-eth-validator-1.gear-tech.io` | [`0xE549b0AfEd…A0b060`](https://hoodi.etherscan.io/address/0xE549b0AfEdA978271FF7E712232B9F7f39A0b060) | [`0xE1ab85A8B4…d7E5aD`](https://hoodi.etherscan.io/address/0xE1ab85A8B4d5d5B6af0bbD0203EB322DF33d0464) | 12 s |
-| `local`   | `ws://127.0.0.1:8545` (Anvil) | `ws://127.0.0.1:9944` | discovered at runtime | bound to Router | 1 s |
+| Name | Ethereum WS | Ethereum HTTP | Vara.eth RPC | Router | WVARA | Block time |
+|------|-------------|---------------|--------------|--------|-------|------------|
+| `mainnet` | `wss://mainnet-reth-rpc.gear-tech.io/ws` | `https://mainnet-reth-rpc.gear-tech.io` | `wss://validator-1-eth.vara.network` | [`0x9C13FE9242…aA74cb6`](https://etherscan.io/address/0x9C13FE9242dfe2ba2Cd446480A9308279aA74cb6) | [`0xB67010F224…E9d7E5aD`](https://etherscan.io/address/0xB67010F2246814e5c39593ac23A925D9e9d7E5aD) | 12 s |
+| `hoodi`   | `wss://hoodi-reth-rpc.gear-tech.io/ws` | `https://hoodi-reth-rpc.gear-tech.io` | `wss://vara-eth-validator-1.gear-tech.io` | [`0xE549b0AfEd…A0b060`](https://hoodi.etherscan.io/address/0xE549b0AfEdA978271FF7E712232B9F7f39A0b060) | [`0xE1ab85A8B4…d7E5aD`](https://hoodi.etherscan.io/address/0xE1ab85A8B4d5d5B6af0bbD0203EB322DF33d0464) | 12 s |
+| `local`   | `ws://127.0.0.1:8545` (Anvil) | `http://127.0.0.1:8545` | `ws://127.0.0.1:9944` | discovered at runtime | bound to Router | 1 s |
+
+Normal Vara.eth commands use the HTTP endpoint for Ethereum-side JSON-RPC while the validator connection opens in parallel. Event subscriptions use Ethereum WebSocket because they require a persistent stream. For custom endpoints, set `ETHEREUM_HTTP_RPC`; if it is absent, requests fall back to `ETHEREUM_RPC`.
 
 Mainnet and Hoodi each expose an additional beacon RPC for EIP-7594 blob
 lookups (used by `vara-eth:program deploy` to upload WASM bytecode):

--- a/docs/vara-eth-networks.md
+++ b/docs/vara-eth-networks.md
@@ -11,7 +11,7 @@ How to point vara-wallet at each Vara.eth deployment. Select via
 | `hoodi`   | `wss://hoodi-reth-rpc.gear-tech.io/ws` | `https://hoodi-reth-rpc.gear-tech.io` | `wss://vara-eth-validator-1.gear-tech.io` | [`0xE549b0AfEd…A0b060`](https://hoodi.etherscan.io/address/0xE549b0AfEdA978271FF7E712232B9F7f39A0b060) | [`0xE1ab85A8B4…d7E5aD`](https://hoodi.etherscan.io/address/0xE1ab85A8B4d5d5B6af0bbD0203EB322DF33d0464) | 12 s |
 | `local`   | `ws://127.0.0.1:8545` (Anvil) | `http://127.0.0.1:8545` | `ws://127.0.0.1:9944` | discovered at runtime | bound to Router | 1 s |
 
-Normal Vara.eth commands use the HTTP endpoint for Ethereum-side JSON-RPC while the validator connection opens in parallel. Event subscriptions use Ethereum WebSocket because they require a persistent stream. For custom endpoints, set `ETHEREUM_HTTP_RPC`; if it is absent, requests fall back to `ETHEREUM_RPC`.
+Vara.eth commands use the HTTP endpoint for Ethereum-side request/response JSON-RPC. Commands that need validator state or injected transactions open the validator connection in parallel with Ethereum bootstrap. Direct Ethereum submit-only messages (`--via eth --wait submitted`), WVARA writes, and direct submit-only Sails calls with an explicit `--idl` do not open the validator connection. Event subscriptions use Ethereum WebSocket because they require a persistent stream. For custom endpoints, set `ETHEREUM_HTTP_RPC`; if it is absent, requests fall back to `ETHEREUM_RPC`.
 
 Mainnet and Hoodi each expose an additional beacon RPC for EIP-7594 blob
 lookups (used by `vara-eth:program deploy` to upload WASM bytecode):
@@ -34,7 +34,25 @@ vara-wallet --chain vara-eth --network mainnet vara-eth:wvara balance 0xYOUR_ADD
 # Send a message (needs an --account wallet and WVARA-funded signer)
 vara-wallet --chain vara-eth --network mainnet \
   vara-eth:message send 0xMIRROR --payload 0xfeed --account alice
+
+# Fast transaction-only path: return after RPC acceptance, before receipt/reply
+vara-wallet --chain vara-eth --network mainnet \
+  vara-eth:message send 0xMIRROR --payload 0xfeed --account alice \
+  --via eth --wait submitted
 ```
+
+## Submission versus completion
+
+Use `--wait submitted` for automation that only needs proof the RPC accepted a transaction:
+
+- Direct `--via eth` message output contains `txHash`, `status: "submitted"`, and `messageId: null`. The message ID is emitted by the Mirror contract and is unavailable until the Ethereum receipt is mined.
+- Injected output contains both `txHash` and the locally derived `messageId`, but no reply or validator-signature validation is performed.
+- WVARA transfers and message replies return their Ethereum `txHash` without waiting for a block receipt.
+- A raw-unit WVARA submit does not perform a decimals read; `amountRaw` is authoritative and the immediate output reports `amount: null` and `decimals: null`.
+
+The compatibility defaults remain completion-oriented: message sends and Sails functions use `--wait reply`; WVARA transfers and message replies use `--wait receipt`. `--timeout-ms` applies to the reply-wait path, not submit-only RPC acceptance. A submit-only injected row remains pending locally; `--resume` cannot reattach to an in-flight validator promise until upstream subscription-by-hash support exists.
+
+A direct Sails submit can skip validator bootstrap only when `--idl <path>` is supplied. Without a local IDL, the wallet must query Vara.eth for the program code ID and embedded/cached interface before encoding the call.
 
 Bridge / faucet links and full deployment status: see the official
 gear-tech announcement channels.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -367,6 +367,25 @@ describe('classifyTransportError', () => {
     expect(cli!.meta?.reason).toBe('dns_failure');
   });
 
+  it('finds transport codes nested multiple causes below a viem-style error', () => {
+    const socketError = Object.assign(new Error('getaddrinfo ENOTFOUND eth.example'), { code: 'ENOTFOUND' });
+    const fetchError = Object.assign(new Error('fetch failed'), { cause: socketError });
+    const viemError = Object.assign(new Error('HTTP request failed. URL: https://eth.example/'), {
+      cause: fetchError,
+    });
+
+    const cli = classifyTransportError(viemError, { endpoint: 'https://eth.example' });
+
+    expect(cli).toMatchObject({
+      code: 'TRANSPORT_ERROR',
+      meta: {
+        reason: 'dns_failure',
+        endpoint: 'https://eth.example',
+        host: 'eth.example',
+      },
+    });
+  });
+
   it('returns null for non-transport Error instances (e.g. PROGRAM_ERROR-style panics)', () => {
     expect(classifyTransportError(new Error('something else broke'))).toBeNull();
     expect(classifyTransportError(new Error('ENOENT: no such file'))).toBeNull();

--- a/src/__tests__/fixtures/vara-eth-api.stub.ts
+++ b/src/__tests__/fixtures/vara-eth-api.stub.ts
@@ -45,31 +45,57 @@ export class NoSailsIdlError extends VaraEthError {
 }
 export class LocalSigner {}
 let wsConnectImplementation: () => Promise<void> = async () => {};
-let createApiImplementation: () => Promise<unknown> = async () => ({});
+let createApiImplementation: (...args: unknown[]) => Promise<unknown> = async () => ({});
+let wsConnectCalls = 0;
 let wsDisconnectCalls = 0;
+let createApiCalls = 0;
+let lastCreateApiArgs: unknown[] = [];
 
 export function __setWsConnectImplementationForTests(fn: () => Promise<void>): void {
   wsConnectImplementation = fn;
 }
 
-export function __setCreateApiImplementationForTests(fn: () => Promise<unknown>): void {
+export function __setCreateApiImplementationForTests(fn: (...args: unknown[]) => Promise<unknown>): void {
   createApiImplementation = fn;
+}
+
+export function __getWsConnectCallsForTests(): number {
+  return wsConnectCalls;
 }
 
 export function __getWsDisconnectCallsForTests(): number {
   return wsDisconnectCalls;
 }
 
+export function __getCreateApiCallsForTests(): number {
+  return createApiCalls;
+}
+
+export function __getLastPublicClientTransportForTests(): string | undefined {
+  const client = lastCreateApiArgs[1] as { transport?: { type?: string } } | undefined;
+  return client?.transport?.type;
+}
+
 export function __resetVaraEthApiStubForTests(): void {
   wsConnectImplementation = async () => {};
   createApiImplementation = async () => ({});
+  wsConnectCalls = 0;
   wsDisconnectCalls = 0;
+  createApiCalls = 0;
+  lastCreateApiArgs = [];
 }
 
-export const createVaraEthApi = async () => createApiImplementation();
+export const createVaraEthApi = async (...args: unknown[]) => {
+  createApiCalls += 1;
+  lastCreateApiArgs = args;
+  return createApiImplementation(...args);
+};
 export class WsVaraEthProvider {
   constructor(_url: string) {}
-  async connect() { return wsConnectImplementation(); }
+  async connect() {
+    wsConnectCalls += 1;
+    return wsConnectImplementation();
+  }
   disconnect() { wsDisconnectCalls += 1; }
 }
 export class HttpVaraEthProvider {

--- a/src/__tests__/fixtures/vara-eth-api.stub.ts
+++ b/src/__tests__/fixtures/vara-eth-api.stub.ts
@@ -46,6 +46,7 @@ export class NoSailsIdlError extends VaraEthError {
 export class LocalSigner {}
 let ethereumClientConstructCalls = 0;
 let ethereumClientInitCalls = 0;
+let ethereumClientInitImplementation: () => Promise<void> = async () => {};
 export class EthereumClient {
   publicClient: unknown;
   routerAddress: unknown;
@@ -54,7 +55,10 @@ export class EthereumClient {
     this.publicClient = publicClient;
     this.routerAddress = routerAddress;
   }
-  async waitForInitialization() { ethereumClientInitCalls += 1; }
+  async waitForInitialization() {
+    ethereumClientInitCalls += 1;
+    await ethereumClientInitImplementation();
+  }
 }
 let wsConnectImplementation: () => Promise<void> = async () => {};
 let createApiImplementation: (...args: unknown[]) => Promise<unknown> = async () => ({});
@@ -69,6 +73,10 @@ export function __setWsConnectImplementationForTests(fn: () => Promise<void>): v
 
 export function __setCreateApiImplementationForTests(fn: (...args: unknown[]) => Promise<unknown>): void {
   createApiImplementation = fn;
+}
+
+export function __setEthereumClientInitImplementationForTests(fn: () => Promise<void>): void {
+  ethereumClientInitImplementation = fn;
 }
 
 export function __getWsConnectCallsForTests(): number {
@@ -104,6 +112,7 @@ export function __resetVaraEthApiStubForTests(): void {
   createApiCalls = 0;
   ethereumClientConstructCalls = 0;
   ethereumClientInitCalls = 0;
+  ethereumClientInitImplementation = async () => {};
   lastCreateApiArgs = [];
 }
 

--- a/src/__tests__/fixtures/vara-eth-api.stub.ts
+++ b/src/__tests__/fixtures/vara-eth-api.stub.ts
@@ -44,6 +44,18 @@ export class NoSailsIdlError extends VaraEthError {
   }
 }
 export class LocalSigner {}
+let ethereumClientConstructCalls = 0;
+let ethereumClientInitCalls = 0;
+export class EthereumClient {
+  publicClient: unknown;
+  routerAddress: unknown;
+  constructor(publicClient: unknown, routerAddress: unknown) {
+    ethereumClientConstructCalls += 1;
+    this.publicClient = publicClient;
+    this.routerAddress = routerAddress;
+  }
+  async waitForInitialization() { ethereumClientInitCalls += 1; }
+}
 let wsConnectImplementation: () => Promise<void> = async () => {};
 let createApiImplementation: (...args: unknown[]) => Promise<unknown> = async () => ({});
 let wsConnectCalls = 0;
@@ -71,6 +83,14 @@ export function __getCreateApiCallsForTests(): number {
   return createApiCalls;
 }
 
+export function __getEthereumClientConstructCallsForTests(): number {
+  return ethereumClientConstructCalls;
+}
+
+export function __getEthereumClientInitCallsForTests(): number {
+  return ethereumClientInitCalls;
+}
+
 export function __getLastPublicClientTransportForTests(): string | undefined {
   const client = lastCreateApiArgs[1] as { transport?: { type?: string } } | undefined;
   return client?.transport?.type;
@@ -82,6 +102,8 @@ export function __resetVaraEthApiStubForTests(): void {
   wsConnectCalls = 0;
   wsDisconnectCalls = 0;
   createApiCalls = 0;
+  ethereumClientConstructCalls = 0;
+  ethereumClientInitCalls = 0;
   lastCreateApiArgs = [];
 }
 

--- a/src/__tests__/vara-eth-actions.test.ts
+++ b/src/__tests__/vara-eth-actions.test.ts
@@ -29,6 +29,9 @@ const mockGetMirrorClient = jest.fn();
 const mockProgramEvents = jest.fn();
 const mockRouterEvents = jest.fn();
 const mockBlocks = jest.fn();
+const mockCalculateReplyForHandle = jest.fn();
+const mockInitPromiseStore = jest.fn();
+const mockInsertPending = jest.fn();
 
 const mockApi = {
   eth: {
@@ -63,7 +66,7 @@ const mockApi = {
   },
   call: {
     program: {
-      calculateReplyForHandle: jest.fn(),
+      calculateReplyForHandle: mockCalculateReplyForHandle,
     },
   },
   stream: {
@@ -87,6 +90,14 @@ jest.mock('../services/vara-eth/api', () => ({
 jest.mock('../services/vara-eth/account', () => ({
   resolveEthexeAccountAddress: jest.fn(),
   resolveEthexeSigner: jest.fn(),
+}));
+
+jest.mock('../services/vara-eth/promises', () => ({
+  getById: jest.fn(),
+  initPromiseStore: (...args: unknown[]) => mockInitPromiseStore(...args),
+  insertPending: (...args: unknown[]) => mockInsertPending(...args),
+  markFailed: jest.fn(),
+  markResolved: jest.fn(),
 }));
 
 const mockOutput = jest.fn();
@@ -148,6 +159,11 @@ beforeEach(() => {
   mockProgramEvents.mockReturnValue(jest.fn());
   mockRouterEvents.mockReturnValue(jest.fn());
   mockBlocks.mockReturnValue(jest.fn());
+  mockCalculateReplyForHandle.mockResolvedValue({
+    payload: '0x00',
+    value: 0n,
+    code: { isSuccess: true, isError: false, toBytes: () => new Uint8Array([0]) },
+  });
   mockSendAndWaitForReceipt.mockResolvedValue({
     transactionHash: TX_HASH,
     blockNumber: 123n,
@@ -383,6 +399,7 @@ describe('Vara.eth shared actions', () => {
       messageId: MESSAGE_ID,
       reply: null,
     }));
+    expect(mockInsertPending).not.toHaveBeenCalled();
   });
 
   it('rejects invalid wait modes before opening either RPC context', async () => {
@@ -484,6 +501,37 @@ describe('Vara.eth shared actions', () => {
       },
       willSubmit: false,
     }));
+  });
+
+  it('keeps the validator API for submitted-wait Sails queries with a local IDL', async () => {
+    mockCalculateReplyForHandle.mockRejectedValueOnce(new Error('query reached validator API'));
+
+    await expect(outputVaraEthSailsCall(TO, 'Demo/GetMaybe', {
+      idl: FIXTURE_IDL,
+      args: '[]',
+      value: '0',
+      via: 'eth',
+      wait: 'submitted',
+    })).rejects.toThrow('query reached validator API');
+    expect(getEthexeApi).toHaveBeenCalled();
+    expect(mockCalculateReplyForHandle).toHaveBeenCalled();
+  });
+
+  it('keeps the validator API for submitted-wait Sails fee estimates', async () => {
+    const hash = '0x' + '55'.repeat(32);
+
+    await outputVaraEthSailsCall(TO, 'Demo/Echo', {
+      idl: FIXTURE_IDL,
+      args: `["0xaabb","${hash}"]`,
+      value: '0',
+      via: 'eth',
+      wait: 'submitted',
+      dryRun: true,
+      estimate: true,
+    });
+
+    expect(getEthexeApi).toHaveBeenCalled();
+    expect(mockEstimateFee).toHaveBeenCalled();
   });
 
   it('decodes empty replies for Vara.eth Sails v1 null-return functions', async () => {

--- a/src/__tests__/vara-eth-actions.test.ts
+++ b/src/__tests__/vara-eth-actions.test.ts
@@ -22,6 +22,9 @@ const mockEstimateFee = jest.fn();
 const mockSetSigner = jest.fn();
 const mockGetAddress = jest.fn();
 const mockSendAndWaitForReceipt = jest.fn();
+const mockSend = jest.fn();
+const mockSendMessage = jest.fn();
+const mockCreateInjectedTransaction = jest.fn();
 const mockGetMirrorClient = jest.fn();
 const mockProgramEvents = jest.fn();
 const mockRouterEvents = jest.fn();
@@ -46,6 +49,7 @@ const mockApi = {
     deploy: mockDeploy,
     sendAndWait: mockSendAndWait,
   },
+  createInjectedTransaction: mockCreateInjectedTransaction,
   fees: {
     estimate: mockEstimateFee,
   },
@@ -75,6 +79,8 @@ const mockSigner = {
 
 jest.mock('../services/vara-eth/api', () => ({
   getEthexeApi: jest.fn(),
+  getEthexeEthereumContext: jest.fn(),
+  getEthexeEthereumClient: jest.fn(),
   getMirrorClient: (...args: unknown[]) => mockGetMirrorClient(...args),
 }));
 
@@ -91,7 +97,15 @@ jest.mock('../utils', () => ({
   verbose: jest.fn(),
 }));
 
-const { getEthexeApi } = require('../services/vara-eth/api') as { getEthexeApi: jest.Mock };
+const {
+  getEthexeApi,
+  getEthexeEthereumContext,
+  getEthexeEthereumClient,
+} = require('../services/vara-eth/api') as {
+  getEthexeApi: jest.Mock;
+  getEthexeEthereumContext: jest.Mock;
+  getEthexeEthereumClient: jest.Mock;
+};
 const {
   resolveEthexeAccountAddress,
   resolveEthexeSigner,
@@ -122,6 +136,8 @@ const FIXTURE_IDL = join(__dirname, 'fixtures', 'sample-v2.idl');
 beforeEach(() => {
   jest.clearAllMocks();
   getEthexeApi.mockResolvedValue(mockApi);
+  getEthexeEthereumContext.mockReturnValue({ publicClient: mockApi.eth.publicClient });
+  getEthexeEthereumClient.mockResolvedValue(mockApi.eth);
   resolveEthexeAccountAddress.mockReturnValue(ADDRESS);
   resolveEthexeSigner.mockResolvedValue(mockSigner);
   mockGetBalance.mockResolvedValue(2_000_000_000_000_000_000n);
@@ -137,10 +153,17 @@ beforeEach(() => {
     blockNumber: 123n,
     status: 'success',
   });
-  mockTransfer.mockResolvedValue({ sendAndWaitForReceipt: mockSendAndWaitForReceipt });
+  mockSend.mockResolvedValue(TX_HASH);
+  mockTransfer.mockResolvedValue({ send: mockSend, sendAndWaitForReceipt: mockSendAndWaitForReceipt });
   mockPrepareAndSignPermitData.mockResolvedValue({ signature: '0xsig' });
   mockExecutableBalanceTopUpWithPermit.mockResolvedValue({ sendAndWaitForReceipt: mockSendAndWaitForReceipt });
   mockSendReply.mockResolvedValue({ sendAndWaitForReceipt: mockSendAndWaitForReceipt });
+  mockSendMessage.mockResolvedValue({ send: mockSend, sendAndWaitForReceipt: mockSendAndWaitForReceipt });
+  mockCreateInjectedTransaction.mockResolvedValue({
+    send: mockSend,
+    txHash: TX_HASH,
+    messageId: MESSAGE_ID,
+  });
   mockDeploy.mockResolvedValue({
     codeId: CODE_ID,
     programAddress: TO,
@@ -168,6 +191,7 @@ beforeEach(() => {
   mockGetMirrorClient.mockResolvedValue({
     executableBalanceTopUpWithPermit: mockExecutableBalanceTopUpWithPermit,
     sendReply: mockSendReply,
+    sendMessage: mockSendMessage,
   });
 });
 
@@ -228,6 +252,25 @@ describe('Vara.eth shared actions', () => {
     }));
   });
 
+  it('returns after WVARA submission without waiting for a receipt', async () => {
+    await outputVaraEthWvaraTransfer(TO, '1', {
+      account: 'hoodi-smoke',
+      units: 'raw',
+      wait: 'submitted',
+    });
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSendAndWaitForReceipt).not.toHaveBeenCalled();
+    expect(mockDecimals).not.toHaveBeenCalled();
+    expect(getEthexeApi).not.toHaveBeenCalled();
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      txHash: TX_HASH,
+      status: 'submitted',
+      wait: 'submitted',
+      blockNumber: null,
+    }));
+  });
+
   it('tops up via WVARA permit in one submitted transaction', async () => {
     mockDecimals.mockResolvedValue(12);
 
@@ -259,6 +302,26 @@ describe('Vara.eth shared actions', () => {
     }));
   });
 
+  it('returns after reply submission without waiting for a receipt', async () => {
+    const messageId = '0x' + '22'.repeat(32);
+    mockSendReply.mockResolvedValueOnce({ send: mockSend, sendAndWaitForReceipt: mockSendAndWaitForReceipt });
+
+    await outputVaraEthMessageReply(TO, messageId, {
+      account: 'hoodi-smoke',
+      payload: '0xabcd',
+      wait: 'submitted',
+    });
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSendAndWaitForReceipt).not.toHaveBeenCalled();
+    expect(getEthexeApi).not.toHaveBeenCalled();
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      txHash: TX_HASH,
+      status: 'submitted',
+      wait: 'submitted',
+    }));
+  });
+
   it('passes validated timeoutMs to Vara.eth message sends', async () => {
     await outputVaraEthMessageSend(TO, {
       account: 'hoodi-smoke',
@@ -273,6 +336,67 @@ describe('Vara.eth shared actions', () => {
       timeoutMs: 2500,
       validateSignature: true,
     });
+  });
+
+  it('submits direct Ethereum messages without opening the validator API', async () => {
+    await outputVaraEthMessageSend(TO, {
+      account: 'hoodi-smoke',
+      payload: '0xabcd',
+      via: 'eth',
+      wait: 'submitted',
+    });
+
+    expect(getEthexeApi).not.toHaveBeenCalled();
+    expect(mockSendMessage).toHaveBeenCalledWith('0xabcd', undefined);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSendAndWait).not.toHaveBeenCalled();
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      via: 'eth',
+      wait: 'submitted',
+      status: 'submitted',
+      txHash: TX_HASH,
+      messageId: null,
+      reply: null,
+    }));
+  });
+
+  it('uses the injected send RPC without opening a receipt subscription', async () => {
+    await outputVaraEthMessageSend(TO, {
+      account: 'hoodi-smoke',
+      payload: '0xabcd',
+      via: 'injected',
+      wait: 'submitted',
+    });
+
+    expect(mockCreateInjectedTransaction).toHaveBeenCalledWith({
+      destination: TO,
+      payload: '0xabcd',
+      value: 0n,
+    });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSendAndWait).not.toHaveBeenCalled();
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      via: 'injected',
+      wait: 'submitted',
+      status: 'submitted',
+      txHash: TX_HASH,
+      messageId: MESSAGE_ID,
+      reply: null,
+    }));
+  });
+
+  it('rejects invalid wait modes before opening either RPC context', async () => {
+    await expect(outputVaraEthMessageSend(TO, {
+      account: 'hoodi-smoke',
+      payload: '0xabcd',
+      wait: 'finalized',
+    })).rejects.toMatchObject({
+      code: 'INVALID_WAIT_MODE',
+      meta: { wait: 'finalized', allowed: ['submitted', 'reply'] },
+    });
+
+    expect(getEthexeEthereumContext).not.toHaveBeenCalled();
+    expect(getEthexeApi).not.toHaveBeenCalled();
   });
 
   it('rejects invalid Vara.eth message send timeouts before opening the API', async () => {
@@ -400,6 +524,34 @@ describe('Vara.eth shared actions', () => {
       reply: expect.objectContaining({
         payload: '0x',
       }),
+    }));
+  });
+
+  it('submits a locally-described Sails call without opening the validator API', async () => {
+    const hash = '0x' + '55'.repeat(32);
+
+    await outputVaraEthSailsCall(TO, 'Demo/Echo', {
+      account: 'hoodi-smoke',
+      idl: FIXTURE_IDL,
+      args: `["0xaabb","${hash}"]`,
+      value: '0',
+      via: 'eth',
+      wait: 'submitted',
+    });
+
+    expect(getEthexeApi).not.toHaveBeenCalled();
+    expect(mockSendMessage).toHaveBeenCalledWith(expect.stringMatching(/^0x/), 0n);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSendAndWait).not.toHaveBeenCalled();
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      chain: 'vara-eth',
+      kind: 'function',
+      status: 'submitted',
+      wait: 'submitted',
+      txHash: TX_HASH,
+      messageId: null,
+      result: null,
+      reply: null,
     }));
   });
 

--- a/src/__tests__/vara-eth-actions.test.ts
+++ b/src/__tests__/vara-eth-actions.test.ts
@@ -23,6 +23,9 @@ const mockSetSigner = jest.fn();
 const mockGetAddress = jest.fn();
 const mockSendAndWaitForReceipt = jest.fn();
 const mockGetMirrorClient = jest.fn();
+const mockProgramEvents = jest.fn();
+const mockRouterEvents = jest.fn();
+const mockBlocks = jest.fn();
 
 const mockApi = {
   eth: {
@@ -58,6 +61,11 @@ const mockApi = {
     program: {
       calculateReplyForHandle: jest.fn(),
     },
+  },
+  stream: {
+    programEvents: mockProgramEvents,
+    routerEvents: mockRouterEvents,
+    blocks: mockBlocks,
   },
 };
 
@@ -101,6 +109,9 @@ import {
   outputVaraEthSailsCall,
   outputVaraEthProgramTopUp,
   outputVaraEthWvaraTransfer,
+  subscribeVaraEthBlocks,
+  subscribeVaraEthProgram,
+  subscribeVaraEthRouter,
   _isNullReturnTypeForTests,
 } from '../commands/vara-eth-actions';
 import { CliError } from '../utils/errors';
@@ -118,6 +129,9 @@ beforeEach(() => {
   mockDecimals.mockResolvedValue(18);
   mockSymbol.mockResolvedValue('WVARA');
   mockGetAddress.mockResolvedValue(ADDRESS);
+  mockProgramEvents.mockReturnValue(jest.fn());
+  mockRouterEvents.mockReturnValue(jest.fn());
+  mockBlocks.mockReturnValue(jest.fn());
   mockSendAndWaitForReceipt.mockResolvedValue({
     transactionHash: TX_HASH,
     blockNumber: 123n,
@@ -154,6 +168,20 @@ beforeEach(() => {
   mockGetMirrorClient.mockResolvedValue({
     executableBalanceTopUpWithPermit: mockExecutableBalanceTopUpWithPermit,
     sendReply: mockSendReply,
+  });
+});
+
+describe('Vara.eth subscription transport', () => {
+  it('keeps every event stream on the Ethereum WebSocket transport', async () => {
+    const finishImmediately = async (unsubscribe: () => void) => unsubscribe();
+
+    await subscribeVaraEthProgram(ADDRESS, { persist: false }, finishImmediately);
+    await subscribeVaraEthRouter({ persist: false }, finishImmediately);
+    await subscribeVaraEthBlocks({ persist: false }, finishImmediately);
+
+    expect(getEthexeApi).toHaveBeenNthCalledWith(1, { ethereumTransport: 'stream' });
+    expect(getEthexeApi).toHaveBeenNthCalledWith(2, { ethereumTransport: 'stream' });
+    expect(getEthexeApi).toHaveBeenNthCalledWith(3, { ethereumTransport: 'stream' });
   });
 });
 

--- a/src/__tests__/vara-eth-api.test.ts
+++ b/src/__tests__/vara-eth-api.test.ts
@@ -255,6 +255,28 @@ describe('getEthexeApi', () => {
     expect(apiStub.__getCreateApiCallsForTests()).toBe(0);
   });
 
+  it('does not let a stale Ethereum-client failure clear a newer initialization', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __setEthereumClientInitImplementationForTests: (fn: () => Promise<void>) => void;
+    };
+    let rejectFirst!: (error: Error) => void;
+    apiStub.__setEthereumClientInitImplementationForTests(() => new Promise<void>((_resolve, reject) => {
+      rejectFirst = reject;
+    }));
+
+    const first = getEthexeEthereumClient({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+    await Promise.resolve();
+    disconnectEthexeApi();
+    apiStub.__setEthereumClientInitImplementationForTests(async () => {});
+    const second = getEthexeEthereumClient({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+    await expect(second).resolves.toBeDefined();
+
+    rejectFirst(new Error('first initialization failed'));
+    await expect(first).rejects.toMatchObject({ code: 'TRANSPORT_ERROR' });
+
+    expect(getEthexeEthereumClient({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER })).toBe(second);
+  });
+
   it('starts validator connection and API bootstrap concurrently, then caches the result', async () => {
     const apiStub = require('@vara-eth/api') as {
       __setWsConnectImplementationForTests: (fn: () => Promise<void>) => void;

--- a/src/__tests__/vara-eth-api.test.ts
+++ b/src/__tests__/vara-eth-api.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { disconnectEthexeApi, getEthexeApi, resolveEthexeConfig } from '../services/vara-eth/api';
+import {
+  disconnectEthexeApi,
+  getEthexeApi,
+  getEthexeEthereumClient,
+  getEthexeEthereumContext,
+  resolveEthexeConfig,
+} from '../services/vara-eth/api';
 
 const LOCAL_PRESET = {
   varaEthRpc: 'ws://127.0.0.1:9944',
@@ -217,6 +223,38 @@ describe('resolveEthexeConfig', () => {
 });
 
 describe('getEthexeApi', () => {
+  it('creates an Ethereum request context without opening the validator API', () => {
+    const apiStub = require('@vara-eth/api') as {
+      __getWsConnectCallsForTests: () => number;
+      __getCreateApiCallsForTests: () => number;
+    };
+
+    const context = getEthexeEthereumContext({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+
+    expect(context.transport).toBe('http');
+    expect(context.endpoint).toBe(LOCAL_PRESET.ethereumHttpRpc);
+    expect(apiStub.__getWsConnectCallsForTests()).toBe(0);
+    expect(apiStub.__getCreateApiCallsForTests()).toBe(0);
+  });
+
+  it('initializes and caches an Ethereum-only client without opening the validator API', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __getWsConnectCallsForTests: () => number;
+      __getCreateApiCallsForTests: () => number;
+      __getEthereumClientConstructCallsForTests: () => number;
+      __getEthereumClientInitCallsForTests: () => number;
+    };
+
+    const first = await getEthexeEthereumClient({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+    const second = await getEthexeEthereumClient({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+
+    expect(second).toBe(first);
+    expect(apiStub.__getEthereumClientConstructCallsForTests()).toBe(1);
+    expect(apiStub.__getEthereumClientInitCallsForTests()).toBe(1);
+    expect(apiStub.__getWsConnectCallsForTests()).toBe(0);
+    expect(apiStub.__getCreateApiCallsForTests()).toBe(0);
+  });
+
   it('starts validator connection and API bootstrap concurrently, then caches the result', async () => {
     const apiStub = require('@vara-eth/api') as {
       __setWsConnectImplementationForTests: (fn: () => Promise<void>) => void;

--- a/src/__tests__/vara-eth-api.test.ts
+++ b/src/__tests__/vara-eth-api.test.ts
@@ -178,6 +178,26 @@ describe('resolveEthexeConfig', () => {
     expect(cfg.ethereumHttpRpc).toBeUndefined();
   });
 
+  it('keeps an explicit Ethereum WebSocket ahead of an options network preset HTTP endpoint', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __getLastPublicClientTransportForTests: () => string | undefined;
+    };
+
+    const cfg = resolveEthexeConfig({
+      networkPreset: LOCAL_PRESET,
+      ethereumRpc: 'wss://custom-eth.example',
+      routerAddress: EXPLICIT_ROUTER,
+    });
+    expect(cfg.ethereumHttpRpc).toBeUndefined();
+
+    await getEthexeApi({
+      networkPreset: LOCAL_PRESET,
+      ethereumRpc: 'wss://custom-eth.example',
+      routerAddress: EXPLICIT_ROUTER,
+    });
+    expect(apiStub.__getLastPublicClientTransportForTests()).toBe('webSocket');
+  });
+
   it('does not fall back to a persisted router when the command-line preset needs local discovery', () => {
     writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
       varaEthNetwork: 'mainnet',
@@ -263,6 +283,20 @@ describe('getEthexeApi', () => {
     expect(apiStub.__getLastPublicClientTransportForTests()).toBe('webSocket');
   });
 
+  it('identifies a malformed HTTP override by its actual config key', async () => {
+    await expect(getEthexeApi({
+      networkPreset: LOCAL_PRESET,
+      ethereumHttpRpc: 'ftp://invalid.example',
+      routerAddress: EXPLICIT_ROUTER,
+    })).rejects.toMatchObject({
+      code: 'INVALID_CONFIG_VALUE',
+      meta: {
+        key: 'ethereumHttpRpc',
+        value: 'ftp://invalid.example',
+      },
+    });
+  });
+
   it('classifies Vara.eth provider connect timeouts and disconnects the provider', async () => {
     jest.useFakeTimers();
     const apiStub = require('@vara-eth/api') as {
@@ -304,6 +338,54 @@ describe('getEthexeApi', () => {
     expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
   });
 
+  it('attributes nested Ethereum HTTP failures to the HTTP endpoint', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __setCreateApiImplementationForTests: (fn: () => Promise<unknown>) => void;
+    };
+    const socketError = Object.assign(new Error('getaddrinfo ENOTFOUND custom-eth.example'), {
+      code: 'ENOTFOUND',
+    });
+    const fetchError = Object.assign(new Error('fetch failed'), { cause: socketError });
+    apiStub.__setCreateApiImplementationForTests(async () => {
+      throw Object.assign(
+        new Error(`HTTP request failed. URL: ${LOCAL_PRESET.ethereumHttpRpc}/`),
+        { cause: fetchError },
+      );
+    });
+
+    await expect(getEthexeApi({
+      networkPreset: LOCAL_PRESET,
+      routerAddress: EXPLICIT_ROUTER,
+    })).rejects.toMatchObject({
+      code: 'TRANSPORT_ERROR',
+      meta: {
+        reason: 'dns_failure',
+        endpoint: LOCAL_PRESET.ethereumHttpRpc,
+        host: '127.0.0.1',
+      },
+    });
+  });
+
+  it('attributes a bootstrap timeout to HTTP after the validator is connected', async () => {
+    jest.useFakeTimers();
+    const apiStub = require('@vara-eth/api') as {
+      __setCreateApiImplementationForTests: (fn: () => Promise<unknown>) => void;
+    };
+    apiStub.__setCreateApiImplementationForTests(() => new Promise(() => {}));
+
+    const promise = getEthexeApi({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+    await Promise.resolve();
+    jest.advanceTimersByTime(10_000);
+
+    await expect(promise).rejects.toMatchObject({
+      code: 'TRANSPORT_ERROR',
+      meta: {
+        reason: 'timeout',
+        endpoint: LOCAL_PRESET.ethereumHttpRpc,
+      },
+    });
+  });
+
   it('disconnects late-settling provider connections after a timeout', async () => {
     jest.useFakeTimers();
     const apiStub = require('@vara-eth/api') as {
@@ -328,10 +410,9 @@ describe('getEthexeApi', () => {
     expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
 
     resolveConnect();
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let i = 0; i < 6; i += 1) await Promise.resolve();
 
-    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
+    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(2);
   });
 
   it('consumes a late API-bootstrap rejection after the shared timeout', async () => {
@@ -352,9 +433,8 @@ describe('getEthexeApi', () => {
     await expect(promise).rejects.toMatchObject({ code: 'TRANSPORT_ERROR' });
 
     rejectApi(new Error('late bootstrap failure'));
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let i = 0; i < 6; i += 1) await Promise.resolve();
 
-    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
+    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(2);
   });
 });

--- a/src/__tests__/vara-eth-api.test.ts
+++ b/src/__tests__/vara-eth-api.test.ts
@@ -7,6 +7,7 @@ import { disconnectEthexeApi, getEthexeApi, resolveEthexeConfig } from '../servi
 const LOCAL_PRESET = {
   varaEthRpc: 'ws://127.0.0.1:9944',
   ethereumRpc: 'ws://127.0.0.1:8545',
+  ethereumHttpRpc: 'http://127.0.0.1:8545',
   routerAddress: null,
 };
 
@@ -22,10 +23,12 @@ const ENV_KEYS = [
   'VARA_WALLET_DIR',
   'VARA_ETH_ROUTER',
   'ETHEREUM_RPC',
+  'ETHEREUM_HTTP_RPC',
   'VARA_ETH_RPC',
   'VARA_ETH_NETWORK_PRESET_NAME',
   'VARA_ETH_NETWORK_PRESET_VARA_ETH_RPC',
   'VARA_ETH_NETWORK_PRESET_ETHEREUM_RPC',
+  'VARA_ETH_NETWORK_PRESET_ETHEREUM_HTTP_RPC',
   'VARA_ETH_NETWORK_PRESET_ROUTER',
 ] as const;
 
@@ -100,6 +103,7 @@ describe('resolveEthexeConfig', () => {
 
     expect(cfg.varaEthRpc).toBe(LOCAL_PRESET.varaEthRpc);
     expect(cfg.ethereumRpc).toBe(LOCAL_PRESET.ethereumRpc);
+    expect(cfg.ethereumHttpRpc).toBe(LOCAL_PRESET.ethereumHttpRpc);
     expect(cfg.routerAddress).toBe(DISCOVERED_ROUTER);
   });
 
@@ -116,12 +120,14 @@ describe('resolveEthexeConfig', () => {
     writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({ varaEthNetwork: 'mainnet' }) + '\n');
     process.env.VARA_ETH_NETWORK_PRESET_VARA_ETH_RPC = 'wss://hoodi-validator.example';
     process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_RPC = 'wss://hoodi-eth.example';
+    process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_HTTP_RPC = 'https://hoodi-eth.example';
     process.env.VARA_ETH_NETWORK_PRESET_ROUTER = CLI_ROUTER;
 
     const cfg = resolveEthexeConfig();
 
     expect(cfg.varaEthRpc).toBe('wss://hoodi-validator.example');
     expect(cfg.ethereumRpc).toBe('wss://hoodi-eth.example');
+    expect(cfg.ethereumHttpRpc).toBe('https://hoodi-eth.example');
     expect(cfg.routerAddress).toBe(CLI_ROUTER);
   });
 
@@ -138,6 +144,38 @@ describe('resolveEthexeConfig', () => {
     expect(cfg.varaEthRpc).toBe('wss://hoodi-validator.example');
     expect(cfg.ethereumRpc).toBe('wss://hoodi-eth.example');
     expect(cfg.routerAddress).toBe(CLI_ROUTER);
+  });
+
+  it('accepts an explicit HTTP endpoint for one-shot Ethereum requests', () => {
+    process.env.ETHEREUM_HTTP_RPC = 'https://custom-eth.example';
+
+    const cfg = resolveEthexeConfig({
+      varaEthRpc: LOCAL_PRESET.varaEthRpc,
+      ethereumRpc: LOCAL_PRESET.ethereumRpc,
+      routerAddress: EXPLICIT_ROUTER,
+    });
+
+    expect(cfg.ethereumHttpRpc).toBe('https://custom-eth.example');
+
+    const explicit = resolveEthexeConfig({
+      varaEthRpc: LOCAL_PRESET.varaEthRpc,
+      ethereumRpc: LOCAL_PRESET.ethereumRpc,
+      ethereumHttpRpc: 'https://explicit-eth.example',
+      routerAddress: EXPLICIT_ROUTER,
+    });
+    expect(explicit.ethereumHttpRpc).toBe('https://explicit-eth.example');
+  });
+
+  it('does not borrow a preset HTTP endpoint for a custom Ethereum WebSocket', () => {
+    writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({ varaEthNetwork: 'hoodi' }) + '\n');
+
+    const cfg = resolveEthexeConfig({
+      ethereumRpc: 'wss://custom-eth.example',
+      routerAddress: EXPLICIT_ROUTER,
+    });
+
+    expect(cfg.ethereumRpc).toBe('wss://custom-eth.example');
+    expect(cfg.ethereumHttpRpc).toBeUndefined();
   });
 
   it('does not fall back to a persisted router when the command-line preset needs local discovery', () => {
@@ -159,6 +197,72 @@ describe('resolveEthexeConfig', () => {
 });
 
 describe('getEthexeApi', () => {
+  it('starts validator connection and API bootstrap concurrently, then caches the result', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __setWsConnectImplementationForTests: (fn: () => Promise<void>) => void;
+      __setCreateApiImplementationForTests: (fn: () => Promise<unknown>) => void;
+      __getWsConnectCallsForTests: () => number;
+      __getCreateApiCallsForTests: () => number;
+    };
+    let resolveConnect!: () => void;
+    let resolveApi!: (value: unknown) => void;
+    const expectedApi = { initialized: true };
+    apiStub.__setWsConnectImplementationForTests(() => new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    }));
+    apiStub.__setCreateApiImplementationForTests(() => new Promise((resolve) => {
+      resolveApi = resolve;
+    }));
+
+    const promise = getEthexeApi({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+
+    expect(apiStub.__getWsConnectCallsForTests()).toBe(1);
+    expect(apiStub.__getCreateApiCallsForTests()).toBe(1);
+
+    resolveConnect();
+    resolveApi(expectedApi);
+    await expect(promise).resolves.toBe(expectedApi);
+    await expect(getEthexeApi({
+      varaEthRpc: 'wss://ignored.example',
+      ethereumRpc: 'wss://ignored.example',
+      routerAddress: FALLBACK_ROUTER,
+    })).resolves.toBe(expectedApi);
+    expect(apiStub.__getWsConnectCallsForTests()).toBe(1);
+    expect(apiStub.__getCreateApiCallsForTests()).toBe(1);
+  });
+
+  it('uses HTTP for requests and WebSocket for streams', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __getLastPublicClientTransportForTests: () => string | undefined;
+    };
+
+    await getEthexeApi({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+    expect(apiStub.__getLastPublicClientTransportForTests()).toBe('http');
+
+    disconnectEthexeApi();
+    await getEthexeApi({
+      networkPreset: LOCAL_PRESET,
+      routerAddress: EXPLICIT_ROUTER,
+      ethereumTransport: 'stream',
+    });
+    expect(apiStub.__getLastPublicClientTransportForTests()).toBe('webSocket');
+  });
+
+  it('falls back to the configured Ethereum WebSocket when no HTTP endpoint exists', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __getLastPublicClientTransportForTests: () => string | undefined;
+    };
+    const customPreset = {
+      varaEthRpc: LOCAL_PRESET.varaEthRpc,
+      ethereumRpc: LOCAL_PRESET.ethereumRpc,
+      routerAddress: EXPLICIT_ROUTER,
+    } as const;
+
+    await getEthexeApi({ networkPreset: customPreset });
+
+    expect(apiStub.__getLastPublicClientTransportForTests()).toBe('webSocket');
+  });
+
   it('classifies Vara.eth provider connect timeouts and disconnects the provider', async () => {
     jest.useFakeTimers();
     const apiStub = require('@vara-eth/api') as {
@@ -177,6 +281,26 @@ describe('getEthexeApi', () => {
         endpoint: LOCAL_PRESET.varaEthRpc,
       },
     });
+    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
+  });
+
+  it('disconnects exactly once when API bootstrap fails', async () => {
+    const apiStub = require('@vara-eth/api') as {
+      __setCreateApiImplementationForTests: (fn: () => Promise<unknown>) => void;
+      __getWsDisconnectCallsForTests: () => number;
+    };
+    apiStub.__setCreateApiImplementationForTests(async () => {
+      throw new Error('bootstrap failed');
+    });
+
+    await expect(getEthexeApi({
+      networkPreset: LOCAL_PRESET,
+      routerAddress: EXPLICIT_ROUTER,
+    })).rejects.toMatchObject({
+      code: 'TRANSPORT_ERROR',
+      meta: { cause: 'bootstrap failed' },
+    });
+
     expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
   });
 
@@ -207,6 +331,30 @@ describe('getEthexeApi', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(2);
+    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
+  });
+
+  it('consumes a late API-bootstrap rejection after the shared timeout', async () => {
+    jest.useFakeTimers();
+    const apiStub = require('@vara-eth/api') as {
+      __setWsConnectImplementationForTests: (fn: () => Promise<void>) => void;
+      __setCreateApiImplementationForTests: (fn: () => Promise<unknown>) => void;
+      __getWsDisconnectCallsForTests: () => number;
+    };
+    let rejectApi!: (error: Error) => void;
+    apiStub.__setWsConnectImplementationForTests(() => new Promise(() => {}));
+    apiStub.__setCreateApiImplementationForTests(() => new Promise((_, reject) => {
+      rejectApi = reject;
+    }));
+
+    const promise = getEthexeApi({ networkPreset: LOCAL_PRESET, routerAddress: EXPLICIT_ROUTER });
+    jest.advanceTimersByTime(10_000);
+    await expect(promise).rejects.toMatchObject({ code: 'TRANSPORT_ERROR' });
+
+    rejectApi(new Error('late bootstrap failure'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(apiStub.__getWsDisconnectCallsForTests()).toBe(1);
   });
 });

--- a/src/__tests__/vara-eth-networks.test.ts
+++ b/src/__tests__/vara-eth-networks.test.ts
@@ -10,6 +10,7 @@ describe('resolveVaraEthNetwork', () => {
     const cfg = resolveVaraEthNetwork('local');
     expect(cfg.routerAddress).toBeNull();
     expect(cfg.ethereumRpc).toBe('ws://127.0.0.1:8545');
+    expect(cfg.ethereumHttpRpc).toBe('http://127.0.0.1:8545');
     expect(cfg.varaEthRpc).toBe('ws://127.0.0.1:9944');
     expect(cfg.blockTimeMs).toBe(1_000);
   });
@@ -17,6 +18,7 @@ describe('resolveVaraEthNetwork', () => {
   it('returns the hoodi preset with the canonical router + WVARA addresses', () => {
     const cfg = resolveVaraEthNetwork('hoodi');
     expect(cfg.ethereumRpc).toContain('hoodi-reth-rpc.gear-tech.io');
+    expect(cfg.ethereumHttpRpc).toBe('https://hoodi-reth-rpc.gear-tech.io');
     expect(cfg.beaconRpc).toContain('hoodi-lighthouse-rpc.gear-tech.io');
     expect(cfg.varaEthRpc).toContain('vara-eth-validator-1.gear-tech.io');
     expect(cfg.blockTimeMs).toBe(12_000);
@@ -27,6 +29,7 @@ describe('resolveVaraEthNetwork', () => {
   it('returns the mainnet preset with the canonical router + WVARA addresses', () => {
     const cfg = resolveVaraEthNetwork('mainnet');
     expect(cfg.ethereumRpc).toContain('mainnet-reth-rpc.gear-tech.io');
+    expect(cfg.ethereumHttpRpc).toBe('https://mainnet-reth-rpc.gear-tech.io');
     expect(cfg.beaconRpc).toContain('mainnet-lighthouse-rpc.gear-tech.io');
     expect(cfg.varaEthRpc).toContain('validator-1-eth.vara.network');
     expect(cfg.blockTimeMs).toBe(12_000);

--- a/src/__tests__/vara-eth-root-message-routing.test.ts
+++ b/src/__tests__/vara-eth-root-message-routing.test.ts
@@ -60,6 +60,21 @@ describe('root --chain vara-eth message routing', () => {
     }));
   });
 
+  it('routes submit-only completion to the Vara.eth action', async () => {
+    const mirror = '0xabcdef0000000000000000000000000000000002';
+
+    await makeProgram().parseAsync([
+      '--chain', 'vara-eth',
+      'message', 'send', mirror,
+      '--payload', '0xabcd',
+      '--wait', 'submitted',
+    ], { from: 'user' });
+
+    expect(mockMessageSend).toHaveBeenCalledWith(mirror, expect.objectContaining({
+      wait: 'submitted',
+    }));
+  });
+
   it('still rejects native-only message send options on Vara.eth', async () => {
     const mirror = '0xabcdef0000000000000000000000000000000002';
 

--- a/src/__tests__/vara-eth-root-sails-routing.test.ts
+++ b/src/__tests__/vara-eth-root-sails-routing.test.ts
@@ -83,6 +83,7 @@ describe('root --chain vara-eth Sails routing', () => {
       '--idl', 'p.idl',
       '--origin', '0xabcdef0000000000000000000000000000000001',
       '--via', 'eth',
+      '--wait', 'submitted',
       '--dry-run',
     ], { from: 'user' });
 
@@ -91,6 +92,7 @@ describe('root --chain vara-eth Sails routing', () => {
       idl: 'p.idl',
       origin: '0xabcdef0000000000000000000000000000000001',
       via: 'eth',
+      wait: 'submitted',
       dryRun: true,
     }));
   });

--- a/src/__tests__/vara-eth-submit-receipt.test.ts
+++ b/src/__tests__/vara-eth-submit-receipt.test.ts
@@ -22,6 +22,7 @@ const mockSigner = {};
 
 jest.mock('../services/vara-eth/api', () => ({
   getEthexeApi: jest.fn(),
+  getEthexeEthereumContext: jest.fn(),
   getMirrorClient: jest.fn(),
 }));
 
@@ -35,8 +36,9 @@ jest.mock('../utils/output', () => ({
   output: (data: unknown) => mockOutput(data),
 }));
 
-const { getEthexeApi, getMirrorClient } = require('../services/vara-eth/api') as {
+const { getEthexeApi, getEthexeEthereumContext, getMirrorClient } = require('../services/vara-eth/api') as {
   getEthexeApi: jest.Mock;
+  getEthexeEthereumContext: jest.Mock;
   getMirrorClient: jest.Mock;
 };
 const { resolveEthexeSigner } = require('../services/vara-eth/account') as {
@@ -57,6 +59,7 @@ function makeProgram(): Command {
 beforeEach(() => {
   jest.clearAllMocks();
   getEthexeApi.mockResolvedValue(mockApi);
+  getEthexeEthereumContext.mockReturnValue({ publicClient: mockApi.eth.publicClient });
   getMirrorClient.mockResolvedValue({
     sendReply: mockSendReply,
     claimValue: mockClaimValue,

--- a/src/__tests__/vara-eth-wvara.test.ts
+++ b/src/__tests__/vara-eth-wvara.test.ts
@@ -7,7 +7,10 @@
  * service helpers directly to keep tests fast.
  */
 
+import { Command } from 'commander';
+
 import { CliError } from '../utils/errors';
+import { registerVaraEthWvaraCommand } from '../commands/vara-eth-wvara';
 
 // ---- stubs ----------------------------------------------------------------
 
@@ -47,6 +50,8 @@ const mockSigner = { getAddress: mockGetAddress, sendTransaction: jest.fn() };
 
 jest.mock('../services/vara-eth/api', () => ({
   getEthexeApi: jest.fn(),
+  getEthexeEthereumClient: jest.fn(),
+  getEthexeEthereumContext: jest.fn(),
   getMirrorClient: jest.fn(),
   resolveEthexeConfig: jest.fn(),
 }));
@@ -55,8 +60,15 @@ jest.mock('../services/vara-eth/account', () => ({
   resolveEthexeSigner: jest.fn(),
 }));
 
-const { getEthexeApi } = require('../services/vara-eth/api') as {
+const mockOutput = jest.fn();
+jest.mock('../utils/output', () => ({
+  output: (data: unknown) => mockOutput(data),
+}));
+
+const { getEthexeApi, getEthexeEthereumClient, getEthexeEthereumContext } = require('../services/vara-eth/api') as {
   getEthexeApi: jest.Mock;
+  getEthexeEthereumClient: jest.Mock;
+  getEthexeEthereumContext: jest.Mock;
 };
 const { resolveEthexeSigner } = require('../services/vara-eth/account') as {
   resolveEthexeSigner: jest.Mock;
@@ -65,6 +77,8 @@ const { resolveEthexeSigner } = require('../services/vara-eth/account') as {
 beforeEach(() => {
   jest.clearAllMocks();
   getEthexeApi.mockResolvedValue(mockApi);
+  getEthexeEthereumClient.mockResolvedValue(mockApi.eth);
+  getEthexeEthereumContext.mockReturnValue({ publicClient: mockPublicClient });
   resolveEthexeSigner.mockResolvedValue(mockSigner);
   mockTransfer.mockResolvedValue(mockTxManager);
   mockApprove.mockResolvedValue(mockTxManager);
@@ -77,6 +91,13 @@ beforeEach(() => {
     signature: '0xsig',
   });
 });
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerVaraEthWvaraCommand(program);
+  return program;
+}
 
 // ---------------------------------------------------------------------------
 
@@ -106,6 +127,20 @@ describe('vara-eth:wvara transfer', () => {
 
     expect(mockTransfer).toHaveBeenCalledWith('0xabcdef0000000000000000000000000000000002', 500n);
     expect(receipt.transactionHash).toBe('0xdeadbeef');
+  });
+
+  it('preserves a reverted receipt status instead of reporting confirmation', async () => {
+    mockSendAndWaitForReceipt.mockResolvedValueOnce({ transactionHash: '0xdeadbeef', status: 'reverted' });
+
+    await makeProgram().parseAsync([
+      'vara-eth:wvara', 'transfer', '0xabcdef0000000000000000000000000000000002', '500',
+    ], { from: 'user' });
+
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      txHash: '0xdeadbeef',
+      status: 'reverted',
+      wait: 'receipt',
+    }));
   });
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,6 +99,11 @@ program
         process.env.VARA_ETH_NETWORK_PRESET_NAME = opts.network;
         process.env.VARA_ETH_NETWORK_PRESET_VARA_ETH_RPC = preset.varaEthRpc;
         process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_RPC = preset.ethereumRpc;
+        if (preset.ethereumHttpRpc) {
+          process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_HTTP_RPC = preset.ethereumHttpRpc;
+        } else {
+          delete process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_HTTP_RPC;
+        }
         if (preset.routerAddress) {
           process.env.VARA_ETH_NETWORK_PRESET_ROUTER = preset.routerAddress;
         } else {

--- a/src/chains/vara-eth/networks.ts
+++ b/src/chains/vara-eth/networks.ts
@@ -1,7 +1,10 @@
 export type VaraEthNetwork = 'mainnet' | 'hoodi' | 'local';
 
 export interface VaraEthNetworkConfig {
+  /** Ethereum WebSocket endpoint used by event streams. */
   ethereumRpc: string;
+  /** Ethereum HTTP endpoint used by one-shot requests to avoid a WS handshake. */
+  ethereumHttpRpc?: string;
   beaconRpc?: string; // for EIP-7594 blob lookups (code upload)
   varaEthRpc: string;
   routerAddress: `0x${string}` | null; // null = lookup at runtime (Anvil dev)
@@ -21,6 +24,7 @@ export interface VaraEthNetworkConfig {
 export const VARA_ETH_NETWORKS: Readonly<Record<VaraEthNetwork, VaraEthNetworkConfig>> = {
   mainnet: {
     ethereumRpc: 'wss://mainnet-reth-rpc.gear-tech.io/ws',
+    ethereumHttpRpc: 'https://mainnet-reth-rpc.gear-tech.io',
     beaconRpc: 'https://mainnet-lighthouse-rpc.gear-tech.io',
     varaEthRpc: 'wss://validator-1-eth.vara.network',
     routerAddress: '0x9C13FE9242dfe2ba2Cd446480A9308279aA74cb6',
@@ -29,6 +33,7 @@ export const VARA_ETH_NETWORKS: Readonly<Record<VaraEthNetwork, VaraEthNetworkCo
   },
   hoodi: {
     ethereumRpc: 'wss://hoodi-reth-rpc.gear-tech.io/ws',
+    ethereumHttpRpc: 'https://hoodi-reth-rpc.gear-tech.io',
     beaconRpc: 'https://hoodi-lighthouse-rpc.gear-tech.io',
     varaEthRpc: 'wss://vara-eth-validator-1.gear-tech.io',
     routerAddress: '0xE549b0AfEdA978271FF7E712232B9F7f39A0b060',
@@ -37,6 +42,7 @@ export const VARA_ETH_NETWORKS: Readonly<Record<VaraEthNetwork, VaraEthNetworkCo
   },
   local: {
     ethereumRpc: 'ws://127.0.0.1:8545',
+    ethereumHttpRpc: 'http://127.0.0.1:8545',
     varaEthRpc: 'ws://127.0.0.1:9944',
     routerAddress: null, // discovered from Anvil broadcast artifact at runtime
     blockTimeMs: 1_000,

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -42,8 +42,9 @@ export function registerBalanceCommand(program: Command): void {
     .argument('<to>', 'destination address (hex or SS58)')
     .argument('[amount]', 'amount to transfer (in VARA by default)')
     .option('--units <units>', 'amount units: human (default, = VARA) or raw')
+    .option('--wait <stage>', 'Vara.eth completion stage: submitted or receipt (default)', 'receipt')
     .option('--all', 'transfer entire balance (account will be reaped)')
-    .action(async (to: string, amount: string | undefined, options: { units?: string; all?: boolean }) => {
+    .action(async (to: string, amount: string | undefined, options: { units?: string; all?: boolean; wait?: string }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       if (resolveActiveChain(program) === 'vara-eth') {
         if (options.all) {
@@ -52,7 +53,7 @@ export function registerBalanceCommand(program: Command): void {
         if (!amount) {
           throw new CliError('Provide <amount>', 'INVALID_ARGS');
         }
-        await outputVaraEthWvaraTransfer(to, amount, { ...opts, units: options.units });
+        await outputVaraEthWvaraTransfer(to, amount, { ...opts, units: options.units, wait: options.wait });
         return;
       }
 

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -26,6 +26,7 @@ export function registerCallCommand(program: Command): void {
     .option('--dry-run', 'encode the payload and exit without signing or submitting (no account required)')
     .option('--origin <address>', 'Vara.eth origin address for read-only Sails execution')
     .option('--via <via>', 'Vara.eth send path for function calls: eth (default) or injected')
+    .option('--wait <stage>', 'Vara.eth function completion stage: submitted or reply (default)', 'reply')
     .action(async (programId: string, method: string, options: {
       args?: string;
       argsFile?: string;
@@ -38,12 +39,13 @@ export function registerCallCommand(program: Command): void {
       dryRun?: boolean;
       origin?: string;
       via?: 'eth' | 'injected';
+      wait?: string;
     }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       if (resolveActiveChain(program) === 'vara-eth') {
         if (options.gasLimit || options.voucher) {
           throw new CliError(
-            '--chain vara-eth call supports --idl, --args, --args-file, --origin, --via, --dry-run, --estimate, --value, --units, and account options',
+            '--chain vara-eth call supports --idl, --args, --args-file, --origin, --via, --wait, --dry-run, --estimate, --value, --units, and account options',
             'UNSUPPORTED_CHAIN_OPTION',
           );
         }

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -67,6 +67,7 @@ export function registerMessageCommand(program: Command): void {
     .option('--metadata <path>', 'path to .meta.txt file for encoding')
     .option('--voucher <id>', 'voucher ID to pay for the message')
     .option('--via <path>', 'Vara.eth send path: injected (default) or eth', 'injected')
+    .option('--wait <stage>', 'Vara.eth completion stage: submitted or reply (default)', 'reply')
     .option('--timeout-ms <ms>', 'Vara.eth injected promise timeout')
     .option('--no-validate-signature', 'Vara.eth diagnostics: skip injected validator signature validation')
     .option('--resume <txHash>', 'Vara.eth: inspect a cached injected send outcome by tx hash')
@@ -79,6 +80,7 @@ export function registerMessageCommand(program: Command): void {
       metadata?: string;
       voucher?: string;
       via?: 'eth' | 'injected';
+      wait?: string;
       timeoutMs?: string;
       validateSignature?: boolean;
       resume?: string;
@@ -87,7 +89,7 @@ export function registerMessageCommand(program: Command): void {
       if (resolveActiveChain(program) === 'vara-eth') {
         if (options.payloadAscii || options.gasLimit || options.metadata || options.voucher) {
           throw new CliError(
-            '--chain vara-eth message send supports --payload, --value, --units, --via, --timeout-ms, --resume, and account options',
+            '--chain vara-eth message send supports --payload, --value, --units, --via, --wait, --timeout-ms, --resume, and account options',
             'UNSUPPORTED_CHAIN_OPTION',
           );
         }
@@ -196,6 +198,7 @@ export function registerMessageCommand(program: Command): void {
     .option('--metadata <path>', 'path to .meta.txt file for encoding')
     .option('--voucher <id>', 'voucher ID to pay for the message')
     .option('--mirror <address>', 'Vara.eth Mirror program address for the reply')
+    .option('--wait <stage>', 'Vara.eth completion stage: submitted or receipt (default)', 'receipt')
     .action(async (messageId: string, options: {
       payload: string;
       payloadAscii?: string;
@@ -205,6 +208,7 @@ export function registerMessageCommand(program: Command): void {
       metadata?: string;
       voucher?: string;
       mirror?: string;
+      wait?: string;
     }) => {
       const opts = program.optsWithGlobals() as AccountOptions & { ws?: string };
       if (resolveActiveChain(program) === 'vara-eth') {
@@ -213,7 +217,7 @@ export function registerMessageCommand(program: Command): void {
         }
         if (options.payloadAscii || options.gasLimit || options.metadata || options.voucher || options.units) {
           throw new CliError(
-            '--chain vara-eth message reply supports --mirror, --payload, --value, and account options',
+            '--chain vara-eth message reply supports --mirror, --payload, --value, --wait, and account options',
             'UNSUPPORTED_CHAIN_OPTION',
           );
         }

--- a/src/commands/vara-eth-actions.ts
+++ b/src/commands/vara-eth-actions.ts
@@ -602,7 +602,7 @@ export async function subscribeVaraEthProgram(
   if (persist) initEventStore();
   const network = persist ? resolveVaraEthEventNetwork() : null;
 
-  const api = await getEthexeApi();
+  const api = await getEthexeApi({ ethereumTransport: 'stream' });
   verbose(`subscribing to program events ${mirror}`);
   let seen = 0;
   const unsubscribe = api.stream.programEvents(
@@ -633,7 +633,7 @@ export async function subscribeVaraEthRouter(
   if (persist) initEventStore();
   const network = persist ? resolveVaraEthEventNetwork() : null;
 
-  const api = await getEthexeApi();
+  const api = await getEthexeApi({ ethereumTransport: 'stream' });
   verbose('subscribing to router events');
   let seen = 0;
   const unsubscribe = api.stream.routerEvents(
@@ -662,7 +662,7 @@ export async function subscribeVaraEthBlocks(
   if (persist) initEventStore();
   const network = persist ? resolveVaraEthEventNetwork() : null;
 
-  const api = await getEthexeApi();
+  const api = await getEthexeApi({ ethereumTransport: 'stream' });
   verbose('subscribing to blocks');
   let seen = 0;
   const unsubscribe = api.stream.blocks(

--- a/src/commands/vara-eth-actions.ts
+++ b/src/commands/vara-eth-actions.ts
@@ -2,7 +2,12 @@ import { readFileSync } from 'node:fs';
 import type { Address, Hex, TransactionReceipt } from 'viem';
 import { keccak256 } from 'viem';
 
-import { getEthexeApi, getMirrorClient } from '../services/vara-eth/api';
+import {
+  getEthexeApi,
+  getEthexeEthereumClient,
+  getEthexeEthereumContext,
+  getMirrorClient,
+} from '../services/vara-eth/api';
 import { resolveEthexeAccountAddress, resolveEthexeSigner, type EthexeAccountOptions } from '../services/vara-eth/account';
 import { loadVaraEthSails } from '../services/vara-eth/sails-idl';
 import { getById, initPromiseStore, insertPending, markFailed, markResolved } from '../services/vara-eth/promises';
@@ -42,12 +47,14 @@ export interface VaraEthSendOptions extends EthexeAccountOptions {
   timeoutMs?: string;
   validateSignature?: boolean;
   resume?: string;
+  wait?: string;
 }
 
 export interface VaraEthReplyOptions extends EthexeAccountOptions {
   payload?: string;
   value?: string;
   mirror?: string;
+  wait?: string;
 }
 
 export interface VaraEthStateReadOptions {
@@ -74,6 +81,7 @@ export interface VaraEthSailsCallOptions extends EthexeAccountOptions {
   estimate?: boolean;
   origin?: string;
   via?: 'eth' | 'injected';
+  wait?: string;
 }
 
 export async function outputVaraEthBalance(addressArg: string | undefined, opts: EthexeAccountOptions = {}): Promise<void> {
@@ -117,18 +125,45 @@ export async function outputVaraEthBalance(addressArg: string | undefined, opts:
 export async function outputVaraEthWvaraTransfer(
   toArg: string,
   amountArg: string,
-  options: EthexeAccountOptions & { units?: string } = {},
+  options: EthexeAccountOptions & { units?: string; wait?: string } = {},
 ): Promise<void> {
   const to = asAddress(toArg, 'to');
-  const api = await getEthexeApi();
-  const { amount, decimals, units } = await resolveVaraEthTokenAmount(api, amountArg, options.units);
+  const wait = resolveVaraEthWaitMode(options.wait, ['submitted', 'receipt'], 'receipt');
+  const context = getEthexeEthereumContext();
+  const [ethClient, signer] = await Promise.all([
+    getEthexeEthereumClient(),
+    resolveEthexeSigner(context.publicClient, options),
+  ]);
+  ethClient.setSigner(signer);
+  const units = validateUnits(options.units) ?? 'human';
+  const rawSubmit = wait === 'submitted' && units === 'raw';
+  const amountInfo = rawSubmit
+    ? { amount: BigInt(amountArg), decimals: null }
+    : await resolveVaraEthTokenAmount(ethClient.wvara, amountArg, units);
+  const { amount, decimals } = amountInfo;
   if (amount <= 0n) throw new CliError('Amount must be positive', 'INVALID_AMOUNT');
 
-  const signer = await resolveEthexeSigner(api.eth.publicClient, options);
-  api.eth.setSigner(signer);
-
   const from = await signer.getAddress();
-  const txManager = await api.eth.wvara.transfer(to, amount);
+  const txManager = await ethClient.wvara.transfer(to, amount);
+  if (wait === 'submitted') {
+    const txHash = await txManager.send();
+    output({
+      chain: 'vara-eth',
+      display: 'Vara.eth',
+      txHash,
+      blockNumber: null,
+      status: 'submitted',
+      wait,
+      from,
+      to,
+      amount: decimals === null ? null : minimalToVara(amount, decimals),
+      decimals,
+      amountRaw: amount.toString(),
+      units,
+    });
+    return;
+  }
+
   const receipt = await txManager.sendAndWaitForReceipt();
 
   output({
@@ -137,9 +172,11 @@ export async function outputVaraEthWvaraTransfer(
     txHash: receipt.transactionHash,
     blockNumber: Number(receipt.blockNumber),
     status: receipt.status,
+    wait,
     from,
     to,
-    amount: minimalToVara(amount, decimals),
+    amount: minimalToVara(amount, decimals!),
+    decimals,
     amountRaw: amount.toString(),
     units,
   });
@@ -160,20 +197,67 @@ export async function outputVaraEthMessageSend(mirrorArg: string, opts: VaraEthS
   const payload = asHex(opts.payload, '--payload');
   const value = parseOptionalBigInt(opts.value, '--value');
   const via = resolveVaraEthSendPath(opts.via ?? 'injected');
+  const wait = resolveVaraEthWaitMode(opts.wait, ['submitted', 'reply'], 'reply');
   const timeoutMs = parseOptionalPositiveInteger(opts.timeoutMs, '--timeout-ms', 'INVALID_TIMEOUT');
-
-  const api = await getEthexeApi();
-  const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-  api.eth.setSigner(signer);
 
   const validateSignature = opts.validateSignature !== false;
   const persist = via === 'injected';
   if (persist) initPromiseStore();
+  const ethereumContext = getEthexeEthereumContext();
+  const apiPromise = via === 'injected' || wait === 'reply' ? getEthexeApi() : null;
+  const [api, signer] = await Promise.all([
+    apiPromise,
+    resolveEthexeSigner(ethereumContext.publicClient, opts),
+  ]);
+  api?.eth.setSigner(signer);
   const signerAddress = persist ? await signer.getAddress() : '0x';
+
+  if (wait === 'submitted') {
+    let txHash: Hex;
+    let messageId: Hex | null;
+
+    if (via === 'eth') {
+      const mirrorClient = await getMirrorClient(mirror, signer);
+      const tx = await mirrorClient.sendMessage(payload, value);
+      txHash = await tx.send();
+      messageId = null;
+    } else {
+      if ((value ?? 0n) !== 0n) {
+        throw new CliError('Injected Vara.eth messages cannot attach value. Use --via eth.', 'INVALID_VALUE_FOR_INJECTED');
+      }
+      const injectedTx = await api!.createInjectedTransaction({
+        destination: mirror,
+        payload,
+        value: 0n,
+      });
+      txHash = asHex(await injectedTx.send(), 'injected transaction hash');
+      messageId = injectedTx.messageId;
+    }
+
+    if (persist) {
+      try {
+        insertPending(buildPendingRow({ txHash, mirror, payload, value, signerAddress }));
+      } catch {
+        // Persistence should not fail a successful submit.
+      }
+    }
+
+    output({
+      mirror,
+      via,
+      wait,
+      status: 'submitted',
+      messageId,
+      txHash,
+      validator: null,
+      reply: null,
+    });
+    return;
+  }
 
   let result;
   try {
-    result = await api.programs.sendAndWait(mirror, payload, { value, via, timeoutMs, validateSignature });
+    result = await api!.programs.sendAndWait(mirror, payload, { value, via, timeoutMs, validateSignature });
   } catch (err) {
     if (persist) {
       const txHash = extractTxHash(err);
@@ -215,6 +299,8 @@ export async function outputVaraEthMessageSend(mirrorArg: string, opts: VaraEthS
   output({
     mirror,
     via,
+    wait,
+    status: 'resolved',
     messageId: result.messageId,
     txHash: result.txHash,
     validator: result.validator ?? null,
@@ -237,13 +323,26 @@ export async function outputVaraEthMessageReply(
   const messageId = asHex(msgIdArg, 'messageId');
   const payload = asHex(opts.payload!, '--payload');
   const value = parseOptionalBigInt(opts.value, '--value');
+  const wait = resolveVaraEthWaitMode(opts.wait, ['submitted', 'receipt'], 'receipt');
 
-  const api = await getEthexeApi();
-  const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-  api.eth.setSigner(signer);
+  const { publicClient } = getEthexeEthereumContext();
+  const signer = await resolveEthexeSigner(publicClient, opts);
 
   const mirrorClient = await getMirrorClient(mirror, signer);
   const tx = await mirrorClient.sendReply(messageId, payload, value);
+  if (wait === 'submitted') {
+    const txHash = await tx.send();
+    output({
+      mirror,
+      repliedTo: messageId,
+      txHash,
+      blockNumber: null,
+      status: 'submitted',
+      wait,
+    });
+    return;
+  }
+
   const receipt = await tx.sendAndWaitForReceipt();
 
   output({
@@ -252,6 +351,7 @@ export async function outputVaraEthMessageReply(
     txHash: receipt.transactionHash,
     blockNumber: Number(receipt.blockNumber),
     status: receipt.status,
+    wait,
   });
 }
 
@@ -407,8 +507,10 @@ export async function outputVaraEthSailsCall(
 ): Promise<void> {
   const programAddress = asAddress(programArg, 'programAddress');
   const via = resolveVaraEthSendPath(opts.via);
+  const wait = resolveVaraEthWaitMode(opts.wait, ['submitted', 'reply'], 'reply');
   const { serviceName, methodName } = parseSailsMethod(methodArg);
-  const api = await getEthexeApi();
+  const ethereumOnlySubmit = wait === 'submitted' && via === 'eth' && opts.idl !== undefined;
+  const api = ethereumOnlySubmit ? undefined : await getEthexeApi();
   const valueInfo = resolveVaraEthValue(opts.value, opts.units);
   const loaded = await loadVaraEthSails(api, programAddress, {
     idl: opts.idl,
@@ -422,7 +524,7 @@ export async function outputVaraEthSailsCall(
 
   if (opts.dryRun) {
     const feeEstimate = opts.estimate && resolved.kind === 'function'
-      ? await estimateVaraEthSendFee(api, programAddress, encodedPayload, valueInfo.raw, opts)
+      ? await estimateVaraEthSendFee(api!, programAddress, encodedPayload, valueInfo.raw, opts)
       : undefined;
     output({
       chain: 'vara-eth',
@@ -444,7 +546,7 @@ export async function outputVaraEthSailsCall(
   }
 
   if (resolved.kind === 'query') {
-    const reply = await api.call.program.calculateReplyForHandle(origin, programAddress, encodedPayload, valueInfo.raw);
+    const reply = await api!.call.program.calculateReplyForHandle(origin, programAddress, encodedPayload, valueInfo.raw);
     output({
       chain: 'vara-eth',
       kind: 'query',
@@ -477,13 +579,14 @@ export async function outputVaraEthSailsCall(
       value: valueInfo.human,
       valueRaw: valueInfo.raw.toString(),
       units: valueInfo.units,
-      feeEstimate: await estimateVaraEthSendFee(api, programAddress, encodedPayload, valueInfo.raw, opts),
+      feeEstimate: await estimateVaraEthSendFee(api!, programAddress, encodedPayload, valueInfo.raw, opts),
     });
     return;
   }
 
-  const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-  api.eth.setSigner(signer);
+  const publicClient = api?.eth.publicClient ?? getEthexeEthereumContext().publicClient;
+  const signer = await resolveEthexeSigner(publicClient, opts);
+  api?.eth.setSigner(signer);
   const from = await signer.getAddress();
   if (opts.origin && origin.toLowerCase() !== from.toLowerCase()) {
     throw new CliError(
@@ -492,7 +595,50 @@ export async function outputVaraEthSailsCall(
       { origin, signer: from },
     );
   }
-  const result = await api.programs.sendAndWait(programAddress, encodedPayload, {
+
+  if (wait === 'submitted') {
+    let txHash: Hex;
+    let messageId: Hex | null;
+    if (via === 'eth') {
+      const mirrorClient = await getMirrorClient(programAddress, signer);
+      const tx = await mirrorClient.sendMessage(encodedPayload, valueInfo.raw);
+      txHash = await tx.send();
+      messageId = null;
+    } else {
+      if (valueInfo.raw !== 0n) {
+        throw new CliError('Injected Vara.eth messages cannot attach value. Use --via eth.', 'INVALID_VALUE_FOR_INJECTED');
+      }
+      const injectedTx = await api!.createInjectedTransaction({
+        destination: programAddress,
+        payload: encodedPayload,
+        value: 0n,
+      });
+      txHash = asHex(await injectedTx.send(), 'injected transaction hash');
+      messageId = injectedTx.messageId;
+    }
+
+    output({
+      chain: 'vara-eth',
+      kind: 'function',
+      status: 'submitted',
+      wait,
+      programAddress,
+      service: serviceName,
+      method: methodName,
+      origin: from,
+      via,
+      messageId,
+      txHash,
+      value: valueInfo.human,
+      valueRaw: valueInfo.raw.toString(),
+      units: valueInfo.units,
+      result: null,
+      reply: null,
+    });
+    return;
+  }
+
+  const result = await api!.programs.sendAndWait(programAddress, encodedPayload, {
     value: valueInfo.raw,
     via,
   });
@@ -504,6 +650,8 @@ export async function outputVaraEthSailsCall(
     method: methodName,
     origin: from,
     via,
+    wait,
+    status: 'resolved',
     messageId: result.messageId,
     txHash: result.txHash,
     validator: result.validator ?? null,
@@ -566,7 +714,7 @@ export async function outputVaraEthProgramTopUp(
 ): Promise<void> {
   const mirror = asAddress(mirrorArg, 'mirror');
   const api = await getEthexeApi();
-  const { amount, decimals, units } = await resolveVaraEthTokenAmount(api, opts.amount, opts.units);
+  const { amount, decimals, units } = await resolveVaraEthTokenAmount(api.eth.wvara, opts.amount, opts.units);
   if (amount <= 0n) throw new CliError('Amount must be positive', 'INVALID_AMOUNT');
 
   const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
@@ -861,6 +1009,20 @@ function resolveVaraEthSendPath(via: string | undefined): 'eth' | 'injected' {
   throw new CliError('--via must be "eth" or "injected"', 'INVALID_VIA', { via });
 }
 
+function resolveVaraEthWaitMode<T extends string>(
+  wait: string | undefined,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  const resolved = wait ?? fallback;
+  if ((allowed as readonly string[]).includes(resolved)) return resolved as T;
+  throw new CliError(
+    `--wait must be one of: ${allowed.join(', ')}`,
+    'INVALID_WAIT_MODE',
+    { wait: resolved, allowed },
+  );
+}
+
 function resolveVaraEthValue(
   amountArg: string,
   units: string | undefined,
@@ -903,12 +1065,12 @@ function parseVaraEthTokenAmount(amount: string, units: string | undefined, deci
 }
 
 async function resolveVaraEthTokenAmount(
-  api: Awaited<ReturnType<typeof getEthexeApi>>,
+  wvara: { decimals(): Promise<number> },
   amountArg: string,
   units: string | undefined,
 ): Promise<{ amount: bigint; decimals: number; units: 'human' | 'raw' }> {
   const resolvedUnits = validateUnits(units) ?? 'human';
-  const decimals = await api.eth.wvara.decimals();
+  const decimals = await wvara.decimals();
   return {
     amount: parseVaraEthTokenAmount(amountArg, resolvedUnits, decimals),
     decimals,

--- a/src/commands/vara-eth-actions.ts
+++ b/src/commands/vara-eth-actions.ts
@@ -201,7 +201,7 @@ export async function outputVaraEthMessageSend(mirrorArg: string, opts: VaraEthS
   const timeoutMs = parseOptionalPositiveInteger(opts.timeoutMs, '--timeout-ms', 'INVALID_TIMEOUT');
 
   const validateSignature = opts.validateSignature !== false;
-  const persist = via === 'injected';
+  const persist = via === 'injected' && wait === 'reply';
   if (persist) initPromiseStore();
   const ethereumContext = getEthexeEthereumContext();
   const apiPromise = via === 'injected' || wait === 'reply' ? getEthexeApi() : null;
@@ -509,8 +509,7 @@ export async function outputVaraEthSailsCall(
   const via = resolveVaraEthSendPath(opts.via);
   const wait = resolveVaraEthWaitMode(opts.wait, ['submitted', 'reply'], 'reply');
   const { serviceName, methodName } = parseSailsMethod(methodArg);
-  const ethereumOnlySubmit = wait === 'submitted' && via === 'eth' && opts.idl !== undefined;
-  const api = ethereumOnlySubmit ? undefined : await getEthexeApi();
+  let api = opts.idl === undefined ? await getEthexeApi() : undefined;
   const valueInfo = resolveVaraEthValue(opts.value, opts.units);
   const loaded = await loadVaraEthSails(api, programAddress, {
     idl: opts.idl,
@@ -521,6 +520,15 @@ export async function outputVaraEthSailsCall(
   args = coerceArgsAuto(args, resolved.method.args || [], loaded.sails, serviceName);
   const encodedPayload = resolved.method.encodePayload(...args) as Hex;
   const origin = resolveVaraEthOrigin(opts);
+  const ethereumOnlySubmit = wait === 'submitted'
+    && via === 'eth'
+    && resolved.kind === 'function'
+    && !opts.dryRun
+    && !opts.estimate;
+  const needsValidatorApi = resolved.kind === 'query'
+    || opts.estimate === true
+    || (!opts.dryRun && !ethereumOnlySubmit);
+  if (!api && needsValidatorApi) api = await getEthexeApi();
 
   if (opts.dryRun) {
     const feeEstimate = opts.estimate && resolved.kind === 'function'

--- a/src/commands/vara-eth-message.ts
+++ b/src/commands/vara-eth-message.ts
@@ -19,6 +19,7 @@ export function registerVaraEthMessageCommand(program: Command): void {
     .option('--payload <hex>', '0x-prefixed payload bytes (required unless --resume is set)')
     .option('--value <wei>', 'value in wei to attach (default: 0)')
     .option('--via <path>', 'injected (default) or eth (direct Mirror.sendMessage)', 'injected')
+    .option('--wait <stage>', 'completion stage: submitted or reply (default)', 'reply')
     .option('--account <name>', 'Vara.eth wallet name')
     .option('--passphrase <pass>', 'wallet passphrase')
     .option('--timeout-ms <ms>', 'timeout for injected promise wait (default: server-controlled)')
@@ -40,6 +41,7 @@ export function registerVaraEthMessageCommand(program: Command): void {
     .description('Reply to a previously received message')
     .requiredOption('--payload <hex>', '0x-prefixed reply payload')
     .option('--value <wei>', 'value to attach')
+    .option('--wait <stage>', 'completion stage: submitted or receipt (default)', 'receipt')
     .option('--account <name>', 'Vara.eth wallet name')
     .option('--passphrase <pass>', 'wallet passphrase')
     .action(async (mirrorArg: string, msgIdArg: string, _options: ReplyOptions, cmd: Command) => {

--- a/src/commands/vara-eth-wvara.ts
+++ b/src/commands/vara-eth-wvara.ts
@@ -41,14 +41,17 @@ function resolveWaitMode(raw: string | undefined): 'submitted' | 'receipt' {
 }
 
 async function sendWvaraTransaction(
-  tx: { send(): Promise<`0x${string}`>; sendAndWaitForReceipt(): Promise<{ transactionHash: `0x${string}` }> },
+  tx: {
+    send(): Promise<`0x${string}`>;
+    sendAndWaitForReceipt(): Promise<{ transactionHash: `0x${string}`; status: 'success' | 'reverted' }>;
+  },
   wait: 'submitted' | 'receipt',
-): Promise<{ txHash: `0x${string}`; status: 'submitted' | 'confirmed' }> {
+): Promise<{ txHash: `0x${string}`; status: 'submitted' | 'success' | 'reverted' }> {
   if (wait === 'submitted') {
     return { txHash: await tx.send(), status: 'submitted' };
   }
   const receipt = await tx.sendAndWaitForReceipt();
-  return { txHash: receipt.transactionHash, status: 'confirmed' };
+  return { txHash: receipt.transactionHash, status: receipt.status };
 }
 
 export function registerVaraEthWvaraCommand(program: Command): void {

--- a/src/commands/vara-eth-wvara.ts
+++ b/src/commands/vara-eth-wvara.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 
-import { getEthexeApi } from '../services/vara-eth/api';
+import { getEthexeApi, getEthexeEthereumClient, getEthexeEthereumContext } from '../services/vara-eth/api';
 import { resolveEthexeSigner } from '../services/vara-eth/account';
 import { asAddress, parseOptionalBigInt } from '../utils/eth-types';
 import { CliError } from '../utils/errors';
@@ -13,6 +13,11 @@ interface AccountOptions {
 
 interface PermitOptions extends AccountOptions {
   deadline?: string;
+  wait?: string;
+}
+
+interface WriteOptions extends AccountOptions {
+  wait?: string;
 }
 
 function parseBigIntArg(raw: string, field: string): bigint {
@@ -24,6 +29,26 @@ function parseBigIntArg(raw: string, field: string): bigint {
       value: raw,
     });
   }
+}
+
+function resolveWaitMode(raw: string | undefined): 'submitted' | 'receipt' {
+  const wait = raw ?? 'receipt';
+  if (wait === 'submitted' || wait === 'receipt') return wait;
+  throw new CliError('--wait must be one of: submitted, receipt', 'INVALID_WAIT_MODE', {
+    wait,
+    allowed: ['submitted', 'receipt'],
+  });
+}
+
+async function sendWvaraTransaction(
+  tx: { send(): Promise<`0x${string}`>; sendAndWaitForReceipt(): Promise<{ transactionHash: `0x${string}` }> },
+  wait: 'submitted' | 'receipt',
+): Promise<{ txHash: `0x${string}`; status: 'submitted' | 'confirmed' }> {
+  if (wait === 'submitted') {
+    return { txHash: await tx.send(), status: 'submitted' };
+  }
+  const receipt = await tx.sendAndWaitForReceipt();
+  return { txHash: receipt.transactionHash, status: 'confirmed' };
 }
 
 export function registerVaraEthWvaraCommand(program: Command): void {
@@ -50,23 +75,30 @@ export function registerVaraEthWvaraCommand(program: Command): void {
     .description('Transfer WVARA to another address (amount in raw integer units)')
     .option('--account <name>', 'Vara.eth wallet name')
     .option('--passphrase <pass>', 'wallet passphrase')
-    .action(async (toArg: string, amountArg: string, _options: AccountOptions, cmd: Command) => {
-      const opts = cmd.optsWithGlobals() as AccountOptions;
+    .option('--wait <stage>', 'completion stage: submitted or receipt (default)', 'receipt')
+    .action(async (toArg: string, amountArg: string, _options: WriteOptions, cmd: Command) => {
+      const opts = cmd.optsWithGlobals() as WriteOptions;
       const to = asAddress(toArg, 'to');
       const amount = parseBigIntArg(amountArg, 'amount');
+      const wait = resolveWaitMode(opts.wait);
 
-      const api = await getEthexeApi();
-      const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-      api.eth.setSigner(signer);
+      const context = getEthexeEthereumContext();
+      const [ethClient, signer] = await Promise.all([
+        getEthexeEthereumClient(),
+        resolveEthexeSigner(context.publicClient, opts),
+      ]);
+      ethClient.setSigner(signer);
 
       const from = await signer.getAddress();
-      const txManager = await api.eth.wvara.transfer(to, amount);
-      const receipt = await txManager.sendAndWaitForReceipt();
+      const txManager = await ethClient.wvara.transfer(to, amount);
+      const result = await sendWvaraTransaction(txManager, wait);
 
       output({
         chain: 'vara-eth',
         display: 'Vara.eth',
-        txHash: receipt.transactionHash,
+        txHash: result.txHash,
+        status: result.status,
+        wait,
         from,
         to,
         amount: amount.toString(),
@@ -78,23 +110,30 @@ export function registerVaraEthWvaraCommand(program: Command): void {
     .description('Approve a spender to transfer WVARA on your behalf (amount in raw integer units)')
     .option('--account <name>', 'Vara.eth wallet name')
     .option('--passphrase <pass>', 'wallet passphrase')
-    .action(async (spenderArg: string, amountArg: string, _options: AccountOptions, cmd: Command) => {
-      const opts = cmd.optsWithGlobals() as AccountOptions;
+    .option('--wait <stage>', 'completion stage: submitted or receipt (default)', 'receipt')
+    .action(async (spenderArg: string, amountArg: string, _options: WriteOptions, cmd: Command) => {
+      const opts = cmd.optsWithGlobals() as WriteOptions;
       const spender = asAddress(spenderArg, 'spender');
       const amount = parseBigIntArg(amountArg, 'amount');
+      const wait = resolveWaitMode(opts.wait);
 
-      const api = await getEthexeApi();
-      const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-      api.eth.setSigner(signer);
+      const context = getEthexeEthereumContext();
+      const [ethClient, signer] = await Promise.all([
+        getEthexeEthereumClient(),
+        resolveEthexeSigner(context.publicClient, opts),
+      ]);
+      ethClient.setSigner(signer);
 
       const owner = await signer.getAddress();
-      const txManager = await api.eth.wvara.approve(spender, amount);
-      const receipt = await txManager.sendAndWaitForReceipt();
+      const txManager = await ethClient.wvara.approve(spender, amount);
+      const result = await sendWvaraTransaction(txManager, wait);
 
       output({
         chain: 'vara-eth',
         display: 'Vara.eth',
-        txHash: receipt.transactionHash,
+        txHash: result.txHash,
+        status: result.status,
+        wait,
         owner,
         spender,
         amount: amount.toString(),
@@ -107,32 +146,39 @@ export function registerVaraEthWvaraCommand(program: Command): void {
     .option('--account <name>', 'Vara.eth wallet name')
     .option('--passphrase <pass>', 'wallet passphrase')
     .option('--deadline <unix-seconds>', 'permit deadline as UNIX timestamp (default: now + 300s)')
+    .option('--wait <stage>', 'completion stage: submitted or receipt (default)', 'receipt')
     .action(async (spenderArg: string, amountArg: string, _options: PermitOptions, cmd: Command) => {
       const opts = cmd.optsWithGlobals() as PermitOptions;
       const spender = asAddress(spenderArg, 'spender');
       const amount = parseBigIntArg(amountArg, 'amount');
+      const wait = resolveWaitMode(opts.wait);
       const deadlineSeconds = opts.deadline
         ? parseBigIntArg(opts.deadline, '--deadline')
         : BigInt(Math.floor(Date.now() / 1000) + 300);
 
-      const api = await getEthexeApi();
-      const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-      api.eth.setSigner(signer);
+      const context = getEthexeEthereumContext();
+      const [ethClient, signer] = await Promise.all([
+        getEthexeEthereumClient(),
+        resolveEthexeSigner(context.publicClient, opts),
+      ]);
+      ethClient.setSigner(signer);
 
-      const permitData = await api.eth.wvara.prepareAndSignPermitData(spender, amount, deadlineSeconds);
-      const txManager = api.eth.wvara.permit(
+      const permitData = await ethClient.wvara.prepareAndSignPermitData(spender, amount, deadlineSeconds);
+      const txManager = ethClient.wvara.permit(
         permitData.owner,
         permitData.spender,
         permitData.value,
         permitData.deadline,
         permitData.signature,
       );
-      const receipt = await txManager.sendAndWaitForReceipt();
+      const result = await sendWvaraTransaction(txManager, wait);
 
       output({
         chain: 'vara-eth',
         display: 'Vara.eth',
-        txHash: receipt.transactionHash,
+        txHash: result.txHash,
+        status: result.status,
+        wait,
         owner: permitData.owner,
         spender,
         amount: amount.toString(),

--- a/src/services/vara-eth/api.ts
+++ b/src/services/vara-eth/api.ts
@@ -62,7 +62,7 @@ function asAddress(value: unknown): Address | undefined {
 
 function withEthexeConnectionTimeout<T>(
   promise: Promise<T>,
-  endpoint: string,
+  endpoint: string | (() => string),
   cleanupAfterTimeout?: () => void,
 ): Promise<T> {
   let didTimeout = false;
@@ -72,8 +72,9 @@ function withEthexeConnectionTimeout<T>(
       () => {
         didTimeout = true;
         cleanupAfterTimeout?.();
+        const timedOutEndpoint = typeof endpoint === 'function' ? endpoint() : endpoint;
         reject(new CliError(
-          `Connection to ${endpoint} timed out after 10s. Check your network or VARA_ETH_RPC setting.`,
+          `Connection to ${timedOutEndpoint} timed out after 10s. Check your configured RPC endpoints.`,
           'CONNECTION_TIMEOUT',
         ));
       },
@@ -87,6 +88,20 @@ function withEthexeConnectionTimeout<T>(
     }),
     timeoutPromise,
   ]);
+}
+
+function errorMentionsEndpoint(error: unknown, endpoint: string): boolean {
+  const seen = new Set<object>();
+  let current: unknown = error;
+  for (let depth = 0; depth < 8 && current; depth += 1) {
+    if (typeof current === 'string') return current.includes(endpoint);
+    if (typeof current !== 'object' || seen.has(current)) return false;
+    seen.add(current);
+    const wrapped = current as { message?: unknown; cause?: unknown };
+    if (typeof wrapped.message === 'string' && wrapped.message.includes(endpoint)) return true;
+    current = wrapped.cause;
+  }
+  return false;
 }
 
 function findBroadcastArtifacts(root = process.cwd()): string[] {
@@ -194,7 +209,8 @@ export function resolveEthexeConfig(options: EthexeApiOptions = {}): {
 
   const varaEthRpc = options.varaEthRpc ?? cliPresetVaraEthRpc ?? process.env.VARA_ETH_RPC ?? config.varaEthRpc ?? configPreset?.varaEthRpc;
   const ethereumRpc = options.ethereumRpc ?? cliPresetEthereumRpc ?? process.env.ETHEREUM_RPC ?? config.ethereumRpc ?? configPreset?.ethereumRpc;
-  let ethereumHttpRpc = options.ethereumHttpRpc ?? cliPresetEthereumHttpRpc ?? process.env.ETHEREUM_HTTP_RPC;
+  const matchingCliPresetHttpRpc = ethereumRpc === cliPresetEthereumRpc ? cliPresetEthereumHttpRpc : undefined;
+  let ethereumHttpRpc = options.ethereumHttpRpc ?? matchingCliPresetHttpRpc ?? process.env.ETHEREUM_HTTP_RPC;
   if (!ethereumHttpRpc && !hasCliPreset && !options.ethereumRpc && ethereumRpc === configPreset?.ethereumRpc) {
     ethereumHttpRpc = configPreset?.ethereumHttpRpc;
   }
@@ -232,7 +248,10 @@ export function resolveEthexeConfig(options: EthexeApiOptions = {}): {
   return { varaEthRpc, ethereumRpc, ethereumHttpRpc, routerAddress };
 }
 
-function createEthereumPublicClient(endpoint: string): PublicClient {
+function createEthereumPublicClient(
+  endpoint: string,
+  configKey: 'ethereumRpc' | 'ethereumHttpRpc',
+): PublicClient {
   if (/^https?:\/\//i.test(endpoint)) {
     return createPublicClient({ transport: http(endpoint) }) as PublicClient;
   }
@@ -242,7 +261,7 @@ function createEthereumPublicClient(endpoint: string): PublicClient {
   throw new CliError(
     `Unsupported Ethereum RPC URL "${endpoint}". Expected http(s):// or ws(s)://.`,
     'INVALID_CONFIG_VALUE',
-    { key: 'ethereumRpc', value: endpoint },
+    { key: configKey, value: endpoint },
   );
 }
 
@@ -255,39 +274,44 @@ export async function getEthexeApi(options: EthexeApiOptions = {}): Promise<Vara
   if (cached) return cached.api;
 
   const cfg = resolveEthexeConfig(options);
-  const ethereumEndpoint = options.ethereumTransport === 'stream'
-    ? cfg.ethereumRpc
-    : (cfg.ethereumHttpRpc ?? cfg.ethereumRpc);
+  const usesEthereumHttpRpc = options.ethereumTransport !== 'stream' && cfg.ethereumHttpRpc !== undefined;
+  const ethereumEndpoint = usesEthereumHttpRpc ? cfg.ethereumHttpRpc! : cfg.ethereumRpc;
+  const ethereumConfigKey = usesEthereumHttpRpc ? 'ethereumHttpRpc' : 'ethereumRpc';
   const ethereumTransport = /^https?:\/\//i.test(ethereumEndpoint) ? 'http' : 'websocket';
   markStage('vara_eth_config', { ethereumTransport });
 
   const ws = new WsVaraEthProvider(cfg.varaEthRpc);
-  let disconnected = false;
   const disconnectWs = () => {
-    if (disconnected) return;
-    disconnected = true;
     try {
-      ws.disconnect?.();
+      const disconnect = ws.disconnect?.();
+      void disconnect?.catch(() => {});
     } catch {
       // ignore failed cleanup after connect/bootstrap failure
     }
   };
+  let validatorConnected = false;
+  const timeoutEndpoint = () => validatorConnected ? ethereumEndpoint : cfg.varaEthRpc;
   let api: VaraEthApi;
   try {
-    const publicClient = createEthereumPublicClient(ethereumEndpoint);
+    const publicClient = createEthereumPublicClient(ethereumEndpoint, ethereumConfigKey);
     const [, initializedApi] = await withEthexeConnectionTimeout(
       Promise.all([
-        ws.connect(),
+        ws.connect().then(() => {
+          validatorConnected = true;
+        }),
         createVaraEthApi(ws, publicClient, cfg.routerAddress),
       ]),
-      cfg.varaEthRpc,
+      timeoutEndpoint,
       disconnectWs,
     );
     api = initializedApi;
     markStage('vara_eth_connect', { ethereumTransport });
   } catch (rawErr) {
     if (!(rawErr instanceof CliError && rawErr.code === 'CONNECTION_TIMEOUT')) disconnectWs();
-    throw classifyTransportError(rawErr, { endpoint: cfg.varaEthRpc }) ?? rawErr;
+    const failedEndpoint = rawErr instanceof CliError && rawErr.code === 'CONNECTION_TIMEOUT'
+      ? timeoutEndpoint()
+      : (errorMentionsEndpoint(rawErr, ethereumEndpoint) ? ethereumEndpoint : cfg.varaEthRpc);
+    throw classifyTransportError(rawErr, { endpoint: failedEndpoint }) ?? rawErr;
   }
 
   cached = { api, ws };

--- a/src/services/vara-eth/api.ts
+++ b/src/services/vara-eth/api.ts
@@ -9,10 +9,9 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
-import { createPublicClient, webSocket, type Address, type PublicClient } from 'viem';
+import { createPublicClient, http, webSocket, type Address, type PublicClient } from 'viem';
 import {
   createVaraEthApi,
-  HttpVaraEthProvider,
   WsVaraEthProvider,
   getMirrorClient as makeMirrorClient,
   type ITransactionSigner,
@@ -23,22 +22,31 @@ import {
 import { CliError, classifyTransportError } from '../../utils/errors';
 import { readConfig } from '../config';
 import { resolveVaraEthNetwork } from '../../chains/vara-eth/networks';
+import { markStage } from '../../utils/timing';
 
 interface CacheEntry {
   api: VaraEthApi;
-  ws: WsVaraEthProvider | HttpVaraEthProvider;
+  ws: WsVaraEthProvider;
 }
 
 let cached: CacheEntry | null = null;
 
 const ETHEXE_CONNECTION_TIMEOUT_MS = 10_000;
 
-interface EthexeApiOptions {
+export interface EthexeApiOptions {
   varaEthRpc?: string;
   ethereumRpc?: string;
+  ethereumHttpRpc?: string;
+  /** Use WebSocket only for long-lived event streams; requests prefer HTTP. */
+  ethereumTransport?: 'request' | 'stream';
   routerAddress?: Address;
   /** Resolved Vara.eth network preset from --network. */
-  networkPreset?: { varaEthRpc: string; ethereumRpc: string; routerAddress: `0x${string}` | null };
+  networkPreset?: {
+    varaEthRpc: string;
+    ethereumRpc: string;
+    ethereumHttpRpc?: string;
+    routerAddress: `0x${string}` | null;
+  };
 }
 
 const BROADCAST_CANDIDATE_NAMES = new Set(['run-latest.json', 'broadcast.log.json']);
@@ -162,12 +170,14 @@ function discoverLocalRouterAddress(root = process.cwd()): Address | undefined {
  * Resolves the Vara.eth endpoint stack from explicit options → command-line
  * network preset → env vars → config → config network preset.
  *
- * Required: `varaEthRpc` (WS), `ethereumRpc` (WS), `routerAddress` (0x-hex).
+ * Required: `varaEthRpc` (WS), `ethereumRpc`, `routerAddress` (0x-hex).
+ * `ethereumHttpRpc` is optional and used for one-shot requests when available.
  * Throws {@link CliError} with `MISSING_ETHEXE_CONFIG` if any are missing.
  */
 export function resolveEthexeConfig(options: EthexeApiOptions = {}): {
   varaEthRpc: string;
   ethereumRpc: string;
+  ethereumHttpRpc?: string;
   routerAddress: Address;
 } {
   const config = readConfig();
@@ -176,12 +186,18 @@ export function resolveEthexeConfig(options: EthexeApiOptions = {}): {
     Boolean(process.env.VARA_ETH_NETWORK_PRESET_VARA_ETH_RPC || process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_RPC);
   const cliPresetVaraEthRpc = options.networkPreset?.varaEthRpc ?? process.env.VARA_ETH_NETWORK_PRESET_VARA_ETH_RPC;
   const cliPresetEthereumRpc = options.networkPreset?.ethereumRpc ?? process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_RPC;
+  const cliPresetEthereumHttpRpc = options.networkPreset?.ethereumHttpRpc
+    ?? process.env.VARA_ETH_NETWORK_PRESET_ETHEREUM_HTTP_RPC;
   const cliPresetRouter =
     options.networkPreset?.routerAddress ??
     (process.env.VARA_ETH_NETWORK_PRESET_ROUTER as Address | undefined);
 
   const varaEthRpc = options.varaEthRpc ?? cliPresetVaraEthRpc ?? process.env.VARA_ETH_RPC ?? config.varaEthRpc ?? configPreset?.varaEthRpc;
   const ethereumRpc = options.ethereumRpc ?? cliPresetEthereumRpc ?? process.env.ETHEREUM_RPC ?? config.ethereumRpc ?? configPreset?.ethereumRpc;
+  let ethereumHttpRpc = options.ethereumHttpRpc ?? cliPresetEthereumHttpRpc ?? process.env.ETHEREUM_HTTP_RPC;
+  if (!ethereumHttpRpc && !hasCliPreset && !options.ethereumRpc && ethereumRpc === configPreset?.ethereumRpc) {
+    ethereumHttpRpc = configPreset?.ethereumHttpRpc;
+  }
   let routerAddress = options.routerAddress;
 
   if (!routerAddress && hasCliPreset) {
@@ -213,7 +229,21 @@ export function resolveEthexeConfig(options: EthexeApiOptions = {}): {
     );
   }
 
-  return { varaEthRpc, ethereumRpc, routerAddress };
+  return { varaEthRpc, ethereumRpc, ethereumHttpRpc, routerAddress };
+}
+
+function createEthereumPublicClient(endpoint: string): PublicClient {
+  if (/^https?:\/\//i.test(endpoint)) {
+    return createPublicClient({ transport: http(endpoint) }) as PublicClient;
+  }
+  if (/^wss?:\/\//i.test(endpoint)) {
+    return createPublicClient({ transport: webSocket(endpoint) }) as PublicClient;
+  }
+  throw new CliError(
+    `Unsupported Ethereum RPC URL "${endpoint}". Expected http(s):// or ws(s)://.`,
+    'INVALID_CONFIG_VALUE',
+    { key: 'ethereumRpc', value: endpoint },
+  );
 }
 
 /**
@@ -225,9 +255,17 @@ export async function getEthexeApi(options: EthexeApiOptions = {}): Promise<Vara
   if (cached) return cached.api;
 
   const cfg = resolveEthexeConfig(options);
+  const ethereumEndpoint = options.ethereumTransport === 'stream'
+    ? cfg.ethereumRpc
+    : (cfg.ethereumHttpRpc ?? cfg.ethereumRpc);
+  const ethereumTransport = /^https?:\/\//i.test(ethereumEndpoint) ? 'http' : 'websocket';
+  markStage('vara_eth_config', { ethereumTransport });
 
   const ws = new WsVaraEthProvider(cfg.varaEthRpc);
+  let disconnected = false;
   const disconnectWs = () => {
+    if (disconnected) return;
+    disconnected = true;
     try {
       ws.disconnect?.();
     } catch {
@@ -236,14 +274,17 @@ export async function getEthexeApi(options: EthexeApiOptions = {}): Promise<Vara
   };
   let api: VaraEthApi;
   try {
-    await withEthexeConnectionTimeout(ws.connect(), cfg.varaEthRpc, disconnectWs);
-
-    const publicClient = createPublicClient({ transport: webSocket(cfg.ethereumRpc) }) as PublicClient;
-    api = await withEthexeConnectionTimeout(
-      createVaraEthApi(ws, publicClient, cfg.routerAddress),
+    const publicClient = createEthereumPublicClient(ethereumEndpoint);
+    const [, initializedApi] = await withEthexeConnectionTimeout(
+      Promise.all([
+        ws.connect(),
+        createVaraEthApi(ws, publicClient, cfg.routerAddress),
+      ]),
       cfg.varaEthRpc,
       disconnectWs,
     );
+    api = initializedApi;
+    markStage('vara_eth_connect', { ethereumTransport });
   } catch (rawErr) {
     if (!(rawErr instanceof CliError && rawErr.code === 'CONNECTION_TIMEOUT')) disconnectWs();
     throw classifyTransportError(rawErr, { endpoint: cfg.varaEthRpc }) ?? rawErr;

--- a/src/services/vara-eth/api.ts
+++ b/src/services/vara-eth/api.ts
@@ -312,14 +312,16 @@ export function getEthexeEthereumClient(options: EthexeApiOptions = {}): Promise
 
   const context = getEthexeEthereumContext(options);
   const client = new EthereumClient(context.publicClient, context.routerAddress);
-  cachedEthereumClient = withEthexeConnectionTimeout(
+  let initialization: Promise<EthereumClient>;
+  initialization = withEthexeConnectionTimeout(
     client.waitForInitialization().then(() => client),
     context.endpoint,
   ).catch((rawError) => {
-    cachedEthereumClient = null;
+    if (cachedEthereumClient === initialization) cachedEthereumClient = null;
     throw classifyTransportError(rawError, { endpoint: context.endpoint }) ?? rawError;
   });
-  return cachedEthereumClient;
+  cachedEthereumClient = initialization;
+  return initialization;
 }
 
 /**

--- a/src/services/vara-eth/api.ts
+++ b/src/services/vara-eth/api.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { createPublicClient, http, webSocket, type Address, type PublicClient } from 'viem';
 import {
   createVaraEthApi,
+  EthereumClient,
   WsVaraEthProvider,
   getMirrorClient as makeMirrorClient,
   type ITransactionSigner,
@@ -30,6 +31,8 @@ interface CacheEntry {
 }
 
 let cached: CacheEntry | null = null;
+let cachedEthereumContext: EthexeEthereumContext | null = null;
+let cachedEthereumClient: Promise<EthereumClient> | null = null;
 
 const ETHEXE_CONNECTION_TIMEOUT_MS = 10_000;
 
@@ -47,6 +50,14 @@ export interface EthexeApiOptions {
     ethereumHttpRpc?: string;
     routerAddress: `0x${string}` | null;
   };
+}
+
+export interface EthexeEthereumContext {
+  publicClient: PublicClient;
+  routerAddress: Address;
+  varaEthRpc: string;
+  endpoint: string;
+  transport: 'http' | 'websocket';
 }
 
 const BROADCAST_CANDIDATE_NAMES = new Set(['run-latest.json', 'broadcast.log.json']);
@@ -266,6 +277,52 @@ function createEthereumPublicClient(
 }
 
 /**
+ * Returns the request-mode Ethereum context without opening the Vara.eth
+ * validator connection. Direct Mirror and WVARA writes use this path when the
+ * caller only needs Ethereum transaction submission or an L1 receipt.
+ */
+export function getEthexeEthereumContext(options: EthexeApiOptions = {}): EthexeEthereumContext {
+  if (cachedEthereumContext) return cachedEthereumContext;
+
+  const cfg = resolveEthexeConfig(options);
+  const usesEthereumHttpRpc = options.ethereumTransport !== 'stream' && cfg.ethereumHttpRpc !== undefined;
+  const endpoint = usesEthereumHttpRpc ? cfg.ethereumHttpRpc! : cfg.ethereumRpc;
+  const configKey = usesEthereumHttpRpc ? 'ethereumHttpRpc' : 'ethereumRpc';
+  const transport = /^https?:\/\//i.test(endpoint) ? 'http' : 'websocket';
+  const publicClient = createEthereumPublicClient(endpoint, configKey);
+
+  cachedEthereumContext = {
+    publicClient,
+    routerAddress: cfg.routerAddress,
+    varaEthRpc: cfg.varaEthRpc,
+    endpoint,
+    transport,
+  };
+  markStage('vara_eth_config', { ethereumTransport: transport });
+  return cachedEthereumContext;
+}
+
+/**
+ * Builds the Ethereum-side client without initializing the Vara.eth validator
+ * API. WVARA and Router transactions need this client; direct Mirror sends can
+ * use {@link getEthexeEthereumContext} alone.
+ */
+export function getEthexeEthereumClient(options: EthexeApiOptions = {}): Promise<EthereumClient> {
+  if (cachedEthereumClient) return cachedEthereumClient;
+
+  const context = getEthexeEthereumContext(options);
+  const client = new EthereumClient(context.publicClient, context.routerAddress);
+  cachedEthereumClient = withEthexeConnectionTimeout(
+    client.waitForInitialization().then(() => client),
+    context.endpoint,
+  ).catch((rawError) => {
+    cachedEthereumClient = null;
+    throw classifyTransportError(rawError, { endpoint: context.endpoint }) ?? rawError;
+  });
+  return cachedEthereumClient;
+}
+
+/**
  * Returns a cached `VaraEthApi` for the current process. Within one CLI
  * invocation every caller shares the same instance; on the second call the
  * supplied options are ignored — only the first call's resolution wins.
@@ -273,14 +330,16 @@ function createEthereumPublicClient(
 export async function getEthexeApi(options: EthexeApiOptions = {}): Promise<VaraEthApi> {
   if (cached) return cached.api;
 
-  const cfg = resolveEthexeConfig(options);
-  const usesEthereumHttpRpc = options.ethereumTransport !== 'stream' && cfg.ethereumHttpRpc !== undefined;
-  const ethereumEndpoint = usesEthereumHttpRpc ? cfg.ethereumHttpRpc! : cfg.ethereumRpc;
-  const ethereumConfigKey = usesEthereumHttpRpc ? 'ethereumHttpRpc' : 'ethereumRpc';
-  const ethereumTransport = /^https?:\/\//i.test(ethereumEndpoint) ? 'http' : 'websocket';
-  markStage('vara_eth_config', { ethereumTransport });
+  const ethereumContext = getEthexeEthereumContext(options);
+  const {
+    endpoint: ethereumEndpoint,
+    transport: ethereumTransport,
+    publicClient,
+    varaEthRpc,
+    routerAddress,
+  } = ethereumContext;
 
-  const ws = new WsVaraEthProvider(cfg.varaEthRpc);
+  const ws = new WsVaraEthProvider(varaEthRpc);
   const disconnectWs = () => {
     try {
       const disconnect = ws.disconnect?.();
@@ -290,16 +349,15 @@ export async function getEthexeApi(options: EthexeApiOptions = {}): Promise<Vara
     }
   };
   let validatorConnected = false;
-  const timeoutEndpoint = () => validatorConnected ? ethereumEndpoint : cfg.varaEthRpc;
+  const timeoutEndpoint = () => validatorConnected ? ethereumEndpoint : varaEthRpc;
   let api: VaraEthApi;
   try {
-    const publicClient = createEthereumPublicClient(ethereumEndpoint, ethereumConfigKey);
     const [, initializedApi] = await withEthexeConnectionTimeout(
       Promise.all([
         ws.connect().then(() => {
           validatorConnected = true;
         }),
-        createVaraEthApi(ws, publicClient, cfg.routerAddress),
+        createVaraEthApi(ws, publicClient, routerAddress),
       ]),
       timeoutEndpoint,
       disconnectWs,
@@ -310,7 +368,7 @@ export async function getEthexeApi(options: EthexeApiOptions = {}): Promise<Vara
     if (!(rawErr instanceof CliError && rawErr.code === 'CONNECTION_TIMEOUT')) disconnectWs();
     const failedEndpoint = rawErr instanceof CliError && rawErr.code === 'CONNECTION_TIMEOUT'
       ? timeoutEndpoint()
-      : (errorMentionsEndpoint(rawErr, ethereumEndpoint) ? ethereumEndpoint : cfg.varaEthRpc);
+      : (errorMentionsEndpoint(rawErr, ethereumEndpoint) ? ethereumEndpoint : varaEthRpc);
     throw classifyTransportError(rawErr, { endpoint: failedEndpoint }) ?? rawErr;
   }
 
@@ -319,22 +377,25 @@ export async function getEthexeApi(options: EthexeApiOptions = {}): Promise<Vara
 }
 
 /**
- * Builds a `MirrorClient` for the given program address, reusing the cached
- * `publicClient` from {@link getEthexeApi}. Optional `signer` switches the
- * client into write mode.
+ * Builds a `MirrorClient` for the given program address from the lightweight
+ * Ethereum request context. Optional `signer` switches the client into write
+ * mode without opening the Vara.eth validator connection.
  */
 export async function getMirrorClient(address: Address, signer?: ITransactionSigner): Promise<MirrorClient> {
-  const api = await getEthexeApi();
-  return makeMirrorClient({ address, publicClient: api.eth.publicClient, signer });
+  const { publicClient } = getEthexeEthereumContext();
+  return makeMirrorClient({ address, publicClient, signer });
 }
 
 /** Tears down the cached Vara.eth connections. Safe to call when nothing is open. */
 export function disconnectEthexeApi(): void {
-  if (!cached) return;
-  try {
-    cached.ws.disconnect?.();
-  } catch {
-    // ignore — disconnect during shutdown
+  if (cached) {
+    try {
+      cached.ws.disconnect?.();
+    } catch {
+      // ignore — disconnect during shutdown
+    }
   }
   cached = null;
+  cachedEthereumContext = null;
+  cachedEthereumClient = null;
 }

--- a/src/services/vara-eth/sails-idl.ts
+++ b/src/services/vara-eth/sails-idl.ts
@@ -29,7 +29,7 @@ export async function loadVaraEthSails(
       program: { codeId(programAddress: Address): Promise<Hex> };
       code: { getOriginal(codeId: Hex): Promise<Hex> };
     };
-  },
+  } | undefined,
   programAddress: Address,
   options: { idl?: string; requiredMethod?: VaraEthSailsMethodRequirement } = {},
 ): Promise<LoadedVaraEthSails> {
@@ -40,6 +40,14 @@ export async function loadVaraEthSails(
       codeId: null,
       source: 'local',
     };
+  }
+
+  if (!api) {
+    throw new CliError(
+      `No IDL source available for Vara.eth program ${programAddress}. Pass --idl <path.idl> for an Ethereum-only call.`,
+      'IDL_NOT_FOUND',
+      { programAddress },
+    );
   }
 
   let codeId: Hex;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -448,6 +448,36 @@ export interface TransportContext {
   cause?: { code?: string; message?: string };
 }
 
+function extractTransportSignals(err: unknown): { code?: string; messages: string[] } {
+  const seen = new Set<object>();
+  const messages: string[] = [];
+  let code: string | undefined;
+
+  const visit = (value: unknown, depth: number): void => {
+    if (depth > 8 || value === null || value === undefined) return;
+    if (typeof value === 'string') {
+      messages.push(value);
+      return;
+    }
+    if (typeof value !== 'object' || seen.has(value)) return;
+    seen.add(value);
+
+    const nested = value as {
+      code?: unknown;
+      message?: unknown;
+      error?: unknown;
+      cause?: unknown;
+    };
+    if (!code && typeof nested.code === 'string') code = nested.code;
+    if (typeof nested.message === 'string') messages.push(nested.message);
+    visit(nested.error, depth + 1);
+    visit(nested.cause, depth + 1);
+  };
+
+  visit(err, 0);
+  return { code, messages };
+}
+
 /**
  * Classify a transport-layer failure (DNS, WS handshake, RPC disconnect,
  * TLS, timeout) into a `TRANSPORT_ERROR` CliError with a structured
@@ -477,22 +507,9 @@ export function classifyTransportError(err: unknown, ctx: TransportContext = {})
   // only the CONNECTION_TIMEOUT sentinel above is migrated.
   if (err instanceof CliError) return null;
 
-  // 1+2. Direct `.code` or wrapped `.error.code` / `.cause.code`.
-  //   - Node net errors throw directly with `.code` (ENOTFOUND, ECONNREFUSED, …).
-  //   - The `ws` library wraps as `{ error: NetError, message, type, target }`.
-  //   - Node's `fetch` wraps the underlying network error as `err.cause`.
-  const anyErr = err as {
-    code?: string;
-    message?: string;
-    error?: { code?: string; message?: string };
-    cause?: { code?: string; message?: string };
-  } | null;
-  const directCode = anyErr?.code ?? anyErr?.error?.code ?? anyErr?.cause?.code;
-  const directMessage = anyErr?.message ?? anyErr?.error?.message ?? anyErr?.cause?.message;
-
-  // 3. Message string. Available for direct Error instances, listener-captured
-  //    causes, and even empty {} (which yields '').
-  const msg = directMessage ?? (typeof err === 'string' ? err : '');
+  // Walk nested `.error` / `.cause` wrappers. Node fetch and viem can put the
+  // actionable socket code two or more causes below the top-level error.
+  const direct = extractTransportSignals(err);
 
   // 4. Listener fallback. Used when the rejection is empty (e.g., browser-style
   //    `Event` from WsProvider) but the on('error') listener captured the
@@ -500,8 +517,13 @@ export function classifyTransportError(err: unknown, ctx: TransportContext = {})
   const ctxCode = ctx.cause?.code;
   const ctxMsg = ctx.cause?.message;
 
-  const code = directCode ?? ctxCode;
-  const combinedMsg = `${msg} ${ctxMsg ?? ''}`.trim();
+  const code = direct.code ?? ctxCode;
+  const combinedMsg = `${direct.messages.join(' ')} ${ctxMsg ?? ''}`.trim();
+  const firstMessage = direct.messages[0];
+  const rootMessage = direct.messages.at(-1);
+  const causeMessage = [firstMessage, rootMessage !== firstMessage ? rootMessage : undefined, ctxMsg]
+    .filter((message): message is string => Boolean(message))
+    .join('; cause: ');
 
   const reason = matchReason(code, combinedMsg);
   if (!reason) {
@@ -511,11 +533,11 @@ export function classifyTransportError(err: unknown, ctx: TransportContext = {})
     // as a bare `{ method: '...' }` object — return null and let the
     // legacy UNKNOWN_ERROR / PROGRAM_ERROR paths take over.
     if (ctx.endpoint || ctx.cause) {
-      return buildTransportError('unknown', ctx, code, combinedMsg);
+      return buildTransportError('unknown', ctx, code, causeMessage);
     }
     return null;
   }
-  return buildTransportError(reason, ctx, code, combinedMsg);
+  return buildTransportError(reason, ctx, code, causeMessage);
 }
 
 function matchReason(code: string | undefined, message: string): TransportReason | null {


### PR DESCRIPTION
## Summary

- start the Vara.eth validator connection and Ethereum API bootstrap concurrently under the existing shared timeout
- use canonical Ethereum HTTP endpoints for one-shot requests while retaining WebSocket transport for subscriptions
- add an Ethereum-only client path for transactions that do not need validator state
- add `--wait submitted` to messages, replies, WVARA writes, and state-changing Sails calls
- allow direct messages and explicitly typed direct Sails writes to return after Ethereum RPC acceptance without opening the validator connection
- preserve existing completion defaults: `reply` for messages and Sails writes, `receipt` for WVARA writes and replies
- harden submit-only Sails, WVARA receipt, injected-persistence, and client-cache edge cases found in review
- document the latency tradeoffs and update Vara.eth agent workflow guidance

## Root cause

Vara.eth commands initialized both the validator WebSocket and Ethereum client even when the requested operation only needed to sign and submit an Ethereum transaction. The serialized setup paid both connection costs, while the Ethereum side also used WebSocket for one-shot JSON-RPC requests. Commands then waited for a receipt or program reply even when the caller only needed a transaction hash.

## Impact

Normal Vara.eth commands overlap independent initialization work and use HTTP for one-shot Ethereum requests. Submit-only direct messages now avoid the validator connection entirely and return after RPC acceptance. Direct Sails writes receive the same fast path when an explicit `--idl` removes the need for validator-backed IDL discovery.

For direct submit-only messages, `messageId` is `null` because it is receipt-derived. Injected submission still opens the validator to construct the transaction, but skips signature validation and reply waiting. Existing command behavior is unchanged unless `--wait submitted` is selected.

Review follow-up fixes ensure submitted-wait Sails queries and estimates keep their required validator API, receipt-mode WVARA writes preserve `success` or `reverted`, submit-only injected sends do not create unresumable database rows, and late initialization failures cannot clear a newer client cache.

A five-pair read-only Hoodi benchmark measured:

- WebSocket fallback median: 969 ms
- HTTP request path median: 757 ms
- median improvement: 22%

## Validation

- `npm test -- --runInBand` — 80 suites, 889 tests passed
- `npx tsc --noEmit`
- `npm run test:smoke`
- `git diff --check`

No live transaction was broadcast while validating the submit-only paths.

## Related

- gear-foundation/vara-skills#28

Closes #76