### PR TITLE
v0.20.6 Recover pending Vara.eth mailbox claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,6 +502,14 @@ vara-wallet --chain vara-eth --network hoodi --account agent-eth \
 vara-wallet --chain vara-eth --network hoodi --account agent-eth \
   vara-eth:message send 0xMIRROR --payload 0xfeed --via eth --wait submitted
 
+# Submit a mailbox claim, then recover it by the saved L1 transaction hash.
+vara-wallet --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --wait submitted
+vara-wallet --chain vara-eth --network hoodi \
+  vara-eth:mailbox claim --resume 0xTX_HASH
+vara-wallet --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:mailbox claim --replace 0xTX_HASH
+
 # Root Sails flow on Vara.eth
 vara-wallet --chain vara-eth --network hoodi --account agent-eth \
   program upload ./program.opt.wasm --idl ./program.idl --args '[]'
@@ -511,9 +519,11 @@ vara-wallet --chain vara-eth --network hoodi call 0xMIRROR Service/Query --args 
 
 Vara.eth wallet files are `~/.vara-wallet/wallets/<name>.vara-eth.json`. They appear in unqualified `wallet list` with `chain: "vara-eth"`, but native commands must not treat those files as Substrate wallets. Passphrases resolve from `--passphrase`, named passphrase files, or `VARA_PASSPHRASE` depending on the command path. Typed Vara.eth errors use stable JSON codes such as `MESSAGE_REVERTED`, `PROMISE_TIMEOUT`, `CHAIN_ID_MISMATCH`, and `TRANSPORT_ERROR` with top-level metadata.
 
-Vara.eth opens the validator connection and Ethereum bootstrap concurrently when both are required. Direct Ethereum submit-only messages and WVARA writes use an Ethereum-only context and skip the validator connection. Built-in presets use an Ethereum HTTP endpoint for one-shot requests, while `vara-eth:subscribe` keeps Ethereum WebSocket transport for event streams. Custom deployments can set `ETHEREUM_HTTP_RPC`; without it, request-mode calls fall back to `ETHEREUM_RPC`.
+Vara.eth opens the validator connection and Ethereum bootstrap concurrently when both are required. Direct Ethereum submit-only messages, WVARA writes, and mailbox claims in every mode (submit, receipt wait, resume, and replacement) use an Ethereum-only context and skip the validator connection. Built-in presets use an Ethereum HTTP endpoint for one-shot requests, while `vara-eth:subscribe` keeps Ethereum WebSocket transport for event streams. Custom deployments can set `ETHEREUM_HTTP_RPC`; without it, request-mode calls fall back to `ETHEREUM_RPC`.
 
 Message sends and state-changing Sails calls default to `--wait reply`; WVARA transfers and message replies default to `--wait receipt`. Use `--wait submitted` when an agent only needs RPC acceptance. Direct Ethereum submission returns `messageId: null` because that ID comes from the mined Mirror event. Injected submission returns its locally derived message ID but does not wait for or validate a validator reply. Do not assume `--resume` can follow a submit-only injected transaction: pending-promise reattachment is not yet supported upstream.
+
+Mailbox claims default to a bounded 45-second L1 receipt wait. A timeout is successful command output with `status: "pending"` and `code: "CLAIM_PENDING"`, including the hash and nonce to pass to `--resume`. Claim transactions are recorded best-effort (without secrets) in `~/.vara-wallet/vara-eth-transactions.db`; persistence failure never turns an already accepted broadcast into a command failure, but prevents recovery after the process exits. `--replace` is only for a saved pending claim and is bound to its original sender, chain ID, Mirror, calldata, and nonce. Fresh EIP-1559 claims use a 20% max-fee headroom; replacements use a fresh quote and at least a 12.5% bump. Legacy saved gas-price claims keep legacy fee mode. Both `--max-fee-per-gas` and `--max-priority-fee-per-gas` may be supplied in wei to skip fee quoting; a partial override still needs a quote. A mined `ValueClaimingRequested` confirms that Mirror accepted the request, not that the co-processor has emitted the final `ValueClaimed` event.
 
 Direct config setters are preset-aware: `config set varaNetwork <mainnet|testnet|local>` also updates `wsEndpoint`, and `config set varaEthNetwork <mainnet|hoodi|local>` also updates the Vara.eth RPC, Ethereum RPC, and Router fields. For Vara.eth Sails read calls, zero-address origin fallback is only for no selected account; a missing or corrupt selected wallet must fail instead of silently querying as zero address.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [0.20.6] - 2026-07-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Add recoverable direct L1 Vara.eth mailbox claims. Claims use a bounded
+  receipt wait, persist secret-free transaction metadata locally, and support
+  resume, one automatic replacement, or a manually controlled same-nonce
+  replacement with fee-bump and sender/chain safeguards.
+
+### Fixed
+
+- Keep Vara.eth mailbox claim submission, receipt polling, and recovery on the
+  Ethereum-only path so they do not start an unnecessary validator connection.
+
 ## [0.20.5] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -201,10 +201,15 @@ Direct Vara.eth commands are available for rail-specific operations:
 ```bash
 vara-wallet vara-eth:wallet create alice --passphrase "$PASSPHRASE"
 vara-wallet --chain vara-eth --network hoodi vara-eth:program top-up 0xMIRROR --amount 1
+# A submitted mailbox claim can be resumed or safely replaced by its saved hash.
+vara-wallet --chain vara-eth --network hoodi --account alice \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --wait submitted
+vara-wallet --chain vara-eth --network hoodi \
+  vara-eth:mailbox claim --resume 0xTX_HASH
 vara-wallet --chain vara-eth --network hoodi vara-eth:subscribe router
 ```
 
-Message sends and state-changing Sails calls default to `--wait reply`; use `--wait submitted` when only RPC acceptance and a transaction hash are needed. WVARA transfers and message replies default to `--wait receipt` and also accept `--wait submitted`. Injected sends remain available with `--via injected`; submit-only injected output includes the locally derived `messageId`, but does not validate a validator signature or wait for program execution. Use `--no-validate-signature` only for diagnostics when waiting for injected replies. See `docs/vara-eth-networks.md` for endpoints and `docs/sails-real-program-e2e.md` for the full Sails deploy/discover/call smoke.
+Message sends and state-changing Sails calls default to `--wait reply`; use `--wait submitted` when only RPC acceptance and a transaction hash are needed. WVARA transfers and message replies default to `--wait receipt` and also accept `--wait submitted`. Mailbox claims default to a bounded receipt wait; they return `CLAIM_PENDING` with their hash and nonce when no receipt arrives, then support `--resume` and same-nonce `--replace` with a fresh EIP-1559 fee quote. Injected sends remain available with `--via injected`; submit-only injected output includes the locally derived `messageId`, but does not validate a validator signature or wait for program execution. Use `--no-validate-signature` only for diagnostics when waiting for injected replies. See `docs/vara-eth-networks.md` for endpoints and `docs/sails-real-program-e2e.md` for the full Sails deploy/discover/call smoke.
 
 #### Persistent agent session
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm link
 | `ETHEREUM_HTTP_RPC` | Ethereum HTTP endpoint for one-shot Vara.eth requests | network preset |
 | `VARA_ETH_ROUTER` | Vara.eth Router address | network preset |
 
-Vara.eth starts its validator connection and Ethereum bootstrap concurrently when a command needs both RPCs. Direct low-level message submissions, WVARA writes, and direct Sails function submissions with both `--via eth --wait submitted` and an explicit `--idl` use an Ethereum-only request context and do not open the validator connection. Built-in network presets use HTTP for one-shot Ethereum requests; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
+Vara.eth starts its validator connection and Ethereum bootstrap concurrently when a command needs both RPCs. Direct low-level message submissions, WVARA writes, mailbox claims (submission, receipt wait, and resume), and direct Sails function submissions with both `--via eth --wait submitted` and an explicit `--idl` use an Ethereum-only request context and do not open the validator connection. Built-in network presets use HTTP for one-shot Ethereum requests; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
 
 ## Account Resolution
 
@@ -206,10 +206,12 @@ vara-wallet --chain vara-eth --network hoodi --account alice \
   vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --wait submitted
 vara-wallet --chain vara-eth --network hoodi \
   vara-eth:mailbox claim --resume 0xTX_HASH
+vara-wallet --chain vara-eth --network hoodi --account alice \
+  vara-eth:mailbox claim --replace 0xTX_HASH
 vara-wallet --chain vara-eth --network hoodi vara-eth:subscribe router
 ```
 
-Message sends and state-changing Sails calls default to `--wait reply`; use `--wait submitted` when only RPC acceptance and a transaction hash are needed. WVARA transfers and message replies default to `--wait receipt` and also accept `--wait submitted`. Mailbox claims default to a bounded receipt wait; they return `CLAIM_PENDING` with their hash and nonce when no receipt arrives, then support `--resume` and same-nonce `--replace` with a fresh EIP-1559 fee quote. Injected sends remain available with `--via injected`; submit-only injected output includes the locally derived `messageId`, but does not validate a validator signature or wait for program execution. Use `--no-validate-signature` only for diagnostics when waiting for injected replies. See `docs/vara-eth-networks.md` for endpoints and `docs/sails-real-program-e2e.md` for the full Sails deploy/discover/call smoke.
+Message sends and state-changing Sails calls default to `--wait reply`; use `--wait submitted` when only RPC acceptance and a transaction hash are needed. WVARA transfers and message replies default to `--wait receipt` and also accept `--wait submitted`. Mailbox claims default to a bounded 45-second receipt wait; `CLAIM_PENDING` includes the hash and nonce when no receipt arrives, and `--resume` checks the saved local transaction without signing or broadcasting. `--replace` reuses the original calldata and nonce, and requires the same Ethereum account and chain. A claim `confirmed` at this layer means the Mirror accepted `ValueClaimingRequested`; the later `ValueClaimed` event is co-processor completion. Injected sends remain available with `--via injected`; submit-only injected output includes the locally derived `messageId`, but does not validate a validator signature or wait for program execution. Use `--no-validate-signature` only for diagnostics when waiting for injected replies. See `docs/vara-eth-networks.md` for endpoints and `docs/sails-real-program-e2e.md` for the full Sails deploy/discover/call smoke.
 
 #### Persistent agent session
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm link
 | `ETHEREUM_HTTP_RPC` | Ethereum HTTP endpoint for one-shot Vara.eth requests | network preset |
 | `VARA_ETH_ROUTER` | Vara.eth Router address | network preset |
 
-Vara.eth starts its validator connection and Ethereum bootstrap concurrently when a command needs both RPCs. Direct low-level message submissions, WVARA writes, mailbox claims (submission, receipt wait, and resume), and direct Sails function submissions with both `--via eth --wait submitted` and an explicit `--idl` use an Ethereum-only request context and do not open the validator connection. Built-in network presets use HTTP for one-shot Ethereum requests; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
+Vara.eth starts its validator connection and Ethereum bootstrap concurrently when a command needs both RPCs. Direct low-level message submissions, WVARA writes, mailbox claims (submission, receipt wait, resume, and replacement), and direct Sails function submissions with both `--via eth --wait submitted` and an explicit `--idl` use an Ethereum-only request context and do not open the validator connection. Built-in network presets use HTTP for one-shot Ethereum requests; `vara-eth:subscribe` commands retain WebSocket transport. A custom setup without `ETHEREUM_HTTP_RPC` remains compatible and falls back to `ETHEREUM_RPC`.
 
 ## Account Resolution
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -265,6 +265,48 @@ Connection timeout is 10s. Bad endpoints fail fast with `TRANSPORT_ERROR` instea
 | Testnet | `wss://testnet.vara.network` | `--network testnet` |
 | Local | `ws://localhost:9944` | `--network local` |
 
