### PR TITLE
Add persistent Vara.eth agent session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.20.4",
+      "version": "0.20.5",
       "bundleDependencies": [
         "@vara-eth/api",
         "viem",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/src/__tests__/vara-eth-actions.test.ts
+++ b/src/__tests__/vara-eth-actions.test.ts
@@ -377,6 +377,8 @@ describe('Vara.eth shared actions', () => {
   });
 
   it('uses the injected send RPC without opening a receipt subscription', async () => {
+    mockSend.mockResolvedValueOnce('Accept');
+
     await outputVaraEthMessageSend(TO, {
       account: 'hoodi-smoke',
       payload: '0xabcd',
@@ -600,6 +602,28 @@ describe('Vara.eth shared actions', () => {
       messageId: null,
       result: null,
       reply: null,
+    }));
+  });
+
+  it('uses the deterministic injected transaction ID when the validator acknowledges with Accept', async () => {
+    mockSend.mockResolvedValueOnce('Accept');
+
+    await outputVaraEthSailsCall(TO, 'Demo/Echo', {
+      account: 'hoodi-smoke',
+      idl: FIXTURE_IDL,
+      args: '["0xaabb","0x5555555555555555555555555555555555555555555555555555555555555555"]',
+      value: '0',
+      via: 'injected',
+      wait: 'submitted',
+    });
+
+    expect(mockCreateInjectedTransaction).toHaveBeenCalled();
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      via: 'injected',
+      wait: 'submitted',
+      status: 'submitted',
+      txHash: TX_HASH,
+      messageId: MESSAGE_ID,
     }));
   });
 

--- a/src/__tests__/vara-eth-session.test.ts
+++ b/src/__tests__/vara-eth-session.test.ts
@@ -15,11 +15,14 @@ const mockResolveMethod = jest.fn();
 const mockDecodeReply = jest.fn();
 const mockSend = jest.fn();
 const mockSetDefaultValidator = jest.fn();
+const mockSerializeReplyCode = jest.fn();
 
 jest.mock('../services/vara-eth/api', () => ({ getEthexeApi: jest.fn() }));
 jest.mock('../services/vara-eth/account', () => ({ resolveEthexeSigner: jest.fn() }));
 jest.mock('../services/vara-eth/sails-idl', () => ({ loadVaraEthSails: (...args: unknown[]) => mockLoadSails(...args) }));
-jest.mock('../shared/output-eth/reply-code', () => ({ serializeReplyCode: jest.fn(() => ({ tag: 'Success' })) }));
+jest.mock('../shared/output-eth/reply-code', () => ({
+  serializeReplyCode: (...args: unknown[]) => mockSerializeReplyCode(...args),
+}));
 jest.mock('../commands/vara-eth-actions', () => ({
   parseSailsMethod: (method: string) => {
     const [serviceName, methodName] = method.split('/');
@@ -56,6 +59,7 @@ beforeEach(() => {
   mockGetAddress.mockResolvedValue(ADDRESS);
   mockLoadSails.mockResolvedValue({ sails });
   mockCalculateReply.mockResolvedValue({ code: { isSuccess: true }, payload: '0x1234', value: 0n });
+  mockSerializeReplyCode.mockReturnValue({ tag: 'Success' });
   mockDecodeReply.mockReturnValue({ decoded: true });
   mockCreateInjectedTransaction.mockResolvedValue({
     txHash: TX_HASH,
@@ -109,5 +113,21 @@ describe('vara-eth:session', () => {
       type: 'error', id: 'bad', error: expect.objectContaining({ code: 'INVALID_SESSION_REQUEST' }),
     }));
     expect(mockOutputNdjson).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'result', id: 'good' }));
+  });
+
+  it('includes the serialized reply code when a query is rejected', async () => {
+    mockResolveMethod.mockReturnValue({ kind: 'query', method: queryMethod });
+    mockCalculateReply.mockResolvedValue({ code: { isSuccess: false }, payload: '0x', value: 0n });
+    mockSerializeReplyCode.mockReturnValue({ tag: 'Error', raw: '0x02000000' });
+
+    await runVaraEthSession({}, Readable.from([
+      `${JSON.stringify({ id: 'rejected', program: PROGRAM, method: 'World/Session', args: [] })}\n`,
+    ]));
+
+    expect(mockOutputNdjson).toHaveBeenLastCalledWith(expect.objectContaining({
+      type: 'error',
+      id: 'rejected',
+      error: expect.objectContaining({ code: 'PROGRAM_ERROR', replyCode: { tag: 'Error', raw: '0x02000000' } }),
+    }));
   });
 });

