### PR TITLE
docs: prepare v0.20.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.20.5] - 2026-07-13
+
+### Added
+
+- Add `vara-eth:session`, a persistent NDJSON Sails session for autonomous agents. It reuses the Vara.eth connection, encrypted named-wallet signer, and loaded IDLs across requests while returning decoded query results or accepted injected function submissions.
+
+### Fixed
+
+- Wait for injected Vara.eth transactions to be accepted before reporting their `txHash` and `messageId`, so validator acknowledgements are not mistaken for transaction identifiers.
+
 ## [0.20.4] - 2026-07-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ vara-wallet --chain vara-eth --network hoodi vara-eth:subscribe router
 
 Message sends and state-changing Sails calls default to `--wait reply`; use `--wait submitted` when only RPC acceptance and a transaction hash are needed. WVARA transfers and message replies default to `--wait receipt` and also accept `--wait submitted`. Injected sends remain available with `--via injected`; submit-only injected output includes the locally derived `messageId`, but does not validate a validator signature or wait for program execution. Use `--no-validate-signature` only for diagnostics when waiting for injected replies. See `docs/vara-eth-networks.md` for endpoints and `docs/sails-real-program-e2e.md` for the full Sails deploy/discover/call smoke.
 
+#### Persistent agent session
+
+For a sequence of Vara.eth Sails requests, use `vara-eth:session` instead of starting a new CLI process for each action. It keeps the API connection, selected encrypted wallet signer, and each loaded IDL in memory. The command reads one JSON request per stdin line and writes NDJSON responses, so an invalid request is reported without ending the session.
+
+```bash
+vara-wallet --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:session <<'EOF'
+{"id":"state-1","program":"0xMIRROR","method":"Game/State","args":[],"idl":"./game.idl"}
+{"id":"move-1","program":"0xMIRROR","method":"Game/Move","args":["north"],"idl":"./game.idl"}
+EOF
+```
+
+The first line is `{ "type": "ready", ... }`. Query results include the decoded reply; function results return `{ "status": "submitted", "txHash", "messageId" }` after the injected transaction is accepted. Functions do not wait for program execution or a reply. Requests require `program` and `method`; `args` must be a JSON array and `idl` is optional.
+
 ### `node`
 
 ```bash

--- a/docs/vara-eth-networks.md
+++ b/docs/vara-eth-networks.md
@@ -54,6 +54,20 @@ The compatibility defaults remain completion-oriented: message sends and Sails f
 
 A direct Sails submit can skip validator bootstrap only when `--idl <path>` is supplied. Without a local IDL, the wallet must query Vara.eth for the program code ID and embedded/cached interface before encoding the call.
 
+## Persistent agent actions
+
+For agents that perform several Sails calls in one run, `vara-eth:session` removes repeated process startup, connection, signer, and IDL-loading work. It accepts one JSON request per stdin line and emits one NDJSON response per request. The session keeps running after a malformed request, making it suitable for an autonomous action loop.
+
+```bash
+vara-wallet --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:session <<'EOF'
+{"id":"read","program":"0xMIRROR","method":"Game/State","args":[],"idl":"./game.idl"}
+{"id":"act","program":"0xMIRROR","method":"Game/Move","args":["north"],"idl":"./game.idl"}
+EOF
+```
+
+The session writes a `ready` record first. Queries return a decoded result. Functions use the injected path and return `status: "submitted"` with a deterministic `txHash` and `messageId` once accepted; they do not wait for execution or a program reply. Send the same `program` and `idl` values on subsequent requests to reuse the loaded interface.
+
 Bridge / faucet links and full deployment status: see the official
 gear-tech announcement channels.
 


### PR DESCRIPTION
## Summary
- add v0.20.5 release notes for the persistent Vara.eth Sails session
- document the NDJSON session protocol, response semantics, and cache reuse

## Verification
- npm test -- --runInBand
- npm run test:pack-smoke