+## Vara.eth mailbox claims
+
+Use `--chain vara-eth` for the Ethereum-anchored rail. Its network presets are
+`mainnet`, `hoodi`, and `local`; a claim requires an Ethereum V3 wallet selected
+with `--account` and funded ETH for L1 gas.
+
+```bash
+# Submit immediately after Ethereum RPC acceptance.
+$VW --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --wait submitted
+
+# The default receipt wait is bounded to 45 seconds. A timeout returns normal
+# JSON with code CLAIM_PENDING, the transaction hash, and the nonce.
+$VW --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID
+
+# Recheck a saved transaction without signing or broadcasting.
+$VW --chain vara-eth --network hoodi \
+  vara-eth:mailbox claim --resume 0xTX_HASH
+
+# Replace a saved pending claim using the same calldata and nonce. Use the same
+# Ethereum account and network as the original transaction.
+$VW --chain vara-eth --network hoodi --account agent-eth \
+  vara-eth:mailbox claim --replace 0xTX_HASH
+```
+
+Claims use only the Ethereum RPC for submission, receipt polling, resume, and
+replacement, so they do not open a Vara.eth validator connection. The wallet
+stores recoverable, secret-free metadata in
+`~/.vara-wallet/vara-eth-transactions.db`. It is best-effort: a local database
+failure never invalidates an accepted broadcast, but the transaction cannot be
+recovered after the process exits.
+
+`--replace` is restricted to a saved pending claim and preserves the original
+Mirror, `claimedId`, calldata, nonce, sender, and chain ID. Fresh EIP-1559
+claims have 20% max-fee headroom; replacements use a fresh quote and at least a
+12.5% bump. A saved legacy gas-price transaction remains in legacy fee mode.
+Supplying both `--max-fee-per-gas` and `--max-priority-fee-per-gas` (wei) skips
+fee quoting; a partial override still needs a quote. A `confirmed` claim means
+the Mirror accepted `ValueClaimingRequested`; wait for `ValueClaimed` to know
+the co-processor has completed the claim.
+
 ## Transport Errors
 
 Replaces the legacy `CONNECTION_TIMEOUT` (WS) and `TIMEOUT` / `CONNECTION_FAILED` (program/dex/vft/message RPC paths) codes — scripts grepping the old codes won't fire. Faucet HTTP `CONNECTION_FAILED` is unchanged. `--light` failures route through the same taxonomy.

--- a/docs/vara-eth-followups.md
+++ b/docs/vara-eth-followups.md
@@ -4,6 +4,13 @@ Deferred items from the `0.20.0` Vara.eth rail. Items listed here are not
 blockers for the current branch; they are operational parity or upstream
 cleanup work.
 
+## Shipped after 0.20.0
+
+- Mailbox-claim recovery uses an Ethereum-only path for submission, receipt
+  polling, resume, and same-nonce replacement. Pending direct claims are stored
+  locally without secrets, bound to their sender and chain ID, and can be resumed
+  or safely fee-bumped after a process restart.
+
 ## Shipped in 0.20.0
 
 - `vara-eth:*` subcommands honor global `--account` and `--passphrase`.

--- a/docs/vara-eth-integration-report.md
+++ b/docs/vara-eth-integration-report.md
@@ -50,6 +50,14 @@ Rail-specific workflows remain available under `vara-eth:*`:
   functions, WVARA transfers, and message replies. Direct Ethereum submissions
   skip the validator connection for low-level messages and for Sails calls with
   an explicit local IDL; completion-oriented defaults are unchanged.
+- Mailbox claims are direct L1 transactions with a bounded receipt wait and
+  local, secret-free transaction journal at
+  `~/.vara-wallet/vara-eth-transactions.db`. Pending claims can be checked with
+  `--resume` or safely replaced with the original calldata and nonce; replacement
+  requires the original Ethereum sender and chain. Claims use Ethereum-only
+  transport for submission, receipt checks, and recovery, so they do not start a
+  validator connection. A confirmed claim receipt only establishes
+  `ValueClaimingRequested`; final `ValueClaimed` completion is asynchronous.
 - `--no-validate-signature` exists only for injected-path diagnostics.
 - `reply.code` output is structured as `{ tag, raw, reason }`.
 - Vara.eth typed errors flow through stable JSON codes such as

--- a/docs/vara-eth-networks.md
+++ b/docs/vara-eth-networks.md
@@ -54,6 +54,43 @@ The compatibility defaults remain completion-oriented: message sends and Sails f
 
 A direct Sails submit can skip validator bootstrap only when `--idl <path>` is supplied. Without a local IDL, the wallet must query Vara.eth for the program code ID and embedded/cached interface before encoding the call.
 
+## Claiming mailbox values safely
+
+`vara-eth:mailbox claim` is a direct Ethereum transaction. The wallet now records
+the submitted transaction, its nonce, calldata, and EIP-1559 fees locally so a
+pending claim can be inspected or replaced without recreating the call by hand.
+
+```bash
+# Submit and receive the hash, nonce, gas limit, and selected EIP-1559 fees immediately.
+vara-wallet --chain vara-eth --network mainnet --account alice \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --wait submitted
+
+# Wait for the receipt for at most 45 seconds (or choose a different bound).
+vara-wallet --chain vara-eth --network mainnet --account alice \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --timeout-ms 30000
+
+# Recheck a locally submitted claim without signing or broadcasting anything.
+vara-wallet --chain vara-eth --network mainnet \
+  vara-eth:mailbox claim --resume 0xTX_HASH
+
+# Replace a still-pending claim with the same calldata and nonce, using a fresh
+# EIP-1559 quote and at least a 12.5% fee bump over the saved transaction.
+vara-wallet --chain vara-eth --network mainnet --account alice \
+  vara-eth:mailbox claim --replace 0xTX_HASH
+```
+
+`status: "pending"` with `code: "CLAIM_PENDING"` means the transaction has
+not produced a receipt within the requested wait window; it is not proof that
+the claim failed. `CLAIM_REPLACED_OR_MINED` means the account nonce advanced
+without a receipt for that hash, so it was replaced externally or mined through
+an unavailable RPC path. Use `--resume` first. Use `--replace` only for a saved
+pending claim: it preserves the original Mirror, `claimedId`, nonce, and calldata.
+A mined receipt with `ValueClaimingRequested` confirms that Mirror accepted the
+claim request; `ValueClaimed` is the later co-processor completion event. Advanced
+callers may set `--nonce`, `--gas`, `--max-fee-per-gas`, and
+`--max-priority-fee-per-gas` explicitly; replacement fee overrides must exceed
+the saved values.
+
 ## Persistent agent actions
 
 For agents that perform several Sails calls in one run, `vara-eth:session` removes repeated process startup, connection, signer, and IDL-loading work. It accepts one JSON request per stdin line and emits one NDJSON response per request. The session keeps running after a malformed request, making it suitable for an autonomous action loop.