--- a/src/__tests__/vara-eth-session.test.ts
+++ b/src/__tests__/vara-eth-session.test.ts
@@ -1,0 +1,113 @@
+import { Readable } from 'node:stream';
+
+const ADDRESS = '0xabcdef0000000000000000000000000000000001';
+const PROGRAM = '0xabcdef0000000000000000000000000000000002';
+const TX_HASH = '0x' + '11'.repeat(32);
+const MESSAGE_ID = '0x' + '22'.repeat(32);
+
+const mockOutputNdjson = jest.fn();
+const mockSetSigner = jest.fn();
+const mockGetAddress = jest.fn();
+const mockCalculateReply = jest.fn();
+const mockCreateInjectedTransaction = jest.fn();
+const mockLoadSails = jest.fn();
+const mockResolveMethod = jest.fn();
+const mockDecodeReply = jest.fn();
+const mockSend = jest.fn();
+const mockSetDefaultValidator = jest.fn();
+
+jest.mock('../services/vara-eth/api', () => ({ getEthexeApi: jest.fn() }));
+jest.mock('../services/vara-eth/account', () => ({ resolveEthexeSigner: jest.fn() }));
+jest.mock('../services/vara-eth/sails-idl', () => ({ loadVaraEthSails: (...args: unknown[]) => mockLoadSails(...args) }));
+jest.mock('../shared/output-eth/reply-code', () => ({ serializeReplyCode: jest.fn(() => ({ tag: 'Success' })) }));
+jest.mock('../commands/vara-eth-actions', () => ({
+  parseSailsMethod: (method: string) => {
+    const [serviceName, methodName] = method.split('/');
+    return { serviceName, methodName };
+  },
+  resolveSailsMethod: (...args: unknown[]) => mockResolveMethod(...args),
+  decodeVaraEthSailsReply: (...args: unknown[]) => mockDecodeReply(...args),
+}));
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  coerceArgsAuto: (args: unknown[]) => args,
+  outputNdjson: (data: unknown) => mockOutputNdjson(data),
+}));
+
+const { getEthexeApi } = require('../services/vara-eth/api') as { getEthexeApi: jest.Mock };
+const { resolveEthexeSigner } = require('../services/vara-eth/account') as { resolveEthexeSigner: jest.Mock };
+
+import { runVaraEthSession } from '../commands/vara-eth-session';
+
+const sails = { services: {} };
+const queryMethod = { args: [], returnTypeDef: {}, encodePayload: jest.fn(() => '0xaaaa') };
+const functionMethod = { args: [], returnTypeDef: {}, encodePayload: jest.fn(() => '0xbbbb') };
+
+const api = {
+  eth: { publicClient: {}, setSigner: mockSetSigner },
+  call: { program: { calculateReplyForHandle: mockCalculateReply } },
+  createInjectedTransaction: mockCreateInjectedTransaction,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getEthexeApi.mockResolvedValue(api);
+  resolveEthexeSigner.mockResolvedValue({ getAddress: mockGetAddress });
+  mockGetAddress.mockResolvedValue(ADDRESS);
+  mockLoadSails.mockResolvedValue({ sails });
+  mockCalculateReply.mockResolvedValue({ code: { isSuccess: true }, payload: '0x1234', value: 0n });
+  mockDecodeReply.mockReturnValue({ decoded: true });
+  mockCreateInjectedTransaction.mockResolvedValue({
+    txHash: TX_HASH,
+    messageId: MESSAGE_ID,
+    setDefaultValidator: mockSetDefaultValidator,
+    send: mockSend,
+  });
+  mockSend.mockResolvedValue('Accept');
+});
+
+describe('vara-eth:session', () => {
+  it('reuses a loaded IDL for sequential query requests and emits decoded replies', async () => {
+    mockResolveMethod.mockReturnValue({ kind: 'query', method: queryMethod });
+
+    await runVaraEthSession({}, Readable.from([
+      `${JSON.stringify({ id: 1, program: PROGRAM, method: 'World/Session', args: [], idl: '/tmp/world.idl' })}\n`,
+      `${JSON.stringify({ id: 2, program: PROGRAM, method: 'World/Session', args: [], idl: '/tmp/world.idl' })}\n`,
+    ]));
+
+    expect(mockLoadSails).toHaveBeenCalledTimes(1);
+    expect(mockCalculateReply).toHaveBeenCalledTimes(2);
+    expect(mockOutputNdjson).toHaveBeenNthCalledWith(1, expect.objectContaining({ type: 'ready', origin: ADDRESS }));
+    expect(mockOutputNdjson).toHaveBeenLastCalledWith(expect.objectContaining({
+      type: 'result', id: 2, kind: 'query', result: { decoded: true },
+    }));
+  });
+
+  it('submits functions once and returns deterministic transaction identifiers', async () => {
+    mockResolveMethod.mockReturnValue({ kind: 'function', method: functionMethod });
+
+    await runVaraEthSession({}, Readable.from([
+      `${JSON.stringify({ id: 'write-1', program: PROGRAM, method: 'Digger/MoveAgent', args: [] })}\n`,
+    ]));
+
+    expect(mockSetDefaultValidator).toHaveBeenCalledTimes(1);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockOutputNdjson).toHaveBeenLastCalledWith(expect.objectContaining({
+      type: 'result', id: 'write-1', kind: 'function', status: 'submitted', txHash: TX_HASH, messageId: MESSAGE_ID,
+    }));
+  });
+
+  it('keeps the session alive after a malformed request', async () => {
+    mockResolveMethod.mockReturnValue({ kind: 'query', method: queryMethod });
+
+    await runVaraEthSession({}, Readable.from([
+      '{"id":"bad"}\n',
+      `${JSON.stringify({ id: 'good', program: PROGRAM, method: 'World/Session', args: [] })}\n`,
+    ]));
+
+    expect(mockOutputNdjson).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'error', id: 'bad', error: expect.objectContaining({ code: 'INVALID_SESSION_REQUEST' }),
+    }));
+    expect(mockOutputNdjson).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'result', id: 'good' }));
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { registerVaraEthSubscribeCommand } from './commands/vara-eth-subscribe';
 import { registerVaraEthWvaraCommand } from './commands/vara-eth-wvara';
 import { registerVaraEthInheritorCommand } from './commands/vara-eth-inheritor';
 import { registerVaraEthValidatorsCommand } from './commands/vara-eth-validators';
