### PR TITLE
chore: prepare v0.20.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.20.4] - 2026-07-13
+
 ### Changed
 
 - Reduce Vara.eth command startup latency by overlapping validator connection with API bootstrap and using preset Ethereum HTTP endpoints for one-shot requests. Event subscriptions continue to use WebSocket, and custom configurations without `ETHEREUM_HTTP_RPC` retain their existing WebSocket fallback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "bundleDependencies": [
         "@vara-eth/api",
         "viem",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {


### PR DESCRIPTION
## Summary
- prepare the 0.20.4 patch release for the merged Vara.eth RPC latency improvements
- bump the package and lockfile version from 0.20.3 to 0.20.4
- publish the matching dated changelog section

## Validation
- npm run build
- npm test (80 suites, 889 tests)
- npm run test:pack-smoke

Merging this PR only prepares the release. Publishing remains gated on the explicit `v0.20.4` tag.