--- a/docs/vara-eth-networks.md
+++ b/docs/vara-eth-networks.md
@@ -11,7 +11,7 @@ How to point vara-wallet at each Vara.eth deployment. Select via
 | `hoodi`   | `wss://hoodi-reth-rpc.gear-tech.io/ws` | `https://hoodi-reth-rpc.gear-tech.io` | `wss://vara-eth-validator-1.gear-tech.io` | [`0xE549b0AfEd…A0b060`](https://hoodi.etherscan.io/address/0xE549b0AfEdA978271FF7E712232B9F7f39A0b060) | [`0xE1ab85A8B4…d7E5aD`](https://hoodi.etherscan.io/address/0xE1ab85A8B4d5d5B6af0bbD0203EB322DF33d0464) | 12 s |
 | `local`   | `ws://127.0.0.1:8545` (Anvil) | `http://127.0.0.1:8545` | `ws://127.0.0.1:9944` | discovered at runtime | bound to Router | 1 s |
 
-Vara.eth commands use the HTTP endpoint for Ethereum-side request/response JSON-RPC. Commands that need validator state or injected transactions open the validator connection in parallel with Ethereum bootstrap. Direct Ethereum submit-only messages (`--via eth --wait submitted`), WVARA writes, and direct submit-only Sails calls with an explicit `--idl` do not open the validator connection. Event subscriptions use Ethereum WebSocket because they require a persistent stream. For custom endpoints, set `ETHEREUM_HTTP_RPC`; if it is absent, requests fall back to `ETHEREUM_RPC`.
+Vara.eth commands use the HTTP endpoint for Ethereum-side request/response JSON-RPC. Commands that need validator state or injected transactions open the validator connection in parallel with Ethereum bootstrap. Direct Ethereum submit-only messages (`--via eth --wait submitted`), WVARA writes, mailbox claims in every mode, and direct submit-only Sails calls with an explicit `--idl` do not open the validator connection. Event subscriptions use Ethereum WebSocket because they require a persistent stream. For custom endpoints, set `ETHEREUM_HTTP_RPC`; if it is absent, requests fall back to `ETHEREUM_RPC`.
 
 Mainnet and Hoodi each expose an additional beacon RPC for EIP-7594 blob
 lookups (used by `vara-eth:program deploy` to upload WASM bytecode):
@@ -56,9 +56,14 @@ A direct Sails submit can skip validator bootstrap only when `--idl <path>` is s
 
 ## Claiming mailbox values safely
 
-`vara-eth:mailbox claim` is a direct Ethereum transaction. The wallet now records
-the submitted transaction, its nonce, calldata, and EIP-1559 fees locally so a
-pending claim can be inspected or replaced without recreating the call by hand.
+`vara-eth:mailbox claim` is a direct Ethereum transaction. Submission, receipt
+waiting, resume, and replacement use only the Ethereum request context; they do
+not start a Vara.eth validator connection. The wallet records the submitted
+transaction, its chain ID, nonce, calldata, and fee data in
+`~/.vara-wallet/vara-eth-transactions.db` so a pending claim can be inspected or
+replaced without recreating the call by hand. The journal contains no secret
+material and is best-effort: an unavailable local database never delays or
+invalidates an accepted broadcast, but recovery is unavailable after process exit.
 
 ```bash
 # Submit and receive the hash, nonce, gas limit, and selected EIP-1559 fees immediately.
@@ -69,6 +74,12 @@ vara-wallet --chain vara-eth --network mainnet --account alice \
 vara-wallet --chain vara-eth --network mainnet --account alice \
   vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --timeout-ms 30000
 
+# Optionally make exactly one same-nonce replacement after the first wait
+# interval, then wait the full timeout again for the replacement receipt.
+vara-wallet --chain vara-eth --network mainnet --account alice \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID \
+  --replace-after-ms 30000 --timeout-ms 45000
+
 # Recheck a locally submitted claim without signing or broadcasting anything.
 vara-wallet --chain vara-eth --network mainnet \
   vara-eth:mailbox claim --resume 0xTX_HASH
@@ -77,6 +88,11 @@ vara-wallet --chain vara-eth --network mainnet \
 # EIP-1559 quote and at least a 12.5% fee bump over the saved transaction.
 vara-wallet --chain vara-eth --network mainnet --account alice \
   vara-eth:mailbox claim --replace 0xTX_HASH
+
+# Supply both EIP-1559 fee values in wei to avoid a fee-quote request.
+vara-wallet --chain vara-eth --network mainnet --account alice \
+  vara-eth:mailbox claim 0xMIRROR 0xCLAIMED_ID --wait submitted \
+  --max-fee-per-gas 3000000000 --max-priority-fee-per-gas 1000000000
 ```
 
 `status: "pending"` with `code: "CLAIM_PENDING"` means the transaction has
@@ -87,7 +103,12 @@ an unavailable RPC path. Use `--resume` first. Use `--replace` only for a saved
 pending claim: it preserves the original Mirror, `claimedId`, nonce, and calldata.
 It also requires the original Ethereum sender and chain ID, so switching account or
 network cannot turn a replacement into a separate claim. Older records without a
-stored chain ID can be resumed but must not be replaced.
+stored chain ID can be resumed but must not be replaced. Fresh EIP-1559 claims use
+20% max-fee headroom. Replacements choose the greater of a fresh quote, a 12.5%
+bump, and valid overrides. Legacy saved gas-price rows remain legacy transactions
+and receive a legacy gas-price bump; EIP-1559 overrides are rejected for them.
+When both EIP-1559 fee flags are explicitly supplied, the wallet does not make a
+fee-quote RPC; supplying only one still requires a quote for the missing value.
 A mined receipt with `ValueClaimingRequested` confirms that Mirror accepted the
 claim request; `ValueClaimed` is the later co-processor completion event. Advanced
 callers may set `--nonce`, `--gas`, `--max-fee-per-gas`, and

--- a/docs/vara-eth-networks.md
+++ b/docs/vara-eth-networks.md
@@ -85,6 +85,9 @@ the claim failed. `CLAIM_REPLACED_OR_MINED` means the account nonce advanced
 without a receipt for that hash, so it was replaced externally or mined through
 an unavailable RPC path. Use `--resume` first. Use `--replace` only for a saved
 pending claim: it preserves the original Mirror, `claimedId`, nonce, and calldata.
+It also requires the original Ethereum sender and chain ID, so switching account or
+network cannot turn a replacement into a separate claim. Older records without a
+stored chain ID can be resumed but must not be replaced.
 A mined receipt with `ValueClaimingRequested` confirms that Mirror accepted the
 claim request; `ValueClaimed` is the later co-processor completion event. Advanced
 callers may set `--nonce`, `--gas`, `--max-fee-per-gas`, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.5",
+"version": "0.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vara-wallet",
-      "version": "0.20.5",
+"version": "0.20.6",
       "bundleDependencies": [
         "@vara-eth/api",
         "viem",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vara-wallet",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "Agentic wallet CLI for Vara Network — designed for AI coding agents",
   "main": "dist/app.js",
   "bin": {

--- a/src/__tests__/vara-eth-direct-transactions.test.ts
+++ b/src/__tests__/vara-eth-direct-transactions.test.ts
@@ -1,0 +1,102 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  closeDirectTransactionStoreForTests,
+  getDirectTransaction,
+  insertDirectTransaction,
+  markDirectTransactionFailed,
+  markDirectTransactionReceipt,
+  markDirectTransactionReplaced,
+} from '../services/vara-eth/direct-transactions';
+
+const TX_HASH = `0x${'11'.repeat(32)}`;
+
+describe('Vara.eth direct transaction persistence', () => {
+  let walletDir: string;
+  let previousWalletDir: string | undefined;
+
+  beforeEach(() => {
+    previousWalletDir = process.env.VARA_WALLET_DIR;
+    walletDir = mkdtempSync(join(tmpdir(), 'vara-wallet-direct-transactions-'));
+    process.env.VARA_WALLET_DIR = walletDir;
+    closeDirectTransactionStoreForTests();
+  });
+
+  afterEach(() => {
+    closeDirectTransactionStoreForTests();
+    if (previousWalletDir === undefined) delete process.env.VARA_WALLET_DIR;
+    else process.env.VARA_WALLET_DIR = previousWalletDir;
+    rmSync(walletDir, { recursive: true, force: true });
+  });
+
+  it('persists scope, fees, and terminal transitions', () => {
+    insertDirectTransaction({
+      txHash: TX_HASH,
+      chainId: 5,
+      operation: 'mailbox_claim',
+      mirror: '0x1234560000000000000000000000000000000001',
+      claimedId: `0x${'22'.repeat(32)}`,
+      sender: '0x1234560000000000000000000000000000000002',
+      nonce: 7n,
+      calldata: '0xdeadbeef',
+      gas: 50_000n,
+      maxFeePerGas: 120n,
+      maxPriorityFeePerGas: 3n,
+    });
+
+    expect(getDirectTransaction(TX_HASH)).toEqual(expect.objectContaining({
+      chain_id: '5', nonce: '7', status: 'pending', max_fee_per_gas: '120',
+    }));
+
+    markDirectTransactionReceipt(TX_HASH, 'confirmed', 123n);
+    expect(getDirectTransaction(TX_HASH)).toEqual(expect.objectContaining({ status: 'confirmed', receipt_block: '123' }));
+
+    markDirectTransactionReplaced(TX_HASH, `0x${'33'.repeat(32)}`);
+    expect(getDirectTransaction(TX_HASH)).toEqual(expect.objectContaining({ status: 'confirmed', replaced_by: null }));
+
+    markDirectTransactionFailed(TX_HASH, 'ignored terminal update');
+    expect(getDirectTransaction(TX_HASH)).toEqual(expect.objectContaining({ status: 'confirmed', last_error: null }));
+  });
+
+  it('does not throw when a locked store prevents a best-effort write', () => {
+    const dbPath = join(walletDir, 'vara-eth-transactions.db');
+    insertDirectTransaction({
+      txHash: TX_HASH, chainId: 5, operation: 'mailbox_claim', mirror: '0x1234560000000000000000000000000000000001',
+      sender: '0x1234560000000000000000000000000000000002', nonce: 7n, calldata: '0xdeadbeef',
+    });
+    closeDirectTransactionStoreForTests();
+    const lock = new Database(dbPath);
+    lock.exec('BEGIN EXCLUSIVE');
+
+    expect(() => insertDirectTransaction({
+      txHash: `0x${'44'.repeat(32)}`, chainId: 5, operation: 'mailbox_claim', mirror: '0x1234560000000000000000000000000000000001',
+      sender: '0x1234560000000000000000000000000000000002', nonce: 8n, calldata: '0xdeadbeef',
+    })).not.toThrow();
+
+    lock.exec('ROLLBACK');
+    lock.close();
+  });
+
+  it('migrates legacy rows without a chain ID but leaves them unsafe to replace', () => {
+    const dbPath = join(walletDir, 'vara-eth-transactions.db');
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE direct_transactions (
+        tx_hash TEXT PRIMARY KEY, operation TEXT NOT NULL, mirror TEXT NOT NULL, claimed_id TEXT,
+        sender TEXT NOT NULL, nonce TEXT NOT NULL, calldata TEXT NOT NULL, gas TEXT,
+        max_fee_per_gas TEXT, max_priority_fee_per_gas TEXT, gas_price TEXT,
+        submitted_at_ts INTEGER NOT NULL, status TEXT NOT NULL, replacement_of TEXT,
+        replaced_by TEXT, receipt_block TEXT, last_error TEXT
+      );
+      INSERT INTO direct_transactions (tx_hash, operation, mirror, sender, nonce, calldata, submitted_at_ts, status)
+      VALUES ('${TX_HASH}', 'mailbox_claim', '0x1234560000000000000000000000000000000001',
+        '0x1234560000000000000000000000000000000002', '7', '0xdeadbeef', 0, 'pending');
+    `);
+    legacy.close();
+
+    expect(getDirectTransaction(TX_HASH)).toEqual(expect.objectContaining({ chain_id: null, status: 'pending' }));
+  });
+});

--- a/src/__tests__/vara-eth-submit-receipt.test.ts
+++ b/src/__tests__/vara-eth-submit-receipt.test.ts
@@ -10,12 +10,12 @@ const mockGetReceipt = jest.fn();
 const mockClaimSend = jest.fn();
 const mockClaimEstimateGas = jest.fn();
 const mockGetTransactionCount = jest.fn();
+const mockGetChainId = jest.fn();
 const mockEstimateFeesPerGas = jest.fn();
 const mockWaitForTransactionReceipt = jest.fn();
 const mockGetTransactionReceipt = jest.fn();
 const mockSendReply = jest.fn();
 const mockClaimValue = jest.fn();
-const mockGetValueClaimingRequestedEvent = jest.fn();
 const mockGetDirectTransaction = jest.fn();
 const mockInsertDirectTransaction = jest.fn();
 const mockMarkDirectTransactionReceipt = jest.fn();
@@ -28,6 +28,7 @@ const mockApi = {
   eth: {
     publicClient: {
       getTransactionCount: mockGetTransactionCount,
+      getChainId: mockGetChainId,
       estimateFeesPerGas: mockEstimateFeesPerGas,
       waitForTransactionReceipt: mockWaitForTransactionReceipt,
       getTransactionReceipt: mockGetTransactionReceipt,
@@ -95,6 +96,7 @@ beforeEach(() => {
   });
   resolveEthexeSigner.mockResolvedValue(mockSigner);
   mockSigner.getAddress.mockResolvedValue('0x1234560000000000000000000000000000000002');
+  mockGetChainId.mockResolvedValue(5);
   mockGetTransactionCount.mockResolvedValue(7);
   mockEstimateFeesPerGas.mockResolvedValue({ maxFeePerGas: 100n, maxPriorityFeePerGas: 2n });
   mockClaimEstimateGas.mockImplementation(async () => {
@@ -125,15 +127,10 @@ beforeEach(() => {
     sendAndWaitForReceipt: mockSendAndWaitForReceipt,
     getReceipt: mockGetReceipt,
   });
-  mockGetValueClaimingRequestedEvent.mockResolvedValue({
-    source: MIRROR,
-    claimedId: CLAIMED_ID,
-  });
   mockClaimValue.mockResolvedValue({
     send: mockClaimSend,
     estimateGas: mockClaimEstimateGas,
     getTx: () => claimRequest,
-    getValueClaimingRequestedEvent: mockGetValueClaimingRequestedEvent,
   });
 });
 
@@ -154,7 +151,7 @@ describe('Vara.eth write commands submit before reading receipts', () => {
     }));
   });
 
-  it('submits vara-eth:mailbox claim before reading claim events', async () => {
+  it('submits a direct L1 claim without opening the validator API', async () => {
     await makeProgram().parseAsync(
       ['vara-eth:mailbox', 'claim', MIRROR, CLAIMED_ID],
       { from: 'user' },
@@ -166,12 +163,13 @@ describe('Vara.eth write commands submit before reading receipts', () => {
       hash: '0x' + '44'.repeat(32),
       timeout: 45_000,
     }));
-    expect(mockGetValueClaimingRequestedEvent).toHaveBeenCalledTimes(1);
+    expect(getEthexeApi).not.toHaveBeenCalled();
     expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
       mirror: MIRROR,
       claimedId: CLAIMED_ID,
       status: 'confirmed',
       nonce: '7',
+      event: null,
     }));
   });
 
@@ -184,6 +182,7 @@ describe('Vara.eth write commands submit before reading receipts', () => {
     expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled();
     expect(mockInsertDirectTransaction).toHaveBeenCalledWith(expect.objectContaining({
       operation: 'mailbox_claim',
+      chainId: 5,
       nonce: 7n,
       maxFeePerGas: 120n,
       maxPriorityFeePerGas: 2n,
@@ -199,6 +198,7 @@ describe('Vara.eth write commands submit before reading receipts', () => {
     const original = '0x' + '55'.repeat(32);
     mockGetDirectTransaction.mockImplementation((txHash: string) => txHash === original ? {
       tx_hash: original,
+      chain_id: '5',
       operation: 'mailbox_claim',
       mirror: MIRROR,
       claimed_id: CLAIMED_ID,
@@ -228,10 +228,79 @@ describe('Vara.eth write commands submit before reading receipts', () => {
     expect(mockMarkDirectTransactionReplaced).toHaveBeenCalledWith(original, '0x' + '44'.repeat(32));
   });
 
+  it('rejects a replacement from a different Ethereum account before broadcasting', async () => {
+    const original = '0x' + '55'.repeat(32);
+    mockGetDirectTransaction.mockReturnValue({
+      tx_hash: original,
+      chain_id: '5',
+      operation: 'mailbox_claim', mirror: MIRROR, claimed_id: CLAIMED_ID,
+      sender: '0x1234560000000000000000000000000000000003', nonce: '7', calldata: '0xclaim',
+      gas: '50000', max_fee_per_gas: '100', max_priority_fee_per_gas: '2', gas_price: null,
+      submitted_at_ts: 0, status: 'pending', replacement_of: null, replaced_by: null, receipt_block: null, last_error: null,
+    });
+
+    await expect(makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', '--replace', original, '--wait', 'submitted'], { from: 'user' },
+    )).rejects.toThrow('does not match the sender');
+
+    expect(mockClaimSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects a replacement on a different Ethereum chain before broadcasting', async () => {
+    const original = '0x' + '55'.repeat(32);
+    mockGetDirectTransaction.mockReturnValue({
+      tx_hash: original,
+      chain_id: '1',
+      operation: 'mailbox_claim', mirror: MIRROR, claimed_id: CLAIMED_ID,
+      sender: '0x1234560000000000000000000000000000000002', nonce: '7', calldata: '0xclaim',
+      gas: '50000', max_fee_per_gas: '100', max_priority_fee_per_gas: '2', gas_price: null,
+      submitted_at_ts: 0, status: 'pending', replacement_of: null, replaced_by: null, receipt_block: null, last_error: null,
+    });
+
+    await expect(makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', '--replace', original, '--wait', 'submitted'], { from: 'user' },
+    )).rejects.toThrow('does not match the saved claim transaction');
+
+    expect(mockClaimSend).not.toHaveBeenCalled();
+  });
+
+  it('preserves legacy gasPrice fee mode for a replacement', async () => {
+    const original = '0x' + '55'.repeat(32);
+    mockGetDirectTransaction.mockReturnValue({
+      tx_hash: original,
+      chain_id: '5',
+      operation: 'mailbox_claim', mirror: MIRROR, claimed_id: CLAIMED_ID,
+      sender: '0x1234560000000000000000000000000000000002', nonce: '7', calldata: '0xclaim',
+      gas: '50000', max_fee_per_gas: null, max_priority_fee_per_gas: null, gas_price: '100',
+      submitted_at_ts: 0, status: 'pending', replacement_of: null, replaced_by: null, receipt_block: null, last_error: null,
+    });
+    mockApi.eth.publicClient.getGasPrice.mockResolvedValue(90n);
+
+    await makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', '--replace', original, '--wait', 'submitted'], { from: 'user' },
+    );
+
+    expect(claimRequest.gasPrice).toBe(113n);
+    expect(claimRequest.maxFeePerGas).toBeUndefined();
+    expect(mockEstimateFeesPerGas).not.toHaveBeenCalled();
+  });
+
+  it('does not estimate fees when both EIP-1559 values are explicit', async () => {
+    await makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', MIRROR, CLAIMED_ID, '--wait', 'submitted', '--max-fee-per-gas', '200', '--max-priority-fee-per-gas', '3'],
+      { from: 'user' },
+    );
+
+    expect(mockEstimateFeesPerGas).not.toHaveBeenCalled();
+    expect(claimRequest.maxFeePerGas).toBe(200n);
+    expect(claimRequest.maxPriorityFeePerGas).toBe(3n);
+  });
+
   it('reports a saved claim as pending when its receipt is not yet available', async () => {
     const original = '0x' + '55'.repeat(32);
     mockGetDirectTransaction.mockReturnValue({
       tx_hash: original,
+      chain_id: '5',
       operation: 'mailbox_claim',
       mirror: MIRROR,
       claimed_id: CLAIMED_ID,
@@ -263,6 +332,47 @@ describe('Vara.eth write commands submit before reading receipts', () => {
       status: 'pending',
       code: 'CLAIM_PENDING',
     }));
+  });
+
+  it('makes a claim terminal when its nonce advanced without an available receipt', async () => {
+    const original = '0x' + '55'.repeat(32);
+    mockGetDirectTransaction.mockReturnValue({
+      tx_hash: original, chain_id: '5', operation: 'mailbox_claim', mirror: MIRROR, claimed_id: CLAIMED_ID,
+      sender: '0x1234560000000000000000000000000000000002', nonce: '7', calldata: '0xclaim',
+      gas: '50000', max_fee_per_gas: '100', max_priority_fee_per_gas: '2', gas_price: null,
+      submitted_at_ts: 0, status: 'pending', replacement_of: null, replaced_by: null, receipt_block: null, last_error: null,
+    });
+    mockGetTransactionReceipt.mockRejectedValue(Object.assign(new Error('Transaction receipt not found'), {
+      name: 'TransactionReceiptNotFoundError',
+    }));
+    mockGetTransactionCount.mockResolvedValue(8);
+
+    await makeProgram().parseAsync(['vara-eth:mailbox', 'claim', '--resume', original], { from: 'user' });
+
+    expect(mockMarkDirectTransactionFailed).toHaveBeenCalledWith(original, 'CLAIM_REPLACED_OR_MINED');
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({ status: 'unknown', code: 'CLAIM_REPLACED_OR_MINED' }));
+  });
+
+  it('marks a receipt timeout as pending but persists other receipt failures', async () => {
+    const failure = new Error('Ethereum RPC unavailable');
+    mockWaitForTransactionReceipt.mockRejectedValue(failure);
+
+    await expect(makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', MIRROR, CLAIMED_ID], { from: 'user' },
+    )).rejects.toThrow('Ethereum RPC unavailable');
+
+    expect(mockMarkDirectTransactionFailed).toHaveBeenCalledWith('0x' + '44'.repeat(32), 'Ethereum RPC unavailable');
+  });
+
+  it('persists reverted receipts without looking up a second receipt for events', async () => {
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      transactionHash: '0x' + '44'.repeat(32), blockNumber: 123n, status: 'reverted', logs: [],
+    });
+
+    await makeProgram().parseAsync(['vara-eth:mailbox', 'claim', MIRROR, CLAIMED_ID], { from: 'user' });
+
+    expect(mockMarkDirectTransactionReceipt).toHaveBeenCalledWith('0x' + '44'.repeat(32), 'reverted', 123n);
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({ status: 'reverted', event: null }));
   });
 
   it('submits one same-nonce replacement after the requested pending interval', async () => {

--- a/src/__tests__/vara-eth-submit-receipt.test.ts
+++ b/src/__tests__/vara-eth-submit-receipt.test.ts
@@ -7,18 +7,37 @@ const CLAIMED_ID = '0x' + '33'.repeat(32);
 const mockSetSigner = jest.fn();
 const mockSendAndWaitForReceipt = jest.fn();
 const mockGetReceipt = jest.fn();
+const mockClaimSend = jest.fn();
+const mockClaimEstimateGas = jest.fn();
+const mockGetTransactionCount = jest.fn();
+const mockEstimateFeesPerGas = jest.fn();
+const mockWaitForTransactionReceipt = jest.fn();
+const mockGetTransactionReceipt = jest.fn();
 const mockSendReply = jest.fn();
 const mockClaimValue = jest.fn();
 const mockGetValueClaimingRequestedEvent = jest.fn();
+const mockGetDirectTransaction = jest.fn();
+const mockInsertDirectTransaction = jest.fn();
+const mockMarkDirectTransactionReceipt = jest.fn();
+const mockMarkDirectTransactionReplaced = jest.fn();
+const mockMarkDirectTransactionFailed = jest.fn();
+
+const claimRequest: Record<string, unknown> = { to: MIRROR, data: '0xclaim' };
 
 const mockApi = {
   eth: {
-    publicClient: {},
+    publicClient: {
+      getTransactionCount: mockGetTransactionCount,
+      estimateFeesPerGas: mockEstimateFeesPerGas,
+      waitForTransactionReceipt: mockWaitForTransactionReceipt,
+      getTransactionReceipt: mockGetTransactionReceipt,
+      getGasPrice: jest.fn(),
+    },
     setSigner: mockSetSigner,
   },
 };
 
-const mockSigner = {};
+const mockSigner = { getAddress: jest.fn() };
 
 jest.mock('../services/vara-eth/api', () => ({
   getEthexeApi: jest.fn(),
@@ -28,6 +47,14 @@ jest.mock('../services/vara-eth/api', () => ({
 
 jest.mock('../services/vara-eth/account', () => ({
   resolveEthexeSigner: jest.fn(),
+}));
+
+jest.mock('../services/vara-eth/direct-transactions', () => ({
+  getDirectTransaction: (...args: unknown[]) => mockGetDirectTransaction(...args),
+  insertDirectTransaction: (...args: unknown[]) => mockInsertDirectTransaction(...args),
+  markDirectTransactionReceipt: (...args: unknown[]) => mockMarkDirectTransactionReceipt(...args),
+  markDirectTransactionReplaced: (...args: unknown[]) => mockMarkDirectTransactionReplaced(...args),
+  markDirectTransactionFailed: (...args: unknown[]) => mockMarkDirectTransactionFailed(...args),
 }));
 
 const mockOutput = jest.fn();
@@ -58,6 +85,8 @@ function makeProgram(): Command {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  for (const key of Object.keys(claimRequest)) delete claimRequest[key];
+  Object.assign(claimRequest, { to: MIRROR, data: '0xclaim' });
   getEthexeApi.mockResolvedValue(mockApi);
   getEthexeEthereumContext.mockReturnValue({ publicClient: mockApi.eth.publicClient });
   getMirrorClient.mockResolvedValue({
@@ -65,6 +94,25 @@ beforeEach(() => {
     claimValue: mockClaimValue,
   });
   resolveEthexeSigner.mockResolvedValue(mockSigner);
+  mockSigner.getAddress.mockResolvedValue('0x1234560000000000000000000000000000000002');
+  mockGetTransactionCount.mockResolvedValue(7);
+  mockEstimateFeesPerGas.mockResolvedValue({ maxFeePerGas: 100n, maxPriorityFeePerGas: 2n });
+  mockClaimEstimateGas.mockImplementation(async () => {
+    claimRequest.gas = 50_000n;
+    return 50_000n;
+  });
+  mockClaimSend.mockResolvedValue('0x' + '44'.repeat(32));
+  mockWaitForTransactionReceipt.mockResolvedValue({
+    transactionHash: '0x' + '44'.repeat(32),
+    blockNumber: 123n,
+    status: 'success',
+  });
+  mockGetTransactionReceipt.mockResolvedValue({
+    transactionHash: '0x' + '44'.repeat(32),
+    blockNumber: 123n,
+    status: 'success',
+  });
+  mockGetDirectTransaction.mockReturnValue(undefined);
   mockSendAndWaitForReceipt.mockResolvedValue({
     transactionHash: '0x' + '44'.repeat(32),
     blockNumber: 123n,
@@ -82,8 +130,9 @@ beforeEach(() => {
     claimedId: CLAIMED_ID,
   });
   mockClaimValue.mockResolvedValue({
-    sendAndWaitForReceipt: mockSendAndWaitForReceipt,
-    getReceipt: mockGetReceipt,
+    send: mockClaimSend,
+    estimateGas: mockClaimEstimateGas,
+    getTx: () => claimRequest,
     getValueClaimingRequestedEvent: mockGetValueClaimingRequestedEvent,
   });
 });
@@ -112,13 +161,137 @@ describe('Vara.eth write commands submit before reading receipts', () => {
     );
 
     expect(mockClaimValue).toHaveBeenCalledWith(CLAIMED_ID);
-    expect(mockSendAndWaitForReceipt).toHaveBeenCalledTimes(1);
-    expect(mockGetReceipt).not.toHaveBeenCalled();
+    expect(mockClaimSend).toHaveBeenCalledTimes(1);
+    expect(mockWaitForTransactionReceipt).toHaveBeenCalledWith(expect.objectContaining({
+      hash: '0x' + '44'.repeat(32),
+      timeout: 45_000,
+    }));
     expect(mockGetValueClaimingRequestedEvent).toHaveBeenCalledTimes(1);
     expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
       mirror: MIRROR,
       claimedId: CLAIMED_ID,
-      status: 'success',
+      status: 'confirmed',
+      nonce: '7',
+    }));
+  });
+
+  it('returns the submitted hash and persisted fee metadata without waiting', async () => {
+    await makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', MIRROR, CLAIMED_ID, '--wait', 'submitted'],
+      { from: 'user' },
+    );
+
+    expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled();
+    expect(mockInsertDirectTransaction).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'mailbox_claim',
+      nonce: 7n,
+      maxFeePerGas: 120n,
+      maxPriorityFeePerGas: 2n,
+    }));
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'submitted',
+      txHash: '0x' + '44'.repeat(32),
+      nonce: '7',
+    }));
+  });
+
+  it('uses the saved nonce and bumps fees when replacing a pending claim', async () => {
+    const original = '0x' + '55'.repeat(32);
+    mockGetDirectTransaction.mockImplementation((txHash: string) => txHash === original ? {
+      tx_hash: original,
+      operation: 'mailbox_claim',
+      mirror: MIRROR,
+      claimed_id: CLAIMED_ID,
+      sender: '0x1234560000000000000000000000000000000002',
+      nonce: '7',
+      calldata: '0xclaim',
+      gas: '50000',
+      max_fee_per_gas: '100',
+      max_priority_fee_per_gas: '2',
+      gas_price: null,
+      submitted_at_ts: 0,
+      status: 'pending',
+      replacement_of: null,
+      replaced_by: null,
+      receipt_block: null,
+      last_error: null,
+    } : undefined);
+
+    await makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', '--replace', original, '--wait', 'submitted'],
+      { from: 'user' },
+    );
+
+    expect(claimRequest.nonce).toBe(7);
+    expect(claimRequest.maxFeePerGas).toBe(120n);
+    expect(claimRequest.maxPriorityFeePerGas).toBe(3n);
+    expect(mockMarkDirectTransactionReplaced).toHaveBeenCalledWith(original, '0x' + '44'.repeat(32));
+  });
+
+  it('reports a saved claim as pending when its receipt is not yet available', async () => {
+    const original = '0x' + '55'.repeat(32);
+    mockGetDirectTransaction.mockReturnValue({
+      tx_hash: original,
+      operation: 'mailbox_claim',
+      mirror: MIRROR,
+      claimed_id: CLAIMED_ID,
+      sender: '0x1234560000000000000000000000000000000002',
+      nonce: '7',
+      calldata: '0xclaim',
+      gas: '50000',
+      max_fee_per_gas: '100',
+      max_priority_fee_per_gas: '2',
+      gas_price: null,
+      submitted_at_ts: 0,
+      status: 'pending',
+      replacement_of: null,
+      replaced_by: null,
+      receipt_block: null,
+      last_error: null,
+    });
+    mockGetTransactionReceipt.mockRejectedValue(Object.assign(new Error('Transaction receipt not found'), {
+      name: 'TransactionReceiptNotFoundError',
+    }));
+
+    await makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', '--resume', original],
+      { from: 'user' },
+    );
+
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      txHash: original,
+      status: 'pending',
+      code: 'CLAIM_PENDING',
+    }));
+  });
+
+  it('submits one same-nonce replacement after the requested pending interval', async () => {
+    const original = '0x' + '55'.repeat(32);
+    const replacement = '0x' + '66'.repeat(32);
+    const timeout = Object.assign(new Error('Timed out waiting for transaction receipt'), {
+      name: 'WaitForTransactionReceiptTimeoutError',
+    });
+    mockClaimSend.mockResolvedValueOnce(original).mockResolvedValueOnce(replacement);
+    mockWaitForTransactionReceipt
+      .mockRejectedValueOnce(timeout)
+      .mockResolvedValueOnce({ transactionHash: replacement, blockNumber: 124n, status: 'success' });
+    // If local persistence is unavailable, a fresh pending nonce would be 8.
+    // The automatic replacement must nevertheless reuse the original nonce 7.
+    mockGetTransactionCount.mockResolvedValueOnce(7).mockResolvedValueOnce(8);
+
+    await makeProgram().parseAsync(
+      ['vara-eth:mailbox', 'claim', MIRROR, CLAIMED_ID, '--replace-after-ms', '1'],
+      { from: 'user' },
+    );
+
+    expect(mockClaimSend).toHaveBeenCalledTimes(2);
+    expect(mockGetTransactionCount).toHaveBeenCalledTimes(1);
+    expect(claimRequest.nonce).toBe(7);
+    expect(mockMarkDirectTransactionReplaced).toHaveBeenCalledWith(original, replacement);
+    expect(mockOutput).toHaveBeenCalledWith(expect.objectContaining({
+      txHash: replacement,
+      status: 'confirmed',
+      replacementOf: original,
     }));
   });
 });

--- a/src/commands/vara-eth-mailbox.ts
+++ b/src/commands/vara-eth-mailbox.ts
@@ -1,44 +1,435 @@
 import { Command } from 'commander';
+import type { TransactionReceipt, TransactionRequest } from 'viem';
 
 import { getEthexeApi, getMirrorClient } from '../services/vara-eth/api';
 import { resolveEthexeSigner } from '../services/vara-eth/account';
-import { asAddress, asHex } from '../utils/eth-types';
+import {
+  getDirectTransaction,
+  insertDirectTransaction,
+  markDirectTransactionFailed,
+  markDirectTransactionReceipt,
+  markDirectTransactionReplaced,
+  type DirectTransactionRecord,
+} from '../services/vara-eth/direct-transactions';
+import { asAddress, asHex, parseOptionalBigInt, parseOptionalPositiveInteger } from '../utils/eth-types';
+import { CliError } from '../utils/errors';
 import { output } from '../utils/output';
+
+const DEFAULT_RECEIPT_TIMEOUT_MS = 45_000;
+const FEE_HEADROOM_NUMERATOR = 1200n;
+const FEE_HEADROOM_DENOMINATOR = 1000n;
+const REPLACEMENT_BUMP_NUMERATOR = 1125n;
+const REPLACEMENT_BUMP_DENOMINATOR = 1000n;
+
+interface ClaimOptions {
+  account?: string;
+  passphrase?: string;
+  wait?: string;
+  timeoutMs?: string;
+  replaceAfterMs?: string;
+  resume?: string;
+  replace?: string;
+  nonce?: string;
+  gas?: string;
+  maxFeePerGas?: string;
+  maxPriorityFeePerGas?: string;
+}
+
+interface PreparedClaim {
+  mirror: `0x${string}`;
+  claimedId: `0x${string}`;
+  tx: {
+    send(): Promise<`0x${string}`>;
+    estimateGas(): Promise<bigint>;
+    getTx(): TransactionRequest;
+    getValueClaimingRequestedEvent(): Promise<{ source: string; claimedId: string }>;
+  };
+  sender: `0x${string}`;
+  nonce: bigint;
+  request: TransactionRequest;
+}
 
 export function registerVaraEthMailboxCommand(program: Command): void {
   const mailbox = program.command('vara-eth:mailbox').description('Mailbox operations on the Vara.eth rail');
 
   mailbox
-    .command('claim <mirror> <claimedId>')
+    .command('claim [mirror] [claimedId]')
     .description('Claim a value entry from the Mirror mailbox')
     .option('--account <name>', 'Vara.eth wallet name')
     .option('--passphrase <pass>', 'wallet passphrase')
+    .option('--wait <stage>', 'completion stage: submitted or receipt (default)', 'receipt')
+    .option('--timeout-ms <ms>', `receipt wait timeout in milliseconds (default: ${DEFAULT_RECEIPT_TIMEOUT_MS})`)
+    .option('--replace-after-ms <ms>', 'after this pending interval, submit one fee-bumped replacement')
+    .option('--resume <txHash>', 'inspect a saved claim transaction without submitting a new one')
+    .option('--replace <txHash>', 'replace a saved pending claim with the same nonce and fresh fees')
+    .option('--nonce <nonce>', 'explicit Ethereum nonce')
+    .option('--gas <gas>', 'explicit gas limit')
+    .option('--max-fee-per-gas <wei>', 'EIP-1559 maximum fee per gas in wei')
+    .option('--max-priority-fee-per-gas <wei>', 'EIP-1559 priority fee per gas in wei')
     .action(async (
-      mirrorArg: string,
-      claimedIdArg: string,
-      _options: { account?: string; passphrase?: string },
+      mirrorArg: string | undefined,
+      claimedIdArg: string | undefined,
+      _options: ClaimOptions,
       cmd: Command,
     ) => {
-      const opts = cmd.optsWithGlobals() as { account?: string; passphrase?: string };
-      const mirror = asAddress(mirrorArg, 'mirror');
-      const claimedId = asHex(claimedIdArg, 'claimedId');
-
-      const api = await getEthexeApi();
-      const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-      api.eth.setSigner(signer);
-
-      const mirrorClient = await getMirrorClient(mirror, signer);
-      const tx = await mirrorClient.claimValue(claimedId);
-      const receipt = await tx.sendAndWaitForReceipt();
-      const event = await tx.getValueClaimingRequestedEvent();
-
-      output({
-        mirror,
-        claimedId,
-        txHash: receipt.transactionHash,
-        blockNumber: Number(receipt.blockNumber),
-        status: receipt.status,
-        event: { source: event.source, claimedId: event.claimedId },
-      });
+      const opts = cmd.optsWithGlobals() as ClaimOptions;
+      await outputVaraEthMailboxClaim(mirrorArg, claimedIdArg, opts);
     });
+}
+
+export async function outputVaraEthMailboxClaim(
+  mirrorArg: string | undefined,
+  claimedIdArg: string | undefined,
+  opts: ClaimOptions,
+): Promise<void> {
+  if (opts.resume && opts.replace) {
+    throw new CliError('--resume and --replace are mutually exclusive', 'INVALID_CLAIM_OPERATION');
+  }
+  if (opts.resume) {
+    if (mirrorArg || claimedIdArg) throw new CliError('--resume does not accept mirror or claimedId arguments', 'INVALID_CLAIM_OPERATION');
+    await resumeClaim(asHex(opts.resume, '--resume'));
+    return;
+  }
+
+  const storedReplacement = opts.replace ? requireStoredClaim(asHex(opts.replace, '--replace')) : undefined;
+  const mirror = resolveClaimMirror(mirrorArg, storedReplacement);
+  const claimedId = resolveClaimedId(claimedIdArg, storedReplacement);
+  const wait = resolveClaimWait(opts.wait);
+  const timeoutMs = parseOptionalPositiveInteger(opts.timeoutMs, '--timeout-ms', 'INVALID_TIMEOUT') ?? DEFAULT_RECEIPT_TIMEOUT_MS;
+  const replaceAfterMs = parseOptionalPositiveInteger(opts.replaceAfterMs, '--replace-after-ms', 'INVALID_TIMEOUT');
+  if (wait === 'submitted' && replaceAfterMs !== undefined) {
+    throw new CliError('--replace-after-ms requires --wait receipt', 'INVALID_CLAIM_OPERATION');
+  }
+
+  const prepared = await prepareClaim(mirror, claimedId, opts, storedReplacement);
+  const txHash = await submitClaim(prepared, storedReplacement?.tx_hash);
+  if (storedReplacement) markDirectTransactionReplaced(storedReplacement.tx_hash, txHash);
+
+  if (wait === 'submitted') {
+    outputClaimSubmission(prepared, txHash, 'submitted', storedReplacement?.tx_hash ?? null);
+    return;
+  }
+
+  const firstWaitMs = replaceAfterMs ?? timeoutMs;
+  const receipt = await waitForClaimReceipt(prepared, txHash, firstWaitMs);
+  if (receipt) {
+    await outputClaimReceipt(prepared, txHash, receipt, storedReplacement?.tx_hash ?? null);
+    return;
+  }
+
+  if (replaceAfterMs === undefined) {
+    outputClaimSubmission(prepared, txHash, 'pending', storedReplacement?.tx_hash ?? null, 'CLAIM_PENDING');
+    return;
+  }
+
+  // Persistence is best-effort. Keep an in-memory representation so automatic
+  // replacement always uses the original nonce even when its SQLite write failed.
+  const replacement = await prepareClaim(
+    mirror,
+    claimedId,
+    opts,
+    getDirectTransaction(txHash) ?? directRecordFromPreparedClaim(prepared, txHash),
+  );
+  const replacementHash = await submitClaim(replacement, txHash);
+  markDirectTransactionReplaced(txHash, replacementHash);
+  const replacementReceipt = await waitForClaimReceipt(replacement, replacementHash, timeoutMs);
+  if (replacementReceipt) {
+    await outputClaimReceipt(replacement, replacementHash, replacementReceipt, txHash);
+    return;
+  }
+  outputClaimSubmission(replacement, replacementHash, 'pending', txHash, 'CLAIM_PENDING');
+}
+
+function resolveClaimWait(raw: string | undefined): 'submitted' | 'receipt' {
+  const wait = raw ?? 'receipt';
+  if (wait === 'submitted' || wait === 'receipt') return wait;
+  throw new CliError('--wait must be one of: submitted, receipt', 'INVALID_WAIT_MODE', { wait });
+}
+
+function resolveClaimMirror(mirrorArg: string | undefined, stored?: DirectTransactionRecord): `0x${string}` {
+  if (!mirrorArg && !stored) throw new CliError('mirror is required unless --replace is used', 'MISSING_REQUIRED_OPTION');
+  const mirror = asAddress(mirrorArg ?? stored!.mirror, 'mirror');
+  if (stored && mirrorArg && mirror.toLowerCase() !== stored.mirror.toLowerCase()) {
+    throw new CliError('mirror does not match the saved claim transaction', 'CLAIM_REPLACEMENT_MISMATCH');
+  }
+  return mirror;
+}
+
+function resolveClaimedId(claimedIdArg: string | undefined, stored?: DirectTransactionRecord): `0x${string}` {
+  if (!claimedIdArg && !stored?.claimed_id) throw new CliError('claimedId is required unless --replace is used', 'MISSING_REQUIRED_OPTION');
+  const claimedId = asHex(claimedIdArg ?? stored!.claimed_id!, 'claimedId');
+  if (stored?.claimed_id && claimedIdArg && claimedId.toLowerCase() !== stored.claimed_id.toLowerCase()) {
+    throw new CliError('claimedId does not match the saved claim transaction', 'CLAIM_REPLACEMENT_MISMATCH');
+  }
+  return claimedId;
+}
+
+function requireStoredClaim(txHash: `0x${string}`): DirectTransactionRecord {
+  const stored = getDirectTransaction(txHash);
+  if (!stored || stored.operation !== 'mailbox_claim') {
+    throw new CliError('No saved mailbox claim was found for --replace', 'CLAIM_REPLACEMENT_NOT_FOUND', { txHash });
+  }
+  if (stored.status !== 'pending') {
+    throw new CliError('Only a pending mailbox claim can be replaced', 'CLAIM_NOT_PENDING', { txHash, status: stored.status });
+  }
+  return stored;
+}
+
+async function prepareClaim(
+  mirror: `0x${string}`,
+  claimedId: `0x${string}`,
+  opts: ClaimOptions,
+  replacement?: DirectTransactionRecord,
+): Promise<PreparedClaim> {
+  const api = await getEthexeApi();
+  const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
+  api.eth.setSigner(signer);
+  const sender = await signer.getAddress();
+  const mirrorClient = await getMirrorClient(mirror, signer);
+  const tx = await mirrorClient.claimValue(claimedId) as PreparedClaim['tx'];
+  const request = tx.getTx();
+  const explicitNonce = parseNonce(opts.nonce);
+  const nonce = replacement ? parseNonce(replacement.nonce)! : (explicitNonce ?? await api.eth.publicClient.getTransactionCount({ address: sender, blockTag: 'pending' }));
+  if (replacement && explicitNonce !== undefined && explicitNonce !== nonce) {
+    throw new CliError('--nonce must equal the nonce of the claim being replaced', 'CLAIM_REPLACEMENT_MISMATCH', { nonce: nonce.toString() });
+  }
+
+  request.nonce = nonce;
+  const explicitGas = parseOptionalBigInt(opts.gas, '--gas');
+  if (explicitGas !== undefined) request.gas = explicitGas;
+  else await tx.estimateGas();
+  await applyClaimFees(request, api.eth.publicClient, opts, replacement);
+
+  return { mirror, claimedId, tx, sender, nonce: BigInt(nonce), request };
+}
+
+function parseNonce(raw: string | undefined): number | undefined {
+  const value = parseOptionalBigInt(raw, '--nonce');
+  if (value === undefined) return undefined;
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new CliError('--nonce must be a non-negative safe integer', 'INVALID_NONCE', { value: raw });
+  }
+  return Number(value);
+}
+
+async function applyClaimFees(
+  request: TransactionRequest,
+  publicClient: { estimateFeesPerGas(): Promise<{ maxFeePerGas?: bigint | null; maxPriorityFeePerGas?: bigint | null; gasPrice?: bigint | null }>; getGasPrice(): Promise<bigint> },
+  opts: ClaimOptions,
+  replacement?: DirectTransactionRecord,
+): Promise<void> {
+  const explicitMaxFee = parseOptionalBigInt(opts.maxFeePerGas, '--max-fee-per-gas');
+  const explicitPriorityFee = parseOptionalBigInt(opts.maxPriorityFeePerGas, '--max-priority-fee-per-gas');
+  const quote = await publicClient.estimateFeesPerGas();
+  const previousMaxFee = replacement?.max_fee_per_gas ? BigInt(replacement.max_fee_per_gas) : undefined;
+  const previousPriorityFee = replacement?.max_priority_fee_per_gas ? BigInt(replacement.max_priority_fee_per_gas) : undefined;
+
+  if (replacement && explicitMaxFee !== undefined && previousMaxFee !== undefined && explicitMaxFee <= previousMaxFee) {
+    throw new CliError('--max-fee-per-gas must exceed the previous replacement fee', 'REPLACEMENT_FEE_TOO_LOW');
+  }
+  if (replacement && explicitPriorityFee !== undefined && previousPriorityFee !== undefined && explicitPriorityFee <= previousPriorityFee) {
+    throw new CliError('--max-priority-fee-per-gas must exceed the previous replacement fee', 'REPLACEMENT_FEE_TOO_LOW');
+  }
+
+  const quoteMaxFee = quote.maxFeePerGas === null || quote.maxFeePerGas === undefined
+    ? undefined
+    : feeHeadroom(quote.maxFeePerGas);
+  const quotePriorityFee = quote.maxPriorityFeePerGas ?? undefined;
+  if (quoteMaxFee !== undefined || explicitMaxFee !== undefined || previousMaxFee !== undefined) {
+    request.maxFeePerGas = maximum(explicitMaxFee, quoteMaxFee, replacementBump(previousMaxFee));
+    request.maxPriorityFeePerGas = maximum(explicitPriorityFee, quotePriorityFee, replacementBump(previousPriorityFee));
+    return;
+  }
+
+  request.gasPrice = maximum(await publicClient.getGasPrice(), replacement?.gas_price ? replacementBump(BigInt(replacement.gas_price)) : undefined);
+}
+
+function replacementBump(value: bigint | undefined): bigint | undefined {
+  if (value === undefined) return undefined;
+  return (value * REPLACEMENT_BUMP_NUMERATOR + REPLACEMENT_BUMP_DENOMINATOR - 1n) / REPLACEMENT_BUMP_DENOMINATOR;
+}
+
+function feeHeadroom(value: bigint): bigint {
+  return (value * FEE_HEADROOM_NUMERATOR + FEE_HEADROOM_DENOMINATOR - 1n) / FEE_HEADROOM_DENOMINATOR;
+}
+
+function maximum(...values: Array<bigint | undefined>): bigint {
+  const defined = values.filter((value): value is bigint => value !== undefined);
+  if (defined.length === 0) throw new CliError('Ethereum RPC did not return a usable fee quote', 'FEE_ESTIMATE_UNAVAILABLE');
+  return defined.reduce((highest, value) => value > highest ? value : highest);
+}
+
+async function submitClaim(prepared: PreparedClaim, replacementOf?: string): Promise<`0x${string}`> {
+  const txHash = await prepared.tx.send();
+  try {
+    insertDirectTransaction({
+      txHash,
+      operation: 'mailbox_claim',
+      mirror: prepared.mirror,
+      claimedId: prepared.claimedId,
+      sender: prepared.sender,
+      nonce: prepared.nonce,
+      calldata: prepared.request.data ?? '0x',
+      gas: prepared.request.gas,
+      maxFeePerGas: prepared.request.maxFeePerGas,
+      maxPriorityFeePerGas: prepared.request.maxPriorityFeePerGas,
+      gasPrice: prepared.request.gasPrice,
+      replacementOf,
+    });
+  } catch {
+    // A successful broadcast remains valid when local persistence is unavailable.
+  }
+  return txHash;
+}
+
+async function waitForClaimReceipt(prepared: PreparedClaim, txHash: `0x${string}`, timeout: number): Promise<TransactionReceipt | null> {
+  const api = await getEthexeApi();
+  try {
+    return await api.eth.publicClient.waitForTransactionReceipt({ hash: txHash, timeout });
+  } catch (error) {
+    if (isReceiptTimeout(error)) return null;
+    markDirectTransactionFailed(txHash, error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+}
+
+async function outputClaimReceipt(
+  prepared: PreparedClaim,
+  txHash: `0x${string}`,
+  receipt: TransactionReceipt,
+  replacementOf: string | null,
+): Promise<void> {
+  const status = receipt.status === 'success' ? 'confirmed' : 'reverted';
+  markDirectTransactionReceipt(txHash, status, receipt.blockNumber);
+  const event = receipt.status === 'success' ? await prepared.tx.getValueClaimingRequestedEvent() : null;
+  output({
+    mirror: prepared.mirror,
+    claimedId: prepared.claimedId,
+    txHash,
+    nonce: prepared.nonce.toString(),
+    blockNumber: Number(receipt.blockNumber),
+    status,
+    replacementOf,
+    fees: serializeFees(prepared.request),
+    event: event ? { source: event.source, claimedId: event.claimedId } : null,
+  });
+}
+
+function outputClaimSubmission(
+  prepared: PreparedClaim,
+  txHash: `0x${string}`,
+  status: 'submitted' | 'pending',
+  replacementOf: string | null,
+  code?: 'CLAIM_PENDING',
+): void {
+  output({
+    mirror: prepared.mirror,
+    claimedId: prepared.claimedId,
+    txHash,
+    nonce: prepared.nonce.toString(),
+    status,
+    code: code ?? null,
+    replacementOf,
+    fees: serializeFees(prepared.request),
+  });
+}
+
+function serializeFees(request: TransactionRequest): Record<string, string | null> {
+  return {
+    gas: request.gas?.toString() ?? null,
+    maxFeePerGas: request.maxFeePerGas?.toString() ?? null,
+    maxPriorityFeePerGas: request.maxPriorityFeePerGas?.toString() ?? null,
+    gasPrice: request.gasPrice?.toString() ?? null,
+  };
+}
+
+function directRecordFromPreparedClaim(prepared: PreparedClaim, txHash: `0x${string}`): DirectTransactionRecord {
+  const fees = serializeFees(prepared.request);
+  return {
+    tx_hash: txHash,
+    operation: 'mailbox_claim',
+    mirror: prepared.mirror,
+    claimed_id: prepared.claimedId,
+    sender: prepared.sender,
+    nonce: prepared.nonce.toString(),
+    calldata: prepared.request.data ?? '0x',
+    gas: fees.gas,
+    max_fee_per_gas: fees.maxFeePerGas,
+    max_priority_fee_per_gas: fees.maxPriorityFeePerGas,
+    gas_price: fees.gasPrice,
+    submitted_at_ts: Date.now(),
+    status: 'pending',
+    replacement_of: null,
+    replaced_by: null,
+    receipt_block: null,
+    last_error: null,
+  };
+}
+
+async function resumeClaim(txHash: `0x${string}`): Promise<void> {
+  const stored = getDirectTransaction(txHash);
+  if (!stored || stored.operation !== 'mailbox_claim') {
+    throw new CliError('No saved mailbox claim was found for --resume', 'CLAIM_RESUME_NOT_FOUND', { txHash });
+  }
+  const api = await getEthexeApi();
+  try {
+    const receipt = await api.eth.publicClient.getTransactionReceipt({ hash: txHash });
+    const status = receipt.status === 'success' ? 'confirmed' : 'reverted';
+    markDirectTransactionReceipt(txHash, status, receipt.blockNumber);
+    output({
+      mirror: stored.mirror,
+      claimedId: stored.claimed_id,
+      txHash,
+      nonce: stored.nonce,
+      status,
+      blockNumber: Number(receipt.blockNumber),
+      replacementOf: stored.replacement_of,
+      fees: {
+        gas: stored.gas,
+        maxFeePerGas: stored.max_fee_per_gas,
+        maxPriorityFeePerGas: stored.max_priority_fee_per_gas,
+        gasPrice: stored.gas_price,
+      },
+    });
+  } catch (error) {
+    if (!isReceiptMissing(error)) throw error;
+    const nextMinedNonce = await api.eth.publicClient.getTransactionCount({
+      address: stored.sender as `0x${string}`,
+      blockTag: 'latest',
+    });
+    if (nextMinedNonce > parseNonce(stored.nonce)!) {
+      output({
+        mirror: stored.mirror,
+        claimedId: stored.claimed_id,
+        txHash,
+        nonce: stored.nonce,
+        status: 'unknown',
+        code: 'CLAIM_REPLACED_OR_MINED',
+        replacementOf: stored.replacement_of,
+      });
+      return;
+    }
+    output({
+      mirror: stored.mirror,
+      claimedId: stored.claimed_id,
+      txHash,
+      nonce: stored.nonce,
+      status: 'pending',
+      code: 'CLAIM_PENDING',
+      replacementOf: stored.replacement_of,
+      replacement: `vara-wallet --chain vara-eth vara-eth:mailbox claim --replace ${txHash}`,
+    });
+  }
+}
+
+function isReceiptTimeout(error: unknown): boolean {
+  const name = error instanceof Error ? error.name : '';
+  const message = error instanceof Error ? error.message : String(error);
+  return name === 'WaitForTransactionReceiptTimeoutError' || /timed out waiting for transaction receipt/i.test(message);
+}
+
+function isReceiptMissing(error: unknown): boolean {
+  const name = error instanceof Error ? error.name : '';
+  const message = error instanceof Error ? error.message : String(error);
+  return name === 'TransactionReceiptNotFoundError' || /transaction receipt.*not found/i.test(message);
 }

--- a/src/commands/vara-eth-mailbox.ts
+++ b/src/commands/vara-eth-mailbox.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
-import type { TransactionReceipt, TransactionRequest } from 'viem';
+import { decodeEventLog, type PublicClient, type TransactionReceipt, type TransactionRequest } from 'viem';
 
-import { getEthexeApi, getMirrorClient } from '../services/vara-eth/api';
+import { getEthexeEthereumContext, getMirrorClient } from '../services/vara-eth/api';
 import { resolveEthexeSigner } from '../services/vara-eth/account';
 import {
   getDirectTransaction,
@@ -20,6 +20,15 @@ const FEE_HEADROOM_NUMERATOR = 1200n;
 const FEE_HEADROOM_DENOMINATOR = 1000n;
 const REPLACEMENT_BUMP_NUMERATOR = 1125n;
 const REPLACEMENT_BUMP_DENOMINATOR = 1000n;
+
+const VALUE_CLAIMING_REQUESTED_ABI = [{
+  type: 'event',
+  name: 'ValueClaimingRequested',
+  inputs: [
+    { name: 'claimedId', type: 'bytes32', indexed: false },
+    { name: 'source', type: 'address', indexed: true },
+  ],
+}] as const;
 
 interface ClaimOptions {
   account?: string;
@@ -42,11 +51,12 @@ interface PreparedClaim {
     send(): Promise<`0x${string}`>;
     estimateGas(): Promise<bigint>;
     getTx(): TransactionRequest;
-    getValueClaimingRequestedEvent(): Promise<{ source: string; claimedId: string }>;
   };
   sender: `0x${string}`;
+  chainId: number;
   nonce: bigint;
   request: TransactionRequest;
+  publicClient: PublicClient;
 }
 
 export function registerVaraEthMailboxCommand(program: Command): void {
@@ -111,7 +121,7 @@ export async function outputVaraEthMailboxClaim(
   }
 
   const firstWaitMs = replaceAfterMs ?? timeoutMs;
-  const receipt = await waitForClaimReceipt(prepared, txHash, firstWaitMs);
+  const receipt = await waitForClaimReceipt(prepared.publicClient, txHash, firstWaitMs);
   if (receipt) {
     await outputClaimReceipt(prepared, txHash, receipt, storedReplacement?.tx_hash ?? null);
     return;
@@ -132,7 +142,7 @@ export async function outputVaraEthMailboxClaim(
   );
   const replacementHash = await submitClaim(replacement, txHash);
   markDirectTransactionReplaced(txHash, replacementHash);
-  const replacementReceipt = await waitForClaimReceipt(replacement, replacementHash, timeoutMs);
+  const replacementReceipt = await waitForClaimReceipt(replacement.publicClient, replacementHash, timeoutMs);
   if (replacementReceipt) {
     await outputClaimReceipt(replacement, replacementHash, replacementReceipt, txHash);
     return;
@@ -181,15 +191,15 @@ async function prepareClaim(
   opts: ClaimOptions,
   replacement?: DirectTransactionRecord,
 ): Promise<PreparedClaim> {
-  const api = await getEthexeApi();
-  const signer = await resolveEthexeSigner(api.eth.publicClient, opts);
-  api.eth.setSigner(signer);
-  const sender = await signer.getAddress();
+  const { publicClient } = getEthexeEthereumContext();
+  const signer = await resolveEthexeSigner(publicClient, opts);
+  const [sender, chainId] = await Promise.all([signer.getAddress(), publicClient.getChainId()]);
+  assertReplacementScope(replacement, sender, chainId);
   const mirrorClient = await getMirrorClient(mirror, signer);
   const tx = await mirrorClient.claimValue(claimedId) as PreparedClaim['tx'];
   const request = tx.getTx();
   const explicitNonce = parseNonce(opts.nonce);
-  const nonce = replacement ? parseNonce(replacement.nonce)! : (explicitNonce ?? await api.eth.publicClient.getTransactionCount({ address: sender, blockTag: 'pending' }));
+  const nonce = replacement ? parseNonce(replacement.nonce)! : (explicitNonce ?? await publicClient.getTransactionCount({ address: sender, blockTag: 'pending' }));
   if (replacement && explicitNonce !== undefined && explicitNonce !== nonce) {
     throw new CliError('--nonce must equal the nonce of the claim being replaced', 'CLAIM_REPLACEMENT_MISMATCH', { nonce: nonce.toString() });
   }
@@ -198,9 +208,32 @@ async function prepareClaim(
   const explicitGas = parseOptionalBigInt(opts.gas, '--gas');
   if (explicitGas !== undefined) request.gas = explicitGas;
   else await tx.estimateGas();
-  await applyClaimFees(request, api.eth.publicClient, opts, replacement);
+  await applyClaimFees(request, publicClient, opts, replacement);
 
-  return { mirror, claimedId, tx, sender, nonce: BigInt(nonce), request };
+  return { mirror, claimedId, tx, sender, chainId, nonce: BigInt(nonce), request, publicClient };
+}
+
+function assertReplacementScope(
+  replacement: DirectTransactionRecord | undefined,
+  sender: `0x${string}`,
+  chainId: number,
+): void {
+  if (!replacement) return;
+  if (replacement.sender.toLowerCase() !== sender.toLowerCase()) {
+    throw new CliError('The selected account does not match the sender of the pending claim', 'CLAIM_REPLACEMENT_SENDER_MISMATCH', {
+      expectedSender: replacement.sender,
+      sender,
+    });
+  }
+  if (replacement.chain_id === null) {
+    throw new CliError('The saved claim has no chain ID and cannot be safely replaced', 'CLAIM_REPLACEMENT_CHAIN_UNKNOWN');
+  }
+  if (Number(replacement.chain_id) !== chainId) {
+    throw new CliError('The selected network does not match the saved claim transaction', 'CLAIM_REPLACEMENT_CHAIN_MISMATCH', {
+      expectedChainId: replacement.chain_id,
+      chainId: chainId.toString(),
+    });
+  }
 }
 
 function parseNonce(raw: string | undefined): number | undefined {
@@ -214,15 +247,23 @@ function parseNonce(raw: string | undefined): number | undefined {
 
 async function applyClaimFees(
   request: TransactionRequest,
-  publicClient: { estimateFeesPerGas(): Promise<{ maxFeePerGas?: bigint | null; maxPriorityFeePerGas?: bigint | null; gasPrice?: bigint | null }>; getGasPrice(): Promise<bigint> },
+  publicClient: Pick<PublicClient, 'estimateFeesPerGas' | 'getGasPrice'>,
   opts: ClaimOptions,
   replacement?: DirectTransactionRecord,
 ): Promise<void> {
   const explicitMaxFee = parseOptionalBigInt(opts.maxFeePerGas, '--max-fee-per-gas');
   const explicitPriorityFee = parseOptionalBigInt(opts.maxPriorityFeePerGas, '--max-priority-fee-per-gas');
-  const quote = await publicClient.estimateFeesPerGas();
   const previousMaxFee = replacement?.max_fee_per_gas ? BigInt(replacement.max_fee_per_gas) : undefined;
   const previousPriorityFee = replacement?.max_priority_fee_per_gas ? BigInt(replacement.max_priority_fee_per_gas) : undefined;
+  const previousGasPrice = replacement?.gas_price ? BigInt(replacement.gas_price) : undefined;
+
+  if (previousGasPrice !== undefined && previousMaxFee === undefined) {
+    if (explicitMaxFee !== undefined || explicitPriorityFee !== undefined) {
+      throw new CliError('A legacy claim replacement must preserve gasPrice fee mode', 'CLAIM_REPLACEMENT_FEE_MODE_MISMATCH');
+    }
+    request.gasPrice = maximum(await publicClient.getGasPrice(), replacementBump(previousGasPrice));
+    return;
+  }
 
   if (replacement && explicitMaxFee !== undefined && previousMaxFee !== undefined && explicitMaxFee <= previousMaxFee) {
     throw new CliError('--max-fee-per-gas must exceed the previous replacement fee', 'REPLACEMENT_FEE_TOO_LOW');
@@ -231,6 +272,13 @@ async function applyClaimFees(
     throw new CliError('--max-priority-fee-per-gas must exceed the previous replacement fee', 'REPLACEMENT_FEE_TOO_LOW');
   }
 
+  if (explicitMaxFee !== undefined && explicitPriorityFee !== undefined) {
+    request.maxFeePerGas = explicitMaxFee;
+    request.maxPriorityFeePerGas = explicitPriorityFee;
+    return;
+  }
+
+  const quote = await publicClient.estimateFeesPerGas();
   const quoteMaxFee = quote.maxFeePerGas === null || quote.maxFeePerGas === undefined
     ? undefined
     : feeHeadroom(quote.maxFeePerGas);
@@ -241,7 +289,11 @@ async function applyClaimFees(
     return;
   }
 
-  request.gasPrice = maximum(await publicClient.getGasPrice(), replacement?.gas_price ? replacementBump(BigInt(replacement.gas_price)) : undefined);
+  if (explicitMaxFee !== undefined || explicitPriorityFee !== undefined) {
+    throw new CliError('Both EIP-1559 fee options require an EIP-1559 fee quote', 'FEE_ESTIMATE_UNAVAILABLE');
+  }
+
+  request.gasPrice = maximum(await publicClient.getGasPrice());
 }
 
 function replacementBump(value: bigint | undefined): bigint | undefined {
@@ -264,6 +316,7 @@ async function submitClaim(prepared: PreparedClaim, replacementOf?: string): Pro
   try {
     insertDirectTransaction({
       txHash,
+      chainId: prepared.chainId,
       operation: 'mailbox_claim',
       mirror: prepared.mirror,
       claimedId: prepared.claimedId,
@@ -282,10 +335,9 @@ async function submitClaim(prepared: PreparedClaim, replacementOf?: string): Pro
   return txHash;
 }
 
-async function waitForClaimReceipt(prepared: PreparedClaim, txHash: `0x${string}`, timeout: number): Promise<TransactionReceipt | null> {
-  const api = await getEthexeApi();
+async function waitForClaimReceipt(publicClient: PublicClient, txHash: `0x${string}`, timeout: number): Promise<TransactionReceipt | null> {
   try {
-    return await api.eth.publicClient.waitForTransactionReceipt({ hash: txHash, timeout });
+    return await publicClient.waitForTransactionReceipt({ hash: txHash, timeout });
   } catch (error) {
     if (isReceiptTimeout(error)) return null;
     markDirectTransactionFailed(txHash, error instanceof Error ? error.message : String(error));
@@ -301,7 +353,7 @@ async function outputClaimReceipt(
 ): Promise<void> {
   const status = receipt.status === 'success' ? 'confirmed' : 'reverted';
   markDirectTransactionReceipt(txHash, status, receipt.blockNumber);
-  const event = receipt.status === 'success' ? await prepared.tx.getValueClaimingRequestedEvent() : null;
+  const event = receipt.status === 'success' ? findValueClaimingRequestedEvent(receipt) : null;
   output({
     mirror: prepared.mirror,
     claimedId: prepared.claimedId,
@@ -313,6 +365,20 @@ async function outputClaimReceipt(
     fees: serializeFees(prepared.request),
     event: event ? { source: event.source, claimedId: event.claimedId } : null,
   });
+}
+
+function findValueClaimingRequestedEvent(receipt: TransactionReceipt): { source: string; claimedId: string } | null {
+  for (const log of receipt.logs ?? []) {
+    try {
+      const event = decodeEventLog({ abi: VALUE_CLAIMING_REQUESTED_ABI, data: log.data, topics: log.topics });
+      if (event.eventName !== 'ValueClaimingRequested') continue;
+      const args = event.args as { source?: string; claimedId?: string };
+      if (args.source && args.claimedId) return { source: args.source, claimedId: args.claimedId };
+    } catch {
+      // A receipt can contain logs from unrelated contracts.
+    }
+  }
+  return null;
 }
 
 function outputClaimSubmission(
@@ -347,6 +413,7 @@ function directRecordFromPreparedClaim(prepared: PreparedClaim, txHash: `0x${str
   const fees = serializeFees(prepared.request);
   return {
     tx_hash: txHash,
+    chain_id: prepared.chainId.toString(),
     operation: 'mailbox_claim',
     mirror: prepared.mirror,
     claimed_id: prepared.claimedId,
@@ -371,9 +438,9 @@ async function resumeClaim(txHash: `0x${string}`): Promise<void> {
   if (!stored || stored.operation !== 'mailbox_claim') {
     throw new CliError('No saved mailbox claim was found for --resume', 'CLAIM_RESUME_NOT_FOUND', { txHash });
   }
-  const api = await getEthexeApi();
+  const { publicClient } = getEthexeEthereumContext();
   try {
-    const receipt = await api.eth.publicClient.getTransactionReceipt({ hash: txHash });
+    const receipt = await publicClient.getTransactionReceipt({ hash: txHash });
     const status = receipt.status === 'success' ? 'confirmed' : 'reverted';
     markDirectTransactionReceipt(txHash, status, receipt.blockNumber);
     output({
@@ -393,11 +460,12 @@ async function resumeClaim(txHash: `0x${string}`): Promise<void> {
     });
   } catch (error) {
     if (!isReceiptMissing(error)) throw error;
-    const nextMinedNonce = await api.eth.publicClient.getTransactionCount({
+    const nextMinedNonce = await publicClient.getTransactionCount({
       address: stored.sender as `0x${string}`,
       blockTag: 'latest',
     });
     if (nextMinedNonce > parseNonce(stored.nonce)!) {
+      markDirectTransactionFailed(txHash, 'CLAIM_REPLACED_OR_MINED');
       output({
         mirror: stored.mirror,
         claimedId: stored.claimed_id,

--- a/src/services/vara-eth/direct-transactions.ts
+++ b/src/services/vara-eth/direct-transactions.ts
@@ -1,0 +1,160 @@
+/**
+ * Persistence for direct Ethereum transactions submitted by Vara.eth commands.
+ *
+ * This is intentionally separate from injected promise persistence: Ethereum
+ * mempool transactions have nonces, replacement chains, and receipts rather
+ * than validator-signed promise outcomes.
+ */
+
+import Database from 'better-sqlite3';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { getConfigDir } from '../config';
+import { verbose } from '../../utils';
+
+export type DirectTransactionStatus = 'pending' | 'confirmed' | 'reverted' | 'replaced' | 'failed';
+
+export interface DirectTransactionRecord {
+  tx_hash: string;
+  operation: string;
+  mirror: string;
+  claimed_id: string | null;
+  sender: string;
+  nonce: string;
+  calldata: string;
+  gas: string | null;
+  max_fee_per_gas: string | null;
+  max_priority_fee_per_gas: string | null;
+  gas_price: string | null;
+  submitted_at_ts: number;
+  status: DirectTransactionStatus;
+  replacement_of: string | null;
+  replaced_by: string | null;
+  receipt_block: string | null;
+  last_error: string | null;
+}
+
+export interface InsertDirectTransaction {
+  txHash: string;
+  operation: string;
+  mirror: string;
+  claimedId?: string;
+  sender: string;
+  nonce: bigint;
+  calldata: string;
+  gas?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  gasPrice?: bigint;
+  replacementOf?: string;
+}
+
+let db: Database.Database | null = null;
+
+function getDb(): Database.Database | null {
+  if (db) return db;
+
+  try {
+    const configDir = getConfigDir();
+    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    db = new Database(path.join(configDir, 'vara-eth-transactions.db'));
+    db.pragma('journal_mode = WAL');
+    db.pragma('busy_timeout = 5000');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS direct_transactions (
+        tx_hash TEXT PRIMARY KEY,
+        operation TEXT NOT NULL,
+        mirror TEXT NOT NULL,
+        claimed_id TEXT,
+        sender TEXT NOT NULL,
+        nonce TEXT NOT NULL,
+        calldata TEXT NOT NULL,
+        gas TEXT,
+        max_fee_per_gas TEXT,
+        max_priority_fee_per_gas TEXT,
+        gas_price TEXT,
+        submitted_at_ts INTEGER NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('pending', 'confirmed', 'reverted', 'replaced', 'failed')),
+        replacement_of TEXT,
+        replaced_by TEXT,
+        receipt_block TEXT,
+        last_error TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_direct_transactions_status ON direct_transactions(status);
+      CREATE INDEX IF NOT EXISTS idx_direct_transactions_sender_nonce ON direct_transactions(sender, nonce);
+    `);
+    return db;
+  } catch (error) {
+    verbose(`Warning: failed to initialize Vara.eth direct transaction store: ${error instanceof Error ? error.message : String(error)}`);
+    db = null;
+    return null;
+  }
+}
+
+export function insertDirectTransaction(input: InsertDirectTransaction): void {
+  const database = getDb();
+  if (!database) return;
+  database.prepare(`
+    INSERT INTO direct_transactions (
+      tx_hash, operation, mirror, claimed_id, sender, nonce, calldata, gas,
+      max_fee_per_gas, max_priority_fee_per_gas, gas_price, submitted_at_ts,
+      status, replacement_of
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+  `).run(
+    input.txHash,
+    input.operation,
+    input.mirror,
+    input.claimedId ?? null,
+    input.sender,
+    input.nonce.toString(),
+    input.calldata,
+    input.gas?.toString() ?? null,
+    input.maxFeePerGas?.toString() ?? null,
+    input.maxPriorityFeePerGas?.toString() ?? null,
+    input.gasPrice?.toString() ?? null,
+    Date.now(),
+    input.replacementOf ?? null,
+  );
+}
+
+export function getDirectTransaction(txHash: string): DirectTransactionRecord | undefined {
+  const database = getDb();
+  if (!database) return undefined;
+  return database.prepare('SELECT * FROM direct_transactions WHERE tx_hash = ?').get(txHash) as DirectTransactionRecord | undefined;
+}
+
+export function markDirectTransactionReceipt(
+  txHash: string,
+  status: Extract<DirectTransactionStatus, 'confirmed' | 'reverted'>,
+  blockNumber: bigint,
+): void {
+  const database = getDb();
+  if (!database) return;
+  database.prepare(`
+    UPDATE direct_transactions
+    SET status = ?, receipt_block = ?, last_error = NULL
+    WHERE tx_hash = ?
+  `).run(status, blockNumber.toString(), txHash);
+}
+
+export function markDirectTransactionReplaced(originalTxHash: string, replacementTxHash: string): void {
+  const database = getDb();
+  if (!database) return;
+  database.prepare(`
+    UPDATE direct_transactions
+    SET status = 'replaced', replaced_by = ?
+    WHERE tx_hash = ? AND status = 'pending'
+  `).run(replacementTxHash, originalTxHash);
+}
+
+export function markDirectTransactionFailed(txHash: string, error: string): void {
+  const database = getDb();
+  if (!database) return;
+  database.prepare(`
+    UPDATE direct_transactions
+    SET status = 'failed', last_error = ?
+    WHERE tx_hash = ? AND status = 'pending'
+  `).run(error, txHash);
+}
+

--- a/src/services/vara-eth/direct-transactions.ts
+++ b/src/services/vara-eth/direct-transactions.ts
@@ -17,6 +17,7 @@ export type DirectTransactionStatus = 'pending' | 'confirmed' | 'reverted' | 're
 
 export interface DirectTransactionRecord {
   tx_hash: string;
+  chain_id: string | null;
   operation: string;
   mirror: string;
   claimed_id: string | null;
@@ -37,6 +38,7 @@ export interface DirectTransactionRecord {
 
 export interface InsertDirectTransaction {
   txHash: string;
+  chainId: number;
   operation: string;
   mirror: string;
   claimedId?: string;
@@ -52,6 +54,10 @@ export interface InsertDirectTransaction {
 
 let db: Database.Database | null = null;
 
+function warnStoreOperation(operation: string, error: unknown): void {
+  verbose(`Warning: failed to ${operation} in Vara.eth direct transaction store: ${error instanceof Error ? error.message : String(error)}`);
+}
+
 function getDb(): Database.Database | null {
   if (db) return db;
 
@@ -60,10 +66,12 @@ function getDb(): Database.Database | null {
     fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
     db = new Database(path.join(configDir, 'vara-eth-transactions.db'));
     db.pragma('journal_mode = WAL');
-    db.pragma('busy_timeout = 5000');
+    // Persistence must never delay a successfully broadcast --wait submitted result.
+    db.pragma('busy_timeout = 0');
     db.exec(`
       CREATE TABLE IF NOT EXISTS direct_transactions (
         tx_hash TEXT PRIMARY KEY,
+        chain_id TEXT NOT NULL,
         operation TEXT NOT NULL,
         mirror TEXT NOT NULL,
         claimed_id TEXT,
@@ -84,6 +92,11 @@ function getDb(): Database.Database | null {
       CREATE INDEX IF NOT EXISTS idx_direct_transactions_status ON direct_transactions(status);
       CREATE INDEX IF NOT EXISTS idx_direct_transactions_sender_nonce ON direct_transactions(sender, nonce);
     `);
+    const columns = db.prepare('PRAGMA table_info(direct_transactions)').all() as Array<{ name: string }>;
+    if (!columns.some(({ name }) => name === 'chain_id')) {
+      // Legacy rows cannot be safely replaced because their chain is unknown.
+      db.exec('ALTER TABLE direct_transactions ADD COLUMN chain_id TEXT');
+    }
     return db;
   } catch (error) {
     verbose(`Warning: failed to initialize Vara.eth direct transaction store: ${error instanceof Error ? error.message : String(error)}`);
@@ -95,33 +108,43 @@ function getDb(): Database.Database | null {
 export function insertDirectTransaction(input: InsertDirectTransaction): void {
   const database = getDb();
   if (!database) return;
-  database.prepare(`
-    INSERT INTO direct_transactions (
-      tx_hash, operation, mirror, claimed_id, sender, nonce, calldata, gas,
-      max_fee_per_gas, max_priority_fee_per_gas, gas_price, submitted_at_ts,
-      status, replacement_of
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
-  `).run(
-    input.txHash,
-    input.operation,
-    input.mirror,
-    input.claimedId ?? null,
-    input.sender,
-    input.nonce.toString(),
-    input.calldata,
-    input.gas?.toString() ?? null,
-    input.maxFeePerGas?.toString() ?? null,
-    input.maxPriorityFeePerGas?.toString() ?? null,
-    input.gasPrice?.toString() ?? null,
-    Date.now(),
-    input.replacementOf ?? null,
-  );
+  try {
+    database.prepare(`
+      INSERT INTO direct_transactions (
+        tx_hash, chain_id, operation, mirror, claimed_id, sender, nonce, calldata, gas,
+        max_fee_per_gas, max_priority_fee_per_gas, gas_price, submitted_at_ts,
+        status, replacement_of
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+    `).run(
+      input.txHash,
+      input.chainId.toString(),
+      input.operation,
+      input.mirror,
+      input.claimedId ?? null,
+      input.sender,
+      input.nonce.toString(),
+      input.calldata,
+      input.gas?.toString() ?? null,
+      input.maxFeePerGas?.toString() ?? null,
+      input.maxPriorityFeePerGas?.toString() ?? null,
+      input.gasPrice?.toString() ?? null,
+      Date.now(),
+      input.replacementOf ?? null,
+    );
+  } catch (error) {
+    warnStoreOperation('record direct transaction', error);
+  }
 }
 
 export function getDirectTransaction(txHash: string): DirectTransactionRecord | undefined {
   const database = getDb();
   if (!database) return undefined;
-  return database.prepare('SELECT * FROM direct_transactions WHERE tx_hash = ?').get(txHash) as DirectTransactionRecord | undefined;
+  try {
+    return database.prepare('SELECT * FROM direct_transactions WHERE tx_hash = ?').get(txHash) as DirectTransactionRecord | undefined;
+  } catch (error) {
+    warnStoreOperation('read direct transaction', error);
+    return undefined;
+  }
 }
 
 export function markDirectTransactionReceipt(
@@ -131,30 +154,47 @@ export function markDirectTransactionReceipt(
 ): void {
   const database = getDb();
   if (!database) return;
-  database.prepare(`
-    UPDATE direct_transactions
-    SET status = ?, receipt_block = ?, last_error = NULL
-    WHERE tx_hash = ?
-  `).run(status, blockNumber.toString(), txHash);
+  try {
+    database.prepare(`
+      UPDATE direct_transactions
+      SET status = ?, receipt_block = ?, last_error = NULL
+      WHERE tx_hash = ?
+    `).run(status, blockNumber.toString(), txHash);
+  } catch (error) {
+    warnStoreOperation('mark direct transaction receipt', error);
+  }
 }
 
 export function markDirectTransactionReplaced(originalTxHash: string, replacementTxHash: string): void {
   const database = getDb();
   if (!database) return;
-  database.prepare(`
-    UPDATE direct_transactions
-    SET status = 'replaced', replaced_by = ?
-    WHERE tx_hash = ? AND status = 'pending'
-  `).run(replacementTxHash, originalTxHash);
+  try {
+    database.prepare(`
+      UPDATE direct_transactions
+      SET status = 'replaced', replaced_by = ?
+      WHERE tx_hash = ? AND status = 'pending'
+    `).run(replacementTxHash, originalTxHash);
+  } catch (error) {
+    warnStoreOperation('mark direct transaction replaced', error);
+  }
 }
 
 export function markDirectTransactionFailed(txHash: string, error: string): void {
   const database = getDb();
   if (!database) return;
-  database.prepare(`
-    UPDATE direct_transactions
-    SET status = 'failed', last_error = ?
-    WHERE tx_hash = ? AND status = 'pending'
-  `).run(error, txHash);
+  try {
+    database.prepare(`
+      UPDATE direct_transactions
+      SET status = 'failed', last_error = ?
+      WHERE tx_hash = ? AND status = 'pending'
+    `).run(error, txHash);
+  } catch (storeError) {
+    warnStoreOperation('mark direct transaction failed', storeError);
+  }
 }
 
+/** Test-only cleanup for isolated SQLite store tests. */
+export function closeDirectTransactionStoreForTests(): void {
+  db?.close();
+  db = null;
+}


### PR DESCRIPTION
## Summary

- Add recoverable direct L1 Vara.eth mailbox claims: bounded receipt waiting, immediate submit-only output, persisted transaction metadata, resume, and controlled same-nonce replacement.
- Protect recovery with sender and chain binding, EIP-1559 headroom and replacement bumps, legacy gas-price compatibility, and terminal handling for transactions replaced or mined outside the wallet.
- Keep claim submission, receipt polling, resume, and replacement on the Ethereum-only RPC path so validator availability does not add latency or become an unrelated dependency.
- Document the agent workflow, recovery states, fee behavior, and the distinction between Mirror acceptance (`ValueClaimingRequested`) and final co-processor settlement (`ValueClaimed`).
- Release `vara-wallet` `0.20.6`.

## Test Coverage

Core fresh-claim, submitted, receipt, resume, scoped replacement, fee-mode, timeout, and persistence paths have behavior and error-path coverage.

Coverage audit: 81.29% statements, 71.12% branches, 84.93% lines for the targeted claim suites. Remaining gaps are isolated input-validation and uncommon RPC/store-error branches; no core recovery path is untested.

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Greptile Review

No Greptile comments. Gemini's six comments are either fixed or intentionally rejected with validated sender/chain, nonce-validation, and receipt-window semantics.

## Scope Drift

Scope Check: CLEAN

Intent: prevent low-fee Vara.eth claims from silently disappearing and make them safely recoverable.

Delivered: direct claim persistence, bounded waits, resume/replacement safety, fee handling, tests, documentation, and a patch release.

## Plan Completion

No plan file clearly applies to this branch; the related Ethexe document is a research roadmap, not a feature implementation plan.

## Verification Results

No plan-specific verification steps or local server apply to this CLI workflow.

## TODOS

No TODO items completed in this PR.

## Documentation

- `README.md`: clarify that direct Vara.eth mailbox claims also keep same-nonce replacement on the Ethereum-only path, matching the CLI and detailed network guide.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm build`
- [x] `pnpm exec jest --runInBand` (82 suites, 908 tests)