+import { registerVaraEthSessionCommand } from './commands/vara-eth-session';
 import { resolveVaraEthNetwork } from './chains/vara-eth/networks';
 import { resolveActionChain } from './utils/active-chain';
 import { readConfig } from './services/config';
@@ -165,6 +166,7 @@ registerVaraEthSubscribeCommand(program);
 registerVaraEthWvaraCommand(program);
 registerVaraEthInheritorCommand(program);
 registerVaraEthValidatorsCommand(program);
+registerVaraEthSessionCommand(program);
 
 // Subscribe commands register their own signal handler with `prependOnceListener`
 // so it runs before this catch-all and tears down the subscription cleanly.

--- a/src/commands/vara-eth-actions.ts
+++ b/src/commands/vara-eth-actions.ts
@@ -230,7 +230,8 @@ export async function outputVaraEthMessageSend(mirrorArg: string, opts: VaraEthS
         payload,
         value: 0n,
       });
-      txHash = asHex(await injectedTx.send(), 'injected transaction hash');
+      await injectedTx.send();
+      txHash = injectedTx.txHash;
       messageId = injectedTx.messageId;
     }
 
@@ -621,7 +622,8 @@ export async function outputVaraEthSailsCall(
         payload: encodedPayload,
         value: 0n,
       });
-      txHash = asHex(await injectedTx.send(), 'injected transaction hash');
+      await injectedTx.send();
+      txHash = injectedTx.txHash;
       messageId = injectedTx.messageId;
     }
 
@@ -901,7 +903,7 @@ async function outputDeploymentWithOptionalInit(params: {
   }
 }
 
-function parseSailsMethod(method: string): { serviceName: string; methodName: string } {
+export function parseSailsMethod(method: string): { serviceName: string; methodName: string } {
   const parts = method.split('/');
   if (parts.length !== 2) {
     throw new CliError(
@@ -912,7 +914,7 @@ function parseSailsMethod(method: string): { serviceName: string; methodName: st
   return { serviceName: parts[0], methodName: parts[1] };
 }
 
-function resolveSailsMethod(
+export function resolveSailsMethod(
   sails: LoadedSails,
   serviceName: string,
   methodName: string,
@@ -943,7 +945,7 @@ function resolveSailsMethod(
   );
 }
 
-type SailsMethodLike = {
+export type SailsMethodLike = {
   args: Array<{ name: string; typeDef: unknown }>;
   returnTypeDef: unknown;
   encodePayload: (...args: unknown[]) => Hex;
@@ -959,7 +961,7 @@ function resolveCallArgs(opts: VaraEthSailsCallOptions, arity: number, methodNam
   return validateTopLevelArgs(parsed, arity, { kind: 'Method', name: methodName });
 }
 
-function decodeVaraEthSailsReply(
+export function decodeVaraEthSailsReply(
   sails: LoadedSails,
   method: SailsMethodLike,
   serviceName: string,

--- a/src/commands/vara-eth-session.ts
+++ b/src/commands/vara-eth-session.ts
@@ -46,13 +46,7 @@ function sessionError(id: string | number | null, error: unknown): void {
   });
 }
 
-function parseRequest(line: string): SessionCall {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(line);
-  } catch {
-    throw new CliError('Session request must be valid JSON', 'INVALID_SESSION_REQUEST');
-  }
+function parseRequest(parsed: unknown): SessionCall {
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new CliError('Session request must be an object', 'INVALID_SESSION_REQUEST');
   }
@@ -69,8 +63,10 @@ function parseRequest(line: string): SessionCall {
   return request;
 }
 
-function assertSuccessReply(code: { isSuccess: boolean }): void {
-  if (!code.isSuccess) throw new CliError('Sails query returned a non-success reply', 'PROGRAM_ERROR');
+function assertSuccessReply(code: { isSuccess: boolean }, replyCode: ReturnType<typeof serializeReplyCode>): void {
+  if (!code.isSuccess) {
+    throw new CliError('Sails query returned a non-success reply', 'PROGRAM_ERROR', { replyCode });
+  }
 }
 
 export function registerVaraEthSessionCommand(program: Command): void {
@@ -106,8 +102,12 @@ export async function runVaraEthSession(
     if (!line.trim()) continue;
     let raw: unknown = null;
     try {
-      raw = JSON.parse(line);
-      const request = parseRequest(line);
+      try {
+        raw = JSON.parse(line);
+      } catch {
+        throw new CliError('Session request must be valid JSON', 'INVALID_SESSION_REQUEST');
+      }
+      const request = parseRequest(raw);
       const id = requestId(raw);
       const programAddress = asAddress(request.program, 'program');
       const { serviceName, methodName } = parseSailsMethod(request.method);
@@ -126,7 +126,8 @@ export async function runVaraEthSession(
 
       if (resolved.kind === 'query') {
         const reply = await api.call.program.calculateReplyForHandle(origin, programAddress, payload, 0n);
-        assertSuccessReply(reply.code);
+        const replyCode = serializeReplyCode(reply.code);
+        assertSuccessReply(reply.code, replyCode);
         outputNdjson({
           type: 'result',
           id,
@@ -135,7 +136,7 @@ export async function runVaraEthSession(
           service: serviceName,
           method: methodName,
           result: decodeVaraEthSailsReply(loaded.sails, resolved.method as SailsMethodLike, serviceName, reply.payload),
-          reply: { payload: reply.payload, value: String(reply.value), code: serializeReplyCode(reply.code) },
+          reply: { payload: reply.payload, value: String(reply.value), code: replyCode },
         });
         continue;
       }

--- a/src/commands/vara-eth-session.ts
+++ b/src/commands/vara-eth-session.ts
@@ -1,0 +1,161 @@
+import { createInterface } from 'node:readline';
+
+import { Command } from 'commander';
+import type { Address, Hex } from 'viem';
+
+import {
+  decodeVaraEthSailsReply,
+  parseSailsMethod,
+  resolveSailsMethod,
+  type SailsMethodLike,
+} from './vara-eth-actions';
+import { resolveEthexeSigner, type EthexeAccountOptions } from '../services/vara-eth/account';
+import { getEthexeApi } from '../services/vara-eth/api';
+import { loadVaraEthSails, type LoadedVaraEthSails } from '../services/vara-eth/sails-idl';
+import { serializeReplyCode } from '../shared/output-eth/reply-code';
+import { coerceArgsAuto, CliError, errorMessage, outputNdjson } from '../utils';
+import { asAddress } from '../utils/eth-types';
+
+export interface SessionOptions extends EthexeAccountOptions {}
+
+interface SessionCall {
+  id?: string | number;
+  program: string;
+  method: string;
+  args?: unknown[];
+  idl?: string;
+}
+
+function requestId(request: unknown): string | number | null {
+  return request !== null && typeof request === 'object' && 'id' in request
+    && (typeof (request as { id?: unknown }).id === 'string' || typeof (request as { id?: unknown }).id === 'number')
+    ? (request as { id: string | number }).id
+    : null;
+}
+
+function sessionError(id: string | number | null, error: unknown): void {
+  const cli = error instanceof CliError ? error : null;
+  outputNdjson({
+    type: 'error',
+    id,
+    error: {
+      code: cli?.code ?? 'SESSION_REQUEST_FAILED',
+      message: errorMessage(error),
+      ...(cli?.meta ?? {}),
+    },
+  });
+}
+
+function parseRequest(line: string): SessionCall {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new CliError('Session request must be valid JSON', 'INVALID_SESSION_REQUEST');
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new CliError('Session request must be an object', 'INVALID_SESSION_REQUEST');
+  }
+  const request = parsed as SessionCall;
+  if (typeof request.program !== 'string' || typeof request.method !== 'string') {
+    throw new CliError('Session request requires string fields "program" and "method"', 'INVALID_SESSION_REQUEST');
+  }
+  if (request.args !== undefined && !Array.isArray(request.args)) {
+    throw new CliError('Session request "args" must be a JSON array', 'INVALID_ARGS_FORMAT');
+  }
+  if (request.idl !== undefined && typeof request.idl !== 'string') {
+    throw new CliError('Session request "idl" must be a string path', 'INVALID_SESSION_REQUEST');
+  }
+  return request;
+}
+
+function assertSuccessReply(code: { isSuccess: boolean }): void {
+  if (!code.isSuccess) throw new CliError('Sails query returned a non-success reply', 'PROGRAM_ERROR');
+}
+
+export function registerVaraEthSessionCommand(program: Command): void {
+  program
+    .command('vara-eth:session')
+    .description('Persistent NDJSON Vara.eth Sails session for autonomous agents')
+    .option('--account <name>', 'Vara.eth wallet name')
+    .option('--passphrase <pass>', 'wallet passphrase')
+    .action(async (_options: SessionOptions, command: Command) => {
+      if (process.stdin.isTTY) {
+        throw new CliError('vara-eth:session requires NDJSON requests on stdin', 'STDIN_REQUIRED');
+      }
+
+      const opts = command.optsWithGlobals() as SessionOptions;
+      await runVaraEthSession(opts);
+    });
+}
+
+export async function runVaraEthSession(
+  opts: SessionOptions,
+  input: NodeJS.ReadableStream = process.stdin,
+): Promise<void> {
+  const api = await getEthexeApi();
+  const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
+  api.eth.setSigner(signer);
+  const origin = await signer.getAddress() as Address;
+  const idls = new Map<string, LoadedVaraEthSails>();
+
+  outputNdjson({ type: 'ready', chain: 'vara-eth', origin });
+
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    let raw: unknown = null;
+    try {
+      raw = JSON.parse(line);
+      const request = parseRequest(line);
+      const id = requestId(raw);
+      const programAddress = asAddress(request.program, 'program');
+      const { serviceName, methodName } = parseSailsMethod(request.method);
+      const cacheKey = `${programAddress.toLowerCase()}|${request.idl ?? ''}`;
+      let loaded = idls.get(cacheKey);
+      if (!loaded) {
+        loaded = await loadVaraEthSails(api, programAddress, {
+          idl: request.idl,
+          requiredMethod: { service: serviceName, method: methodName },
+        });
+        idls.set(cacheKey, loaded);
+      }
+      const resolved = resolveSailsMethod(loaded.sails, serviceName, methodName);
+      const args = coerceArgsAuto(request.args ?? [], resolved.method.args || [], loaded.sails, serviceName);
+      const payload = resolved.method.encodePayload(...args) as Hex;
+
+      if (resolved.kind === 'query') {
+        const reply = await api.call.program.calculateReplyForHandle(origin, programAddress, payload, 0n);
+        assertSuccessReply(reply.code);
+        outputNdjson({
+          type: 'result',
+          id,
+          kind: 'query',
+          programAddress,
+          service: serviceName,
+          method: methodName,
+          result: decodeVaraEthSailsReply(loaded.sails, resolved.method as SailsMethodLike, serviceName, reply.payload),
+          reply: { payload: reply.payload, value: String(reply.value), code: serializeReplyCode(reply.code) },
+        });
+        continue;
+      }
+
+      const injected = await api.createInjectedTransaction({ destination: programAddress, payload, value: 0n });
+      injected.setDefaultValidator();
+      await injected.send();
+      outputNdjson({
+        type: 'result',
+        id,
+        kind: 'function',
+        status: 'submitted',
+        programAddress,
+        service: serviceName,
+        method: methodName,
+        txHash: injected.txHash,
+        messageId: injected.messageId,
+      });
+    } catch (error) {
+      sessionError(requestId(raw), error);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add `vara-eth:session`, a persistent NDJSON Sails client that reuses an encrypted named-wallet signer and Vara.eth API connection
- return deterministic injected transaction and message IDs after validator acknowledgement
- cover session query caching, submitted functions, malformed requests, and injected ID handling
- release the capability as v0.20.5

## Why

Autonomous agents need a low-latency Vara.eth write path without exporting private keys or reconnecting for every action. The session keeps the existing encrypted wallet model while allowing callers to retain a single authenticated connection.

## Validation

- `npm test -- --runInBand src/__tests__/vara-eth-session.test.ts src/__tests__/vara-eth-actions.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `./dist/app.js --chain vara-eth vara-eth:session --help